### PR TITLE
feat: add Fate/Fudge dice (dF) #36

### DIFF
--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -44,5 +44,15 @@ describe('formatResult', () => {
       const result = roll('1d20', { rng: createMockRng([15]) });
       expect(formatResult(result, true)).toBe('1d20[15] = 15');
     });
+
+    test('replaces strikethrough around negative values (dropped fate dice)', () => {
+      const result = roll('4dFkh2', { rng: createMockRng([-1, 0, 1, 1]) });
+      const output = formatResult(result, true);
+
+      expect(output).toContain('(-1)');
+      expect(output).toContain('(0)');
+      expect(output).not.toContain('~~');
+      expect(output).toBe('4dF[(-1), (0), 1, 1] = 2');
+    });
   });
 });

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -33,5 +33,5 @@ export function formatResult(result: RollResult, verbose: boolean): string {
  * This replaces those with `(value)` for clear terminal display.
  */
 function formatRendered(rendered: string): string {
-  return rendered.replace(/~~(\d+)~~/g, '($1)');
+  return rendered.replace(/~~(-?\d+)~~/g, '($1)');
 }

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -134,6 +134,156 @@ describe('evaluate', () => {
     });
   });
 
+  describe('fate dice (dF)', () => {
+    test('dF rolls a single fate die', () => {
+      const ast = parse('dF');
+      const rng = createMockRng([-1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(-1);
+      expect(result.rolls).toHaveLength(1);
+      const die = getDie(result.rolls, 0);
+      expect(die.sides).toBe(0);
+      expect(die.result).toBe(-1);
+      expect(die.critical).toBe(false);
+      expect(die.fumble).toBe(false);
+      expect(die.modifiers).toEqual(['kept']);
+    });
+
+    test('dF with zero result produces exact 0 total', () => {
+      const ast = parse('dF');
+      const rng = createMockRng([0]);
+      const result = evaluate(ast, rng);
+
+      expect(Object.is(result.total, 0)).toBe(true);
+    });
+
+    test('dF with +1 is not flagged as fumble', () => {
+      const ast = parse('dF');
+      const rng = createMockRng([1]);
+      const result = evaluate(ast, rng);
+
+      expect(getDie(result.rolls, 0).fumble).toBe(false);
+      expect(getDie(result.rolls, 0).critical).toBe(false);
+    });
+
+    test('4dF sums all four fate results', () => {
+      const ast = parse('4dF');
+      const rng = createMockRng([-1, 0, 1, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(1);
+      expect(result.rolls).toHaveLength(4);
+      for (const die of result.rolls) {
+        expect(die.sides).toBe(0);
+      }
+    });
+
+    test('expression is canonical "1dF" / "4dF" (not d0)', () => {
+      const single = evaluate(parse('dF'), createMockRng([0]));
+      const four = evaluate(parse('4dF'), createMockRng([0, 0, 0, 0]));
+
+      expect(single.expression).toBe('1dF');
+      expect(four.expression).toBe('4dF');
+    });
+
+    test('rendered shows negative values', () => {
+      const ast = parse('4dF');
+      const rng = createMockRng([-1, 0, 1, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rendered).toBe('4dF[-1, 0, 1, 1] = 1');
+    });
+
+    test('4dFkh2 keeps the two highest fate results', () => {
+      const ast = parse('4dFkh2');
+      const rng = createMockRng([-1, 0, 1, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(2);
+      const dropped = result.rolls.filter((d) => d.modifiers.includes('dropped'));
+      expect(dropped).toHaveLength(2);
+      expect(dropped.map((d) => d.result).sort()).toEqual([-1, 0]);
+    });
+
+    test('4dFdl1 drops the lowest fate result', () => {
+      const ast = parse('4dFdl1');
+      const rng = createMockRng([-1, 0, 1, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(2);
+      const dropped = result.rolls.filter((d) => d.modifiers.includes('dropped'));
+      expect(dropped).toHaveLength(1);
+      expect(dropped[0]?.result).toBe(-1);
+    });
+
+    test('0dF produces total 0 and no rolls', () => {
+      const ast = parse('0dF');
+      const rng = createMockRng([]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(0);
+      expect(result.rolls).toHaveLength(0);
+    });
+
+    test('dF+5 adds modifier to fate result', () => {
+      const ast = parse('dF+5');
+      const rng = createMockRng([0]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(5);
+    });
+
+    test('-dF negates the fate result', () => {
+      const ast = parse('-dF');
+      const rng = createMockRng([1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(-1);
+    });
+
+    test('(-1)dF throws INVALID_DICE_COUNT', () => {
+      const ast = parse('(-1)dF');
+      const rng = createMockRng([]);
+
+      expect(() => evaluate(ast, rng)).toThrow(EvaluatorError);
+      try {
+        evaluate(ast, rng);
+      } catch (err) {
+        expect(err).toBeInstanceOf(EvaluatorError);
+        if (err instanceof EvaluatorError) {
+          expect(err.code).toBe('INVALID_DICE_COUNT');
+          expect(err.nodeType).toBe('FateDice');
+        }
+      }
+    });
+
+    test('5dF with maxDice=4 throws DICE_LIMIT_EXCEEDED', () => {
+      const ast = parse('5dF');
+      const rng = createMockRng([0, 0, 0, 0, 0]);
+
+      try {
+        evaluate(ast, rng, { maxDice: 4 });
+        throw new Error('expected DICE_LIMIT_EXCEEDED');
+      } catch (err) {
+        expect(err).toBeInstanceOf(EvaluatorError);
+        if (err instanceof EvaluatorError) {
+          expect(err.code).toBe('DICE_LIMIT_EXCEEDED');
+          expect(err.nodeType).toBe('FateDice');
+        }
+      }
+    });
+
+    test('(2+2)dF evaluates count expression', () => {
+      const ast = parse('(2+2)dF');
+      const rng = createMockRng([1, 1, 1, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(4);
+      expect(result.rolls).toHaveLength(4);
+    });
+  });
+
   describe('arithmetic operations', () => {
     test('addition', () => {
       const ast = parse('1d6 + 3');

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -6,7 +6,14 @@
 
 import type { RollParserErrorCode } from '../errors';
 import { RollParserError } from '../errors';
-import type { ASTNode, BinaryOpNode, DiceNode, ModifierNode, UnaryOpNode } from '../parser/ast';
+import type {
+  ASTNode,
+  BinaryOpNode,
+  DiceNode,
+  FateDiceNode,
+  ModifierNode,
+  UnaryOpNode,
+} from '../parser/ast';
 import { isModifier } from '../parser/ast';
 import type { RNG } from '../rng/types';
 import type { DieResult, EvaluateOptions, RollResult } from '../types';
@@ -76,6 +83,20 @@ function createDieResult(sides: number, result: number): DieResult {
 }
 
 /**
+ * Creates a Fate/Fudge die result. Uses `sides = 0` as a sentinel — Fate dice
+ * have no max-face concept, so `critical` and `fumble` are always `false`.
+ */
+function createFateDieResult(result: number): DieResult {
+  return {
+    sides: 0,
+    result,
+    modifiers: [],
+    critical: false,
+    fumble: false,
+  };
+}
+
+/**
  * Renders dice results for display (e.g., "[3, 5, 2]" or "[~~3~~, 5, ~~2~~]").
  */
 function renderDice(dice: DieResult[]): string {
@@ -98,6 +119,9 @@ function evalNode(node: ASTNode, rng: RNG, ctx: EvalContext, env: EvalEnv): numb
 
     case 'Dice':
       return evalDice(node, rng, ctx, env);
+
+    case 'FateDice':
+      return evalFateDice(node, rng, ctx, env);
 
     case 'BinaryOp':
       return evalBinaryOp(node, rng, ctx, env);
@@ -166,6 +190,45 @@ function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): num
 
   const total = sumKeptDice(markedDice);
   const notation = `${count}d${sides}`;
+
+  ctx.expressionParts.push(notation);
+  ctx.renderedParts.push(`${notation}${renderDice(markedDice)}`);
+
+  return total;
+}
+
+function evalFateDice(node: FateDiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
+  const count = evalNode(
+    node.count,
+    rng,
+    { rolls: [], expressionParts: [], renderedParts: [] },
+    env,
+  );
+
+  if (!Number.isInteger(count) || count < 0) {
+    throw new EvaluatorError(`Invalid dice count: ${count}`, 'INVALID_DICE_COUNT', 'FateDice');
+  }
+
+  if (env.totalDiceRolled + count > env.maxDice) {
+    throw new EvaluatorError(
+      `Total dice count ${env.totalDiceRolled + count} exceeds limit of ${env.maxDice}`,
+      'DICE_LIMIT_EXCEEDED',
+      'FateDice',
+    );
+  }
+  env.totalDiceRolled += count;
+
+  const dice: DieResult[] = [];
+  for (let i = 0; i < count; i++) {
+    const result = rng.nextInt(-1, 1);
+    dice.push(createFateDieResult(result));
+  }
+
+  const markedDice = markAllKept(dice);
+  ctx.rolls.push(...markedDice);
+
+  const total = sumKeptDice(markedDice);
+  const notation = `${count}dF`;
 
   ctx.expressionParts.push(notation);
   ctx.renderedParts.push(`${notation}${renderDice(markedDice)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type {
   ASTNode,
   BinaryOpNode,
   DiceNode,
+  FateDiceNode,
   LiteralNode,
   ModifierNode,
   UnaryOpNode,
@@ -24,6 +25,7 @@ export type {
 export {
   isBinaryOp,
   isDice,
+  isFateDice,
   isLiteral,
   isModifier,
   isUnaryOp,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -115,6 +115,43 @@ describe('roll() integration', () => {
     });
   });
 
+  describe('fate dice (dF)', () => {
+    test('basic 4dF', () => {
+      const result = roll('4dF', { rng: createMockRng([-1, 0, 1, 1]) });
+
+      expect(result.total).toBe(1);
+      expect(result.notation).toBe('4dF');
+      expect(result.expression).toBe('4dF');
+      expect(result.rolls).toHaveLength(4);
+      for (const die of result.rolls) {
+        expect(die.sides).toBe(0);
+        expect(die.critical).toBe(false);
+        expect(die.fumble).toBe(false);
+      }
+    });
+
+    test('dF+5 combines fate with arithmetic', () => {
+      const result = roll('dF+5', { rng: createMockRng([0]) });
+      expect(result.total).toBe(5);
+    });
+
+    test('seeded reproducibility for dF', () => {
+      const r1 = roll('4dF', { seed: 'fate-seed-xyz' });
+      const r2 = roll('4dF', { seed: 'fate-seed-xyz' });
+
+      expect(r1.total).toBe(r2.total);
+      expect(r1.rolls.map((r) => r.result)).toEqual(r2.rolls.map((r) => r.result));
+      for (const die of r1.rolls) {
+        expect([-1, 0, 1]).toContain(die.result);
+      }
+    });
+
+    test('rendered output shows fate notation and results', () => {
+      const result = roll('4dF', { rng: createMockRng([-1, 0, 1, 1]) });
+      expect(result.rendered).toBe('4dF[-1, 0, 1, 1] = 1');
+    });
+  });
+
   describe('seeded reproducibility', () => {
     test('same seed produces same result', () => {
       const r1 = roll('4d6', { seed: 'test-seed-123' });

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -429,6 +429,53 @@ describe('Lexer', () => {
       expect(lex('dl')[0]?.type).toBe(TokenType.DROP_LOW);
       expect(lex('dF')[0]?.type).toBe(TokenType.DICE_FATE);
     });
+
+    it('should tokenize 4dFkh2 without greedy identifier merge', () => {
+      const tokens = lex('4dFkh2');
+
+      expect(tokens).toHaveLength(5);
+      expect(tokens[0]).toEqual({ type: TokenType.NUMBER, value: '4', position: 0 });
+      expect(tokens[1]).toEqual({ type: TokenType.DICE_FATE, value: 'df', position: 1 });
+      expect(tokens[2]).toEqual({ type: TokenType.KEEP_HIGH, value: 'kh', position: 3 });
+      expect(tokens[3]).toEqual({ type: TokenType.NUMBER, value: '2', position: 5 });
+    });
+
+    it('should tokenize 4dFdl1 without greedy identifier merge', () => {
+      const tokens = lex('4dFdl1');
+
+      expect(tokens).toHaveLength(5);
+      expect(tokens[0]?.type).toBe(TokenType.NUMBER);
+      expect(tokens[1]?.type).toBe(TokenType.DICE_FATE);
+      expect(tokens[2]?.type).toBe(TokenType.DROP_LOW);
+      expect(tokens[3]?.type).toBe(TokenType.NUMBER);
+    });
+
+    it('should tokenize dFdF as two consecutive fate tokens', () => {
+      const tokens = lex('dFdF');
+
+      expect(tokens).toHaveLength(3);
+      expect(tokens[0]).toEqual({ type: TokenType.DICE_FATE, value: 'df', position: 0 });
+      expect(tokens[1]).toEqual({ type: TokenType.DICE_FATE, value: 'df', position: 2 });
+    });
+
+    it('should tokenize dF+5 with trailing arithmetic', () => {
+      const tokens = lex('dF+5');
+
+      expect(tokens).toHaveLength(4);
+      expect(tokens[0]?.type).toBe(TokenType.DICE_FATE);
+      expect(tokens[1]?.type).toBe(TokenType.PLUS);
+      expect(tokens[2]?.type).toBe(TokenType.NUMBER);
+    });
+
+    it('should tokenize 2dFd20 with a following dice expression', () => {
+      const tokens = lex('2dFd20');
+
+      expect(tokens).toHaveLength(5);
+      expect(tokens[0]?.type).toBe(TokenType.NUMBER);
+      expect(tokens[1]?.type).toBe(TokenType.DICE_FATE);
+      expect(tokens[2]?.type).toBe(TokenType.DICE);
+      expect(tokens[3]?.type).toBe(TokenType.NUMBER);
+    });
   });
 
   describe('fail token', () => {

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -178,10 +178,25 @@ export class Lexer {
    * Scans an identifier using full-accumulation: collects all consecutive
    * alpha characters, then classifies the result against known keywords.
    *
-   * Special case: bare 'd' followed by '%' produces DICE_PERCENT.
+   * Special cases run before/after the accumulation loop:
+   * - `dF` / `Df` / `dF` / `DF` produces DICE_FATE. Must be handled BEFORE
+   *   the loop because `F` is alpha and would otherwise be greedily merged
+   *   into identifiers like `dfkh` (from `4dFkh2`) or `dfdf` (from `dFdF`).
+   *   Reserves the `d[fF]` prefix namespace for Fate dice.
+   * - Bare `d` followed by `%` produces DICE_PERCENT. `%` is not alpha so the
+   *   accumulation loop stops naturally and the post-loop check handles it.
    */
   private scanIdentifier(): Token {
     const startPos = this.pos;
+
+    const first = this.peek();
+    const second = this.peekNext();
+    if ((first === 'd' || first === 'D') && (second === 'f' || second === 'F')) {
+      this.advance();
+      this.advance();
+      return this.createTokenAt(TokenType.DICE_FATE, 'df', startPos);
+    }
+
     let value = '';
 
     while (!this.isAtEnd() && this.isAlpha(this.peek())) {
@@ -190,16 +205,9 @@ export class Lexer {
 
     const lower = value.toLowerCase();
 
-    // Special case: d% (percentile dice) — '%' is not alpha, so it's not
-    // accumulated above. Check after accumulation if we got bare 'd'.
     if (lower === 'd' && !this.isAtEnd() && this.peek() === '%') {
       this.advance();
       return this.createTokenAt(TokenType.DICE_PERCENT, 'd%', startPos);
-    }
-
-    // Special case: dF — accumulated as 'df', maps to DICE_FATE
-    if (lower === 'df') {
-      return this.createTokenAt(TokenType.DICE_FATE, lower, startPos);
     }
 
     const tokenType = IDENTIFIER_KEYWORDS[lower];

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -23,6 +23,15 @@ export type DiceNode = {
 };
 
 /**
+ * Fate/Fudge dice node (`dF`).
+ * Each die produces a result in {-1, 0, +1}. No configurable sides.
+ */
+export type FateDiceNode = {
+  type: 'FateDice';
+  count: ASTNode;
+};
+
+/**
  * Binary operation node.
  */
 export type BinaryOpNode = {
@@ -56,7 +65,13 @@ export type ModifierNode = {
 /**
  * Union type of all AST nodes.
  */
-export type ASTNode = LiteralNode | DiceNode | BinaryOpNode | UnaryOpNode | ModifierNode;
+export type ASTNode =
+  | LiteralNode
+  | DiceNode
+  | FateDiceNode
+  | BinaryOpNode
+  | UnaryOpNode
+  | ModifierNode;
 
 /**
  * Type guard for LiteralNode.
@@ -70,6 +85,13 @@ export function isLiteral(node: ASTNode): node is LiteralNode {
  */
 export function isDice(node: ASTNode): node is DiceNode {
   return node.type === 'Dice';
+}
+
+/**
+ * Type guard for FateDiceNode.
+ */
+export function isFateDice(node: ASTNode): node is FateDiceNode {
+  return node.type === 'FateDice';
 }
 
 /**

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -5,6 +5,7 @@ import type {
   ASTNode,
   BinaryOpNode,
   DiceNode,
+  FateDiceNode,
   LiteralNode,
   ModifierNode,
   UnaryOpNode,
@@ -18,6 +19,10 @@ function literal(value: number): LiteralNode {
 
 function dice(count: ASTNode, sides: ASTNode): DiceNode {
   return { type: 'Dice', count, sides };
+}
+
+function fateDice(count: ASTNode): FateDiceNode {
+  return { type: 'FateDice', count };
 }
 
 function binary(operator: BinaryOpNode['operator'], left: ASTNode, right: ASTNode): BinaryOpNode {
@@ -137,6 +142,48 @@ describe('Parser', () => {
 
     it('should throw on d % 3 (whitespace breaks token)', () => {
       expect(() => parse('d % 3')).toThrow(ParseError);
+    });
+  });
+
+  describe('fate dice (dF)', () => {
+    it('should parse prefix dF as FateDice(1)', () => {
+      expect(parse('dF')).toEqual(fateDice(literal(1)));
+    });
+
+    it('should parse infix 4dF', () => {
+      expect(parse('4dF')).toEqual(fateDice(literal(4)));
+    });
+
+    it('should parse computed count (2+2)dF', () => {
+      expect(parse('(2+2)dF')).toEqual(fateDice(binary('+', literal(2), literal(2))));
+    });
+
+    it('should parse dF+5 with trailing arithmetic', () => {
+      expect(parse('dF+5')).toEqual(binary('+', fateDice(literal(1)), literal(5)));
+    });
+
+    it('should parse 4dFkh2 with keep modifier', () => {
+      expect(parse('4dFkh2')).toEqual(
+        modifier('keep', 'highest', literal(2), fateDice(literal(4))),
+      );
+    });
+
+    it('should parse 4dFdl1 with drop modifier', () => {
+      expect(parse('4dFdl1')).toEqual(modifier('drop', 'lowest', literal(1), fateDice(literal(4))));
+    });
+
+    it('should parse -dF as unary minus over fate dice', () => {
+      expect(parse('-dF')).toEqual(unary(fateDice(literal(1))));
+    });
+
+    it('should parse (-1)dF with unary count (evaluator rejects at runtime)', () => {
+      expect(parse('(-1)dF')).toEqual(fateDice(unary(literal(1))));
+    });
+
+    it('should be case-insensitive (DF, Df, df)', () => {
+      expect(parse('DF')).toEqual(fateDice(literal(1)));
+      expect(parse('Df')).toEqual(fateDice(literal(1)));
+      expect(parse('df')).toEqual(fateDice(literal(1)));
     });
   });
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -13,6 +13,7 @@ import type {
   ASTNode,
   BinaryOpNode,
   DiceNode,
+  FateDiceNode,
   LiteralNode,
   ModifierNode,
   UnaryOpNode,
@@ -141,6 +142,9 @@ export class Parser {
       case TokenType.DICE_PERCENT:
         return this.parsePrefixDicePercent();
 
+      case TokenType.DICE_FATE:
+        return this.parsePrefixFateDice();
+
       case TokenType.LPAREN:
         return this.parseGrouped();
 
@@ -168,6 +172,9 @@ export class Parser {
 
       case TokenType.DICE_PERCENT:
         return this.parseInfixDicePercent(left);
+
+      case TokenType.DICE_FATE:
+        return this.parseInfixFateDice(left);
 
       case TokenType.PLUS:
       case TokenType.MINUS:
@@ -246,6 +253,24 @@ export class Parser {
       type: 'Dice',
       count: left,
       sides: { type: 'Literal', value: 100 },
+    };
+  }
+
+  private parsePrefixFateDice(): FateDiceNode {
+    // dF → FateDice(1)
+    return {
+      type: 'FateDice',
+      count: { type: 'Literal', value: 1 },
+    };
+  }
+
+  private parseInfixFateDice(left: ASTNode): FateDiceNode {
+    // 4dF → FateDice(4). Unlike parseInfixDice, there is no sides sub-parse,
+    // so modifiers (`kh`, `dl`, …) naturally bind at the outer Pratt loop
+    // without BP competition against a right-operand.
+    return {
+      type: 'FateDice',
+      count: left,
     };
   }
 
@@ -388,6 +413,7 @@ export class Parser {
         return BP.POW_LEFT;
       case TokenType.DICE:
       case TokenType.DICE_PERCENT:
+      case TokenType.DICE_FATE:
         return BP.DICE_LEFT;
       case TokenType.KEEP_HIGH:
       case TokenType.KEEP_LOW:

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -39,6 +39,28 @@ describe('property-based invariants', () => {
       );
     });
 
+    test('NdF total is always an integer in [-N, +N]', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 0, max: 20 }), (count) => {
+          const result = roll(`${count}dF`);
+          return (
+            Number.isInteger(result.total) &&
+            result.total >= -count &&
+            result.total <= count &&
+            result.rolls.length === count &&
+            result.rolls.every(
+              (r) =>
+                r.sides === 0 &&
+                r.critical === false &&
+                r.fumble === false &&
+                (r.result === -1 || r.result === 0 || r.result === 1),
+            )
+          );
+        }),
+        { numRuns: 300 },
+      );
+    });
+
     test('0dX always returns 0', () => {
       fc.assert(
         fc.property(fc.integer({ min: 1, max: 100 }), (sides) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,15 +31,19 @@ export type DieModifier = 'dropped' | 'kept' | 'exploded' | 'rerolled';
  * Individual die roll result with metadata.
  */
 export type DieResult = {
-  /** Number of sides on the die */
+  /**
+   * Number of sides on the die. Normal dice use `sides >= 1`. Fate/Fudge
+   * dice use `sides = 0` as a sentinel — they have no configurable sides
+   * and always produce results in {-1, 0, +1}.
+   */
   sides: number;
   /** The rolled value */
   result: number;
   /** Modifiers applied to this die */
   modifiers: DieModifier[];
-  /** True if rolled the maximum value */
+  /** True if rolled the maximum value (always false for Fate dice) */
   critical: boolean;
-  /** True if rolled 1 */
+  /** True if rolled 1 (always false for Fate dice) */
   fumble: boolean;
 };
 


### PR DESCRIPTION
## Changes

- Fixed `scanIdentifier` greedy-accumulation bug that broke `4dFkh2`, `4dFdl1`, `dFdF` — added pre-loop fast path for `d[fF]` before alpha chars merged into unknown identifiers
- Added `FateDiceNode` AST node (`{ type: 'FateDice'; count: ASTNode }`) and `isFateDice` type guard; exported from public API
- Added NUD/LED parser handlers for `DICE_FATE` and `BP.DICE_LEFT` in `getLeftBp`
- Added `createFateDieResult` helper (`sides = 0`, `critical = false`, `fumble = false`) and `evalFateDice` using `rng.nextInt(-1, 1)`
- Updated `formatRendered` strikethrough regex to `/~~(-?\d+)~~/g` for negative dropped dice
- Documented `DieResult.sides = 0` sentinel on the `sides` field in `src/types.ts`
- Added 19 new tests across lexer, parser, evaluator, format, integration, and property suites

Closes #36

<sub>*Drafted with AI assistance*</sub>
