### PR TITLE
fix: parser and evaluator correctness #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ src/
 | World of Darkness | `10d10>=6f1` | 2 |
 | Savage Worlds | `1d6!` | 2 |
 
+## Known Limitations
+
+- **`4d6d1` parses as nested dice, not "drop 1".** The bare `d` token is always
+  interpreted as the dice operator, so `4d6d1` becomes `(4d6)d1` (roll 4d6, then
+  use the result as the count for d1). To drop dice, use the explicit `dl`
+  (drop lowest) or `dh` (drop highest) modifiers: `4d6dl1`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -126,6 +126,19 @@ describe('parseArgs', () => {
       const result = parseArgs(['--seed', '--verbose']);
       expect(result).toEqual({ ok: false, error: 'Missing value for --seed' });
     });
+
+    test('parses --seed with negative numeric value', () => {
+      const result = parseArgs(['2d6', '--seed', '-42']);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.args.seed).toBe('-42');
+      }
+    });
+
+    test('returns error when --seed is followed by non-numeric flag', () => {
+      const result = parseArgs(['--seed', '-v']);
+      expect(result).toEqual({ ok: false, error: 'Missing value for --seed' });
+    });
   });
 
   describe('flag combinations', () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -46,7 +46,7 @@ export function parseArgs(argv: string[]): ParseArgsResult {
       verbose = true;
     } else if (arg === '--seed') {
       const next = argv[i + 1];
-      if (next === undefined || next.startsWith('-')) {
+      if (next === undefined || (next.startsWith('-') && !/^-\d/.test(next))) {
         return { ok: false, error: 'Missing value for --seed' };
       }
       seed = next;

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -378,6 +378,15 @@ describe('evaluate', () => {
       expect(getDie(result.rolls, 0).critical).toBe(false);
     });
 
+    test('1d1 is fumble but not critical', () => {
+      const ast = parse('1d1');
+      const rng = createMockRng([1]);
+      const result = evaluate(ast, rng);
+
+      expect(getDie(result.rolls, 0).critical).toBe(false);
+      expect(getDie(result.rolls, 0).fumble).toBe(true);
+    });
+
     test('normal roll has no critical or fumble', () => {
       const ast = parse('1d20');
       const rng = createMockRng([10]);
@@ -475,6 +484,28 @@ describe('evaluate', () => {
       const rng = createMockRng([3]);
 
       expect(() => evaluate(ast, rng)).toThrow('Modulo by zero');
+    });
+
+    test('chained modifiers produce exactly one kept or dropped per die', () => {
+      const ast = parse('4d6dl1kh3');
+      const rng = createMockRng([3, 1, 4, 2]);
+      const result = evaluate(ast, rng);
+
+      for (const die of result.rolls) {
+        const kept = die.modifiers.filter((m) => m === 'kept');
+        const dropped = die.modifiers.filter((m) => m === 'dropped');
+        const total = kept.length + dropped.length;
+        expect(total).toBe(1);
+      }
+    });
+
+    test('implicit modifier count (4d6kh) keeps highest 1', () => {
+      const ast = parse('4d6kh');
+      const rng = createMockRng([3, 5, 2, 6]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(6);
+      expect(result.expression).toBe('4d6kh1');
     });
 
     test('keeps all dice when keep count exceeds pool', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -54,7 +54,7 @@ function createDieResult(sides: number, result: number): DieResult {
     sides,
     result,
     modifiers: [],
-    critical: result === sides,
+    critical: result === sides && sides > 1,
     fumble: result === 1,
   };
 }
@@ -261,8 +261,8 @@ function mergeDropSets(baseDice: DieResult[], specs: ModifierSpec[]): DieResult[
   return baseDice.map((die, index) => ({
     ...die,
     modifiers: droppedIndices.has(index)
-      ? [...die.modifiers.filter((m) => m !== 'kept'), 'dropped']
-      : [...die.modifiers.filter((m) => m !== 'dropped'), 'kept'],
+      ? [...die.modifiers.filter((m) => m !== 'kept' && m !== 'dropped'), 'dropped']
+      : [...die.modifiers.filter((m) => m !== 'dropped' && m !== 'kept'), 'kept'],
   }));
 }
 

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -228,6 +228,30 @@ describe('Parser', () => {
         modifier('keep', 'lowest', literal(1), dice(literal(2), literal(20))),
       );
     });
+
+    it('should default implicit modifier count to 1: 4d6kh', () => {
+      expect(parse('4d6kh')).toEqual(
+        modifier('keep', 'highest', literal(1), dice(literal(4), literal(6))),
+      );
+    });
+
+    it('should default implicit kl count to 1: 4d6kl', () => {
+      expect(parse('4d6kl')).toEqual(
+        modifier('keep', 'lowest', literal(1), dice(literal(4), literal(6))),
+      );
+    });
+
+    it('should default implicit dl count to 1: 4d6dl', () => {
+      expect(parse('4d6dl')).toEqual(
+        modifier('drop', 'lowest', literal(1), dice(literal(4), literal(6))),
+      );
+    });
+
+    it('should default implicit dh count to 1: 4d6dh', () => {
+      expect(parse('4d6dh')).toEqual(
+        modifier('drop', 'highest', literal(1), dice(literal(4), literal(6))),
+      );
+    });
   });
 
   describe('dice + arithmetic', () => {
@@ -318,10 +342,6 @@ describe('Parser', () => {
 
     it('should throw on extra closing parenthesis', () => {
       expect(() => parse('1+2)')).toThrow(ParseError);
-    });
-
-    it('should throw on missing modifier count', () => {
-      expect(() => parse('4d6kh')).toThrow(ParseError);
     });
 
     it('should throw on trailing operator', () => {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -234,19 +234,12 @@ export class Parser {
         ? 'highest'
         : 'lowest';
 
-    // Count is required after modifier (number or parenthesized expression)
+    // Default to 1 when no explicit count follows the modifier (e.g., 4d6kh → 4d6kh1)
     const nextToken = this.peek().type;
-    if (nextToken !== TokenType.NUMBER && nextToken !== TokenType.LPAREN) {
-      throw new ParseError(
-        `Expected number or expression after '${token.value}' modifier`,
-        this.peek().position,
-        this.peek(),
-      );
-    }
-
-    // Use DICE_LEFT to prevent modifiers from appearing in count position (e.g., 4d6kh1kh3)
-    // This allows computed counts like 4d6kh(1+2) but prevents nested modifiers
-    const count = this.parseExpression(BP.DICE_LEFT);
+    const count: ASTNode =
+      nextToken === TokenType.NUMBER || nextToken === TokenType.LPAREN
+        ? this.parseExpression(BP.DICE_LEFT)
+        : { type: 'Literal', value: 1 };
 
     return {
       type: 'Modifier',


### PR DESCRIPTION
- Fixed duplicate `kept` modifiers in `mergeDropSets()` by filtering both `kept` and `dropped` before appending
- Default implicit modifier count to 1 (`4d6kh` parses as `4d6kh1`)
- Suppressed `critical` flag when `sides === 1` (fumble takes precedence)
- Allowed negative numeric values for `--seed` in CLI (`--seed -42`)
- Documented `4d6d1` nested-dice parsing limitation in README

Closes #21

[Claude Code session](https://claude.ai/code/session_017f2WxbEDKVh7AspZZP6Gjw)

<sub>*Drafted with AI assistance*</sub>
