### PR TITLE
fix: add dice count safety limit #19

### DIFF
--- a/.claude/docs/GAPS.md
+++ b/.claude/docs/GAPS.md
@@ -8,14 +8,12 @@ have no issue and are noted at the bottom.
 
 ## Critical
 
-### 1. No dice count safety limit — process hangs on large inputs *(→ [#19](https://github.com/edloidas/roll-parser/issues/19))*
+### ~~1. No dice count safety limit — process hangs on large inputs~~ *(→ [#19](https://github.com/edloidas/roll-parser/issues/19))* ✓ Resolved
 
-`src/evaluator/evaluator.ts:120` — The `evalDice` function loops
-`for (let i = 0; i < count; i++)` with no upper bound. Input like
-`999999999999d6` creates an effectively infinite loop that hangs the process.
-The `maxIterations` option exists in `RollOptions` (`src/roll.ts:23`) but is
-never passed to or used by the evaluator. There is no `MAX_DICE` constant or
-guard. This is a denial-of-service vector for any server-side usage.
+Added `DEFAULT_MAX_DICE` (10,000) with aggregate counter across the full
+expression. `maxDice` option in `RollOptions` and `EvaluateOptions` lets
+consumers override the limit. Invalid values (NaN, Infinity, negatives) fall
+back to the default.
 
 ### 2. CI test job has `continue-on-error: true` *(→ [#20](https://github.com/edloidas/roll-parser/issues/20))*
 
@@ -92,11 +90,10 @@ commas, and strikethrough for dropped dice.
 
 ## Medium — Code Quality
 
-### 12. `maxIterations` option is defined but never used *(→ [#19](https://github.com/edloidas/roll-parser/issues/19))*
+### ~~12. `maxIterations` option is defined but never used~~ *(→ [#19](https://github.com/edloidas/roll-parser/issues/19))* ✓ Resolved
 
-`src/roll.ts:23` declares `maxIterations?: number` with the comment "Stage 2
-exploding dice" but it is never threaded through to the evaluator. Dead API
-surface that will confuse consumers who try to use it.
+Replaced `maxIterations` with `maxDice` in `RollOptions`. Now wired through
+`evaluate()` → `EvalEnv` → `evalDice()` with aggregate tracking.
 
 ### 13. Mock RNG bundled into production entry point *(→ [#24](https://github.com/edloidas/roll-parser/issues/24))*
 

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, test } from 'bun:test';
 import { parse } from '../parser/parser';
 import { createMockRng } from '../rng/mock';
 import type { DieResult } from '../types';
