### PR TITLE
feat: add percentile dice (d%) #35

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -73,6 +73,67 @@ describe('evaluate', () => {
     });
   });
 
+  describe('percentile dice (d%)', () => {
+    test('d% rolls a d100', () => {
+      const ast = parse('d%');
+      const rng = createMockRng([73]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(73);
+      expect(result.rolls).toHaveLength(1);
+      expect(getDie(result.rolls, 0).sides).toBe(100);
+    });
+
+    test('2d% sums two d100 rolls', () => {
+      const ast = parse('2d%');
+      const rng = createMockRng([42, 88]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(130);
+      expect(result.rolls).toHaveLength(2);
+    });
+
+    test('expression shows canonical 1d100', () => {
+      const ast = parse('d%');
+      const rng = createMockRng([50]);
+      const result = evaluate(ast, rng);
+
+      expect(result.expression).toBe('1d100');
+    });
+
+    test('critical on 100', () => {
+      const ast = parse('d%');
+      const rng = createMockRng([100]);
+      const result = evaluate(ast, rng);
+
+      expect(getDie(result.rolls, 0).critical).toBe(true);
+    });
+
+    test('fumble on 1', () => {
+      const ast = parse('d%');
+      const rng = createMockRng([1]);
+      const result = evaluate(ast, rng);
+
+      expect(getDie(result.rolls, 0).fumble).toBe(true);
+    });
+
+    test('2d%kh1 keeps highest', () => {
+      const ast = parse('2d%kh1');
+      const rng = createMockRng([42, 88]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(88);
+    });
+
+    test('notation preserved when passed via options', () => {
+      const ast = parse('d%');
+      const rng = createMockRng([50]);
+      const result = evaluate(ast, rng, { notation: 'd%' });
+
+      expect(result.notation).toBe('d%');
+    });
+  });
+
   describe('arithmetic operations', () => {
     test('addition', () => {
       const ast = parse('1d6 + 3');

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -83,6 +83,38 @@ describe('roll() integration', () => {
     });
   });
 
+  describe('percentile dice (d%)', () => {
+    test('basic d%', () => {
+      const result = roll('d%', { rng: createMockRng([73]) });
+      expect(result.total).toBe(73);
+      expect(result.notation).toBe('d%');
+      expect(result.expression).toBe('1d100');
+    });
+
+    test('2d%', () => {
+      const result = roll('2d%', { rng: createMockRng([42, 88]) });
+      expect(result.total).toBe(130);
+      expect(result.notation).toBe('2d%');
+    });
+
+    test('d%+5', () => {
+      const result = roll('d%+5', { rng: createMockRng([50]) });
+      expect(result.total).toBe(55);
+    });
+
+    test('2d%kh1 keeps highest', () => {
+      const result = roll('2d%kh1', { rng: createMockRng([30, 90]) });
+      expect(result.total).toBe(90);
+    });
+
+    test('rendered output shows rolls', () => {
+      const result = roll('d%', { rng: createMockRng([73]) });
+      expect(result.rendered).toContain('1d100');
+      expect(result.rendered).toContain('[73]');
+      expect(result.rendered).toContain('= 73');
+    });
+  });
+
   describe('seeded reproducibility', () => {
     test('same seed produces same result', () => {
       const r1 = roll('4d6', { seed: 'test-seed-123' });

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -96,6 +96,50 @@ describe('Parser', () => {
     });
   });
 
+  describe('percentile dice (d%)', () => {
+    it('should parse prefix d% as 1d100', () => {
+      expect(parse('d%')).toEqual(dice(literal(1), literal(100)));
+    });
+
+    it('should parse infix 2d%', () => {
+      expect(parse('2d%')).toEqual(dice(literal(2), literal(100)));
+    });
+
+    it('should parse d%+5', () => {
+      expect(parse('d%+5')).toEqual(binary('+', dice(literal(1), literal(100)), literal(5)));
+    });
+
+    it('should parse computed count (2)d%', () => {
+      expect(parse('(2)d%')).toEqual(dice(literal(2), literal(100)));
+    });
+
+    it('should parse 2d%kh1 with keep modifier', () => {
+      expect(parse('2d%kh1')).toEqual(
+        modifier('keep', 'highest', literal(1), dice(literal(2), literal(100))),
+      );
+    });
+
+    it('should produce same AST as d100', () => {
+      expect(parse('d%')).toEqual(parse('d100'));
+    });
+
+    it('should be case-insensitive (D%)', () => {
+      expect(parse('D%')).toEqual(dice(literal(1), literal(100)));
+    });
+
+    it('should not affect modulo operator', () => {
+      expect(parse('10%3')).toEqual(binary('%', literal(10), literal(3)));
+    });
+
+    it('should throw on d%%', () => {
+      expect(() => parse('d%%')).toThrow(ParseError);
+    });
+
+    it('should throw on d % 3 (whitespace breaks token)', () => {
+      expect(() => parse('d % 3')).toThrow(ParseError);
+    });
+  });
+
   describe('arithmetic precedence', () => {
     it('should parse addition', () => {
       expect(parse('1+2')).toEqual(binary('+', literal(1), literal(2)));

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -138,6 +138,9 @@ export class Parser {
       case TokenType.DICE:
         return this.parsePrefixDice();
 
+      case TokenType.DICE_PERCENT:
+        return this.parsePrefixDicePercent();
+
       case TokenType.LPAREN:
         return this.parseGrouped();
 
@@ -162,6 +165,9 @@ export class Parser {
     switch (token.type) {
       case TokenType.DICE:
         return this.parseInfixDice(left);
+
+      case TokenType.DICE_PERCENT:
+        return this.parseInfixDicePercent(left);
 
       case TokenType.PLUS:
       case TokenType.MINUS:
@@ -222,6 +228,24 @@ export class Parser {
       type: 'Dice',
       count: left,
       sides,
+    };
+  }
+
+  private parsePrefixDicePercent(): DiceNode {
+    // d% → Dice(1, 100)
+    return {
+      type: 'Dice',
+      count: { type: 'Literal', value: 1 },
+      sides: { type: 'Literal', value: 100 },
+    };
+  }
+
+  private parseInfixDicePercent(left: ASTNode): DiceNode {
+    // 2d% → Dice(2, 100)
+    return {
+      type: 'Dice',
+      count: left,
+      sides: { type: 'Literal', value: 100 },
     };
   }
 
@@ -363,6 +387,7 @@ export class Parser {
       case TokenType.POWER:
         return BP.POW_LEFT;
       case TokenType.DICE:
+      case TokenType.DICE_PERCENT:
         return BP.DICE_LEFT;
       case TokenType.KEEP_HIGH:
       case TokenType.KEEP_LOW:

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -24,6 +24,21 @@ describe('property-based invariants', () => {
       );
     });
 
+    test('Nd% total is always in valid range [N, N*100]', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 10 }), (count) => {
+          const result = roll(`${count}d%`);
+          return (
+            result.total >= count &&
+            result.total <= count * 100 &&
+            result.rolls.length === count &&
+            result.rolls.every((r) => r.sides === 100)
+          );
+        }),
+        { numRuns: 200 },
+      );
+    });
+
     test('0dX always returns 0', () => {
       fc.assert(
         fc.property(fc.integer({ min: 1, max: 100 }), (sides) => {


### PR DESCRIPTION
## Changes

- Added `DICE_PERCENT` NUD and LED handlers in the parser with dedicated methods that return `DiceNode(count, Literal(100))` without consuming a right-hand operand
- Registered `DICE_PERCENT` in `getLeftBp` with `BP.DICE_LEFT` (40) for infix binding
- Added 22 tests: parser (10), evaluator (7), integration (5), property (1) covering AST structure, evaluation, notation preservation, edge cases, and error paths

Closes #35

<sub>*Drafted with AI assistance*</sub>
