### PR TITLE
build: fix npm publish artifacts #22

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,7 +39,7 @@
     }
   },
   "files": {
-    "include": ["src/**/*.ts", "bin/**/*.ts"],
+    "include": ["src/**/*.ts"],
     "ignore": ["node_modules", "dist", "coverage"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "bin": "./dist/cli.js",
+  "bin": { "roll-parser": "./dist/cli.js" },
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -16,7 +17,9 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "!src/**/*.test.ts",
+    "!src/rng/mock.ts"
   ],
   "keywords": [
     "parser",
@@ -52,8 +55,9 @@
     "build:esm": "bun build src/index.ts --outfile dist/index.mjs --target bun",
     "build:cjs": "bun build src/index.ts --outfile dist/index.js --target node",
     "build:cli": "bun build src/cli/index.ts --outfile dist/cli.js --target node",
-    "build:types": "tsc --emitDeclarationOnly --declaration --noEmit false --outDir dist",
+    "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
     "test": "bun test",
+    "test:node": "node -e \"import('./dist/index.mjs').then(m => { const r = m.roll('1d6'); if (!(r.total >= 1 && r.total <= 6)) throw new Error('ESM smoke failed: total=' + r.total); console.log('Node.js ESM smoke: ok'); })\" && node -e \"const m = require('./dist/index.js'); const r = m.roll('1d6'); if (!(r.total >= 1 && r.total <= 6)) throw new Error('CJS smoke failed: total=' + r.total); console.log('Node.js CJS smoke: ok');\"",
     "test:watch": "bun test --watch",
     "test:ci": "bun test --bail",
     "validate": "bun run check && bun run build && bun test:ci",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Changes

- Added `tsconfig.build.json` with `emitDeclarationOnly`, `rootDir: "src"`, and test file exclusions to prevent `.d.ts` leakage into `dist/`
- Updated `build:types` to use `-p tsconfig.build.json` instead of CLI flag overrides
- Added `files` negation patterns to exclude test sources and `src/rng/mock.ts` from npm tarball
- Changed `bin` to explicit object form, added `sideEffects: false`
- Removed stale `bin/**/*.ts` glob from `biome.json`
- Added `test:node` script covering ESM and CJS bundles under Node.js

Closes #22

[Claude Code session](https://claude.ai/code)

<sub>Drafted with AI assistance</sub>