-import { evaluate, EvaluatorError } from './evaluator';
+import { DEFAULT_MAX_DICE, evaluate, EvaluatorError } from './evaluator';
 
 /**
  * Helper to safely get a die result at index, throwing if not present.
@@ -524,6 +524,101 @@ describe('evaluate', () => {
 
       expect(result.total).toBe(0);
       expect(result.rolls.every((r) => r.modifiers.includes('dropped'))).toBe(true);
+    });
+  });
+
+  describe('dice count safety limit', () => {
+    test('DEFAULT_MAX_DICE is 10,000', () => {
+      expect(DEFAULT_MAX_DICE).toBe(10_000);
+    });
+
+    test('allows dice count at the limit', () => {
+      const ast = parse('3d6');
+      const rng = createMockRng([1, 2, 3]);
+      const result = evaluate(ast, rng, { maxDice: 3 });
+
+      expect(result.total).toBe(6);
+      expect(result.rolls).toHaveLength(3);
+    });
+
+    test('throws when single group exceeds limit', () => {
+      const ast = parse('5d6');
+      const rng = createMockRng([1, 2, 3, 4, 5]);
+
+      expect(() => evaluate(ast, rng, { maxDice: 4 })).toThrow(EvaluatorError);
+      expect(() => evaluate(ast, rng, { maxDice: 4 })).toThrow(
+        'Total dice count 5 exceeds limit of 4',
+      );
+    });
+
+    test('throws when aggregate across groups exceeds limit', () => {
+      const ast = parse('3d6+3d6');
+      const rng = createMockRng([1, 2, 3, 4, 5, 6]);
+
+      expect(() => evaluate(ast, rng, { maxDice: 5 })).toThrow(EvaluatorError);
+      expect(() => evaluate(ast, rng, { maxDice: 5 })).toThrow(
+        'Total dice count 6 exceeds limit of 5',
+      );
+    });
+
+    test('aggregate limit allows exact total', () => {
+      const ast = parse('3d6+2d6');
+      const rng = createMockRng([1, 2, 3, 4, 5]);
+      const result = evaluate(ast, rng, { maxDice: 5 });
+
+      expect(result.total).toBe(15);
+      expect(result.rolls).toHaveLength(5);
+    });
+
+    test('consumer can raise the limit', () => {
+      const ast = parse('3d6');
+      const rng = createMockRng([1, 2, 3]);
+      const result = evaluate(ast, rng, { maxDice: 100_000 });
+
+      expect(result.total).toBe(6);
+    });
+
+    test('zero dice count passes without incrementing counter', () => {
+      const ast = parse('0d6');
+      const rng = createMockRng([]);
+      const result = evaluate(ast, rng, { maxDice: 1 });
+
+      expect(result.total).toBe(0);
+      expect(result.rolls).toHaveLength(0);
+    });
+
+    test('invalid maxDice falls back to default', () => {
+      const ast = parse('3d6');
+      const vals = [1, 2, 3];
+
+      // NaN, negative, Infinity, zero — all fall back to DEFAULT_MAX_DICE
+      expect(() => evaluate(ast, createMockRng(vals), { maxDice: Number.NaN })).not.toThrow();
+      expect(() => evaluate(ast, createMockRng(vals), { maxDice: -1 })).not.toThrow();
+      expect(() =>
+        evaluate(ast, createMockRng(vals), { maxDice: Number.POSITIVE_INFINITY }),
+      ).not.toThrow();
+      expect(() => evaluate(ast, createMockRng(vals), { maxDice: 0 })).not.toThrow();
+    });
+
+    test('float maxDice is floored', () => {
+      const ast = parse('3d6');
+      const rng = createMockRng([1, 2, 3]);
+
+      // maxDice: 2.9 → floor → 2, so 3d6 should throw
+      expect(() => evaluate(ast, rng, { maxDice: 2.9 })).toThrow(EvaluatorError);
+    });
+
+    test('error message includes actual count and limit', () => {
+      const ast = parse('10d6');
+      const rng = createMockRng(Array.from({ length: 10 }, () => 1));
+
+      try {
+        evaluate(ast, rng, { maxDice: 5 });
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(EvaluatorError);
+        expect((error as EvaluatorError).message).toBe('Total dice count 10 exceeds limit of 5');
+      }
     });
   });
 });

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -27,8 +27,19 @@ export class EvaluatorError extends Error {
   }
 }
 
+/** Default maximum total dice allowed per evaluation. */
+export const DEFAULT_MAX_DICE = 10_000;
+
 /**
- * Internal evaluation context for tracking state during recursion.
+ * Per-evaluation shared environment (created once, shared across all branches).
+ */
+type EvalEnv = {
+  readonly maxDice: number;
+  totalDiceRolled: number;
+};
+
+/**
+ * Per-branch mutable accumulator for tracking rolls and output during recursion.
  */
 type EvalContext = {
   rolls: DieResult[];
@@ -75,22 +86,22 @@ function renderDice(dice: DieResult[]): string {
 /**
  * Evaluates an AST node, returning value and updating context.
  */
-function evalNode(node: ASTNode, rng: RNG, ctx: EvalContext): number {
+function evalNode(node: ASTNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   switch (node.type) {
     case 'Literal':
       return evalLiteral(node.value, ctx);
 
     case 'Dice':
-      return evalDice(node, rng, ctx);
+      return evalDice(node, rng, ctx, env);
 
     case 'BinaryOp':
-      return evalBinaryOp(node, rng, ctx);
+      return evalBinaryOp(node, rng, ctx, env);
 
     case 'UnaryOp':
-      return evalUnaryOp(node, rng, ctx);
+      return evalUnaryOp(node, rng, ctx, env);
 
     case 'Modifier':
-      return evalModifier(node, rng, ctx);
+      return evalModifier(node, rng, ctx, env);
 
     default: {
       const exhaustive: never = node;
@@ -105,9 +116,19 @@ function evalLiteral(value: number, ctx: EvalContext): number {
   return value;
 }
 
-function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext): number {
-  const count = evalNode(node.count, rng, { rolls: [], expressionParts: [], renderedParts: [] });
-  const sides = evalNode(node.sides, rng, { rolls: [], expressionParts: [], renderedParts: [] });
+function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
+  const count = evalNode(
+    node.count,
+    rng,
+    { rolls: [], expressionParts: [], renderedParts: [] },
+    env,
+  );
+  const sides = evalNode(
+    node.sides,
+    rng,
+    { rolls: [], expressionParts: [], renderedParts: [] },
+    env,
+  );
 
   if (!Number.isInteger(count) || count < 0) {
     throw new EvaluatorError(`Invalid dice count: ${count}`);
@@ -115,6 +136,13 @@ function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext): number {
   if (!Number.isInteger(sides) || sides < 1) {
     throw new EvaluatorError(`Invalid dice sides: ${sides}`);
   }
+
+  if (env.totalDiceRolled + count > env.maxDice) {
+    throw new EvaluatorError(
+      `Total dice count ${env.totalDiceRolled + count} exceeds limit of ${env.maxDice}`,
+    );
+  }
+  env.totalDiceRolled += count;
 
   const dice: DieResult[] = [];
   for (let i = 0; i < count; i++) {
@@ -134,12 +162,12 @@ function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext): number {
   return total;
 }
 
-function evalBinaryOp(node: BinaryOpNode, rng: RNG, ctx: EvalContext): number {
+function evalBinaryOp(node: BinaryOpNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   const leftCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const rightCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
 
-  const left = evalNode(node.left, rng, leftCtx);
-  const right = evalNode(node.right, rng, rightCtx);
+  const left = evalNode(node.left, rng, leftCtx, env);
+  const right = evalNode(node.right, rng, rightCtx, env);
 
   ctx.rolls.push(...leftCtx.rolls, ...rightCtx.rolls);
 
@@ -177,9 +205,9 @@ function evalBinaryOp(node: BinaryOpNode, rng: RNG, ctx: EvalContext): number {
   }
 }
 
-function evalUnaryOp(node: UnaryOpNode, rng: RNG, ctx: EvalContext): number {
+function evalUnaryOp(node: UnaryOpNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   const innerCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
-  const value = evalNode(node.operand, rng, innerCtx);
+  const value = evalNode(node.operand, rng, innerCtx, env);
 
   ctx.rolls.push(...innerCtx.rolls);
 
@@ -199,13 +227,14 @@ function evalUnaryOp(node: UnaryOpNode, rng: RNG, ctx: EvalContext): number {
 function flattenModifierChain(
   node: ModifierNode,
   rng: RNG,
+  env: EvalEnv,
 ): { specs: ModifierSpec[]; baseTarget: ASTNode } {
   const specs: ModifierSpec[] = [];
   let current: ASTNode = node;
 
   while (isModifier(current)) {
     const countCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
-    const modCount = evalNode(current.count, rng, countCtx);
+    const modCount = evalNode(current.count, rng, countCtx, env);
 
     if (!Number.isInteger(modCount) || modCount < 0) {
       throw new EvaluatorError(`Invalid modifier count: ${modCount}`);
@@ -266,11 +295,11 @@ function mergeDropSets(baseDice: DieResult[], specs: ModifierSpec[]): DieResult[
   }));
 }
 
-function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext): number {
-  const { specs, baseTarget } = flattenModifierChain(node, rng);
+function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
+  const { specs, baseTarget } = flattenModifierChain(node, rng, env);
 
   const targetCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
-  evalNode(baseTarget, rng, targetCtx);
+  evalNode(baseTarget, rng, targetCtx, env);
 
   const mergedDice = mergeDropSets(targetCtx.rolls, specs);
 
@@ -304,13 +333,19 @@ function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext): number {
  * ```
  */
 export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}): RollResult {
+  const maxDice =
+    options.maxDice != null && Number.isFinite(options.maxDice) && options.maxDice > 0
+      ? Math.floor(options.maxDice)
+      : DEFAULT_MAX_DICE;
+
+  const env: EvalEnv = { maxDice, totalDiceRolled: 0 };
   const ctx: EvalContext = {
     rolls: [],
     expressionParts: [],
     renderedParts: [],
   };
 
-  const total = evalNode(ast, rng, ctx);
+  const total = evalNode(ast, rng, ctx, env);
 
   const expression = ctx.expressionParts.join('');
   const rendered = `${ctx.renderedParts.join('')} = ${total}`;

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -4,7 +4,7 @@
  * @module evaluator
  */
 
-export { evaluate, EvaluatorError } from './evaluator';
+export { DEFAULT_MAX_DICE, evaluate, EvaluatorError } from './evaluator';
 export {
   applyDropHighest,
   applyDropLowest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export { SeededRNG } from './rng/seeded';
 export { createMockRng, MockRNGExhaustedError } from './rng/mock';
 
 // * Evaluator exports
-export { evaluate, EvaluatorError } from './evaluator/evaluator';
+export { DEFAULT_MAX_DICE, evaluate, EvaluatorError } from './evaluator/evaluator';
 export type { DieModifier, DieResult, EvaluateOptions, RollResult } from './types';
 
 // * Public API

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -317,4 +317,21 @@ describe('roll() integration', () => {
       expect(result.total).toBe(5);
     });
   });
+
+  describe('dice count safety limit', () => {
+    test('roll() passes maxDice to evaluator', () => {
+      expect(() => roll('5d6', { maxDice: 4 })).toThrow(EvaluatorError);
+      expect(() => roll('5d6', { maxDice: 4 })).toThrow('exceeds limit of 4');
+    });
+
+    test('roll() aggregate limit across groups', () => {
+      expect(() => roll('3d6+3d6', { maxDice: 5 })).toThrow(EvaluatorError);
+    });
+
+    test('roll() respects default limit without maxDice option', () => {
+      // 3d6 is well under the default 10,000 limit
+      const result = roll('3d6', { rng: createMockRng([1, 2, 3]) });
+      expect(result.total).toBe(6);
+    });
+  });
 });

--- a/src/roll.ts
+++ b/src/roll.ts
@@ -5,7 +5,7 @@
  */
 
 import type { RNG } from './rng/types';
-import type { RollResult } from './types';
+import type { EvaluateOptions, RollResult } from './types';
 import { evaluate } from './evaluator/evaluator';
 import { lex } from './lexer/lexer';
 import { Parser } from './parser/parser';
@@ -19,8 +19,8 @@ export type RollOptions = {
   rng?: RNG;
   /** Seed for deterministic rolls (ignored if rng provided) */
   seed?: string | number;
-  /** Safety limit for iterations (default: 1000) - Stage 2 exploding dice */
-  maxIterations?: number;
+  /** Maximum total dice allowed per evaluation (default: 10,000) */
+  maxDice?: number;
 };
 
 /**
@@ -50,5 +50,7 @@ export function roll(notation: string, options: RollOptions = {}): RollResult {
   const rng = options.rng ?? new SeededRNG(options.seed);
   const tokens = lex(notation);
   const ast = new Parser(tokens).parse();
-  return evaluate(ast, rng, { notation });
+  const evalOptions: EvaluateOptions = { notation };
+  if (options.maxDice != null) evalOptions.maxDice = options.maxDice;
+  return evaluate(ast, rng, evalOptions);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,4 +47,6 @@ export type RollResult = {
 export type EvaluateOptions = {
   /** Original notation string (for result metadata) */
   notation?: string;
+  /** Maximum total dice allowed per evaluation (default: 10,000) */
+  maxDice?: number;
 };


### PR DESCRIPTION
Replaced dead `maxIterations` with `maxDice` option (default 10,000) in `RollOptions` and `EvaluateOptions`. Added `EvalEnv` type for per-evaluation config and aggregate dice counter. The guard in `evalDice()` tracks total dice across the full expression, preventing DoS via additive groups. Invalid `maxDice` values (NaN, Infinity, negatives) fall back to the default. Exported `DEFAULT_MAX_DICE` constant.

Closes #19

<sub>*Drafted with AI assistance*</sub>
