### PR TITLE
fix: SuccessCount target validation, terminality, and BP regression #51

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1458,25 +1458,6 @@ describe('evaluate', () => {
       }
     });
 
-    test('arithmetic on success count — 5d6>=5+3', () => {
-      const ast = parse('5d6>=5+3');
-      const rng = createMockRng([1, 2, 3, 4, 5]);
-      const result = evaluate(ast, rng);
-
-      // 1 success (the 5) + 3 literal = 4.
-      expect(result.total).toBe(4);
-      expect(result.successes).toBe(1);
-    });
-
-    test('multiplication on success count — 5d6>=5*2', () => {
-      const ast = parse('5d6>=5*2');
-      const rng = createMockRng([5, 5, 2, 6, 1]);
-      const result = evaluate(ast, rng);
-
-      expect(result.successes).toBe(3); // 5, 5, 6
-      expect(result.total).toBe(6); // 3 * 2
-    });
-
     test('rendered output uses ** and __ markers', () => {
       const ast = parse('3d6>=5f1');
       const rng = createMockRng([1, 5, 3]);
@@ -1522,17 +1503,6 @@ describe('evaluate', () => {
 
       expect(result.successes).toBe(2);
       expect(result.failures).toBe(0);
-    });
-
-    test('aggregates across multiple success-count subexpressions', () => {
-      const ast = parse('4d6>=5 + 4d6>=4');
-      // Pool 1: [5, 6, 2, 3] → 2 successes
-      // Pool 2: [4, 1, 4, 2] → 2 successes
-      const rng = createMockRng([5, 6, 2, 3, 4, 1, 4, 2]);
-      const result = evaluate(ast, rng);
-
-      expect(result.successes).toBe(4);
-      expect(result.total).toBe(4);
     });
   });
 

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -644,8 +644,8 @@ function evalSuccessCount(
     failValue != null ? `f${failValue}` : ''
   }`;
 
-  // No-op when the target produced no dice in its pool. `containsDice` should
-  // already reject this at parse time, but guard defensively.
+  // No-op when the target produced no dice in its pool. `containsDicePool`
+  // should already reject this at parse time, but guard defensively.
   if (targetCtx.rolls.length === 0) {
     ctx.expressionParts.push(`${targetExpr}${code}`);
     ctx.renderedParts.push(`${targetExpr}${code}`);

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -93,9 +93,10 @@ export type RerollNode = {
  * Success counting node (`>=T`, `>T`, `<T`, `<=T`, `=T`, with optional `f=F`).
  *
  * Transforms a dice pool into a success count: each die meeting `threshold`
- * adds +1, each die meeting `failThreshold` subtracts 1. Terminal — no further
- * postfix modifiers may wrap a `SuccessCountNode`. The `failThreshold`
- * operator is always `=` (fail on an exact value).
+ * adds +1, each die meeting `failThreshold` subtracts 1. Terminal — a
+ * `SuccessCountNode` may not be wrapped by any postfix modifier, binary
+ * operator, unary operator, versus operand, or function argument. The
+ * `failThreshold` operator is always `=` (fail on an exact value).
  */
 export type SuccessCountNode = {
   type: 'SuccessCount';

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -847,16 +847,22 @@ describe('Parser', () => {
       );
     });
 
-    it('should attach outer + as BinaryOp on SuccessCount: 5d6>=5+3', () => {
-      expect(parse('5d6>=5+3')).toEqual(
-        binary('+', successCount(dice(literal(5), literal(6)), cp('>=', literal(5))), literal(3)),
-      );
+    it('should reject outer + on SuccessCount: 5d6>=5+3', () => {
+      expect(() => parse('5d6>=5+3')).toThrow(ParseError);
+      try {
+        parse('5d6>=5+3');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
     });
 
-    it('should attach outer * as BinaryOp on SuccessCount: 5d6>=5 * 2', () => {
-      expect(parse('5d6>=5 * 2')).toEqual(
-        binary('*', successCount(dice(literal(5), literal(6)), cp('>=', literal(5))), literal(2)),
-      );
+    it('should reject outer * on SuccessCount: 5d6>=5 * 2', () => {
+      expect(() => parse('5d6>=5 * 2')).toThrow(ParseError);
+      try {
+        parse('5d6>=5 * 2');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
     });
 
     it('should wrap keep-highest-then-count: 4d6kh3>=5', () => {
@@ -967,9 +973,99 @@ describe('Parser', () => {
       }
     });
 
-    it('should accept dice inside binary target: (1d6+2)>=3', () => {
-      expect(parse('(1d6+2)>=3')).toEqual(
-        successCount(binary('+', dice(literal(1), literal(6)), literal(2)), cp('>=', literal(3))),
+    it('should reject non-pool arithmetic target: (1d6+2)>=3', () => {
+      expect(() => parse('(1d6+2)>=3')).toThrow(ParseError);
+      try {
+        parse('(1d6+2)>=3');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject non-pool multiplication target: (1d6*2)>=10', () => {
+      expect(() => parse('(1d6*2)>=10')).toThrow(ParseError);
+      try {
+        parse('(1d6*2)>=10');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject versus inside success-count target: (1d20 vs 15)>=1', () => {
+      expect(() => parse('(1d20 vs 15)>=1')).toThrow(ParseError);
+      try {
+        parse('(1d20 vs 15)>=1');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject XdY+N>T (BP keeps arithmetic ahead of compare): 5d6+2>4', () => {
+      expect(() => parse('5d6+2>4')).toThrow(ParseError);
+      try {
+        parse('5d6+2>4');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject XdY+N>=T: 5d6+2>=4', () => {
+      expect(() => parse('5d6+2>=4')).toThrow(ParseError);
+      try {
+        parse('5d6+2>=4');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject binary wrapping on success count: 2 * (1d6>=5)', () => {
+      expect(() => parse('2 * (1d6>=5)')).toThrow(ParseError);
+      try {
+        parse('2 * (1d6>=5)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject parenthesized + on success count: (1d6>=5) + 3', () => {
+      expect(() => parse('(1d6>=5) + 3')).toThrow(ParseError);
+      try {
+        parse('(1d6>=5) + 3');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject success count inside function arg: max(1d6>=5, 2)', () => {
+      expect(() => parse('max(1d6>=5, 2)')).toThrow(ParseError);
+      try {
+        parse('max(1d6>=5, 2)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject success count as vs roll side: 10d10>=6 vs 8', () => {
+      expect(() => parse('10d10>=6 vs 8')).toThrow(ParseError);
+      try {
+        parse('10d10>=6 vs 8');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject unary minus on success count: -(1d6>=5)', () => {
+      expect(() => parse('-(1d6>=5)')).toThrow(ParseError);
+      try {
+        parse('-(1d6>=5)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should still parse plain pool success count: 5d6>=5', () => {
+      expect(parse('5d6>=5')).toEqual(
+        successCount(dice(literal(5), literal(6)), cp('>=', literal(5))),
       );
     });
   });

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -23,7 +23,7 @@ import type {
   UnaryOpNode,
   VersusNode,
 } from './ast';
-import { containsDice, containsDicePool, isSuccessCount } from './ast';
+import { containsDicePool, isSuccessCount } from './ast';
 
 /**
  * Error thrown when the parser encounters invalid syntax.
@@ -57,6 +57,10 @@ const BP = {
   // Versus (left-associative, lowest precedence — `1d20+10 vs 25+10` = `(1d20+10) vs (25+10)`)
   VS_LEFT: 2,
   VS_RIGHT: 3,
+  // Comparison operators used as the success-count LED. Must be below
+  // ADD/MUL so `XdY+N>T` parses as `(XdY+N)>T` and fails the pool-target
+  // guard with a clear error, instead of the `>` stealing `N` from the `+`.
+  COMPARE: 8,
   // Addition/subtraction (left-associative)
   ADD_LEFT: 10,
   ADD_RIGHT: 11,
@@ -157,7 +161,7 @@ export class Parser {
         return this.parseLiteral(token);
 
       case TokenType.MINUS:
-        return this.parseUnaryMinus();
+        return this.parseUnaryMinus(token);
 
       case TokenType.DICE:
         return this.parsePrefixDice();
@@ -254,8 +258,9 @@ export class Parser {
     };
   }
 
-  private parseUnaryMinus(): UnaryOpNode {
+  private parseUnaryMinus(token: Token): UnaryOpNode {
     const operand = this.parseExpression(BP.UNARY);
+    this.rejectSuccessCountTarget(operand, token);
     return {
       type: 'UnaryOp',
       operator: '-',
@@ -333,10 +338,14 @@ export class Parser {
 
     const args: ASTNode[] = [];
     if (this.peek().type !== TokenType.RPAREN) {
-      args.push(this.parseExpression(0));
+      const first = this.parseExpression(0);
+      this.rejectSuccessCountTarget(first, token);
+      args.push(first);
       while (this.peek().type === TokenType.COMMA) {
         this.advance();
-        args.push(this.parseExpression(0));
+        const next = this.parseExpression(0);
+        this.rejectSuccessCountTarget(next, token);
+        args.push(next);
       }
     }
 
@@ -374,9 +383,13 @@ export class Parser {
   }
 
   private parseBinaryOp(left: ASTNode, token: Token): BinaryOpNode {
+    this.rejectSuccessCountTarget(left, token);
+
     const operator = this.getOperatorSymbol(token);
     const rightBp = this.getRightBp(token);
     const right = this.parseExpression(rightBp);
+
+    this.rejectSuccessCountTarget(right, token);
 
     return {
       type: 'BinaryOp',
@@ -508,11 +521,12 @@ export class Parser {
     // Success counting is terminal: chaining (`>=5>=3`) has no semantics.
     this.rejectSuccessCountTarget(target, token);
 
-    // Reject non-dice targets like `1>=3` or `(1+2)>=3`. Success counting
-    // operates on a dice pool; a sum has no pool to count.
-    if (!containsDice(target)) {
+    // Reject non-pool targets like `1>=3`, `(1+2)>=3`, `(1d6*2)>=10`, or
+    // `(1d20 vs 15)>=1`. Success counting operates on a raw dice pool; any
+    // arithmetic or composition wrapping would be silently ignored.
+    if (!containsDicePool(target)) {
       throw new ParseError(
-        `Success counting requires a dice expression`,
+        `Success counting requires a dice pool target`,
         'INVALID_SUCCESS_COUNT_TARGET',
         token.position,
         token,
@@ -537,6 +551,8 @@ export class Parser {
   }
 
   private parseVersus(left: ASTNode, token: Token): VersusNode {
+    this.rejectSuccessCountTarget(left, token);
+
     // ? Chained `a vs b vs c` has no semantics — a degree is a scalar, not a
     //   comparable. Parens (`a vs (b vs c)`) slip past this check and are
     //   caught by the evaluator via `EvalEnv.insideVersus`.
@@ -545,6 +561,7 @@ export class Parser {
     }
 
     const dc = this.parseExpression(BP.VS_RIGHT);
+    this.rejectSuccessCountTarget(dc, token);
 
     return { type: 'Versus', roll: left, dc };
   }
@@ -657,15 +674,19 @@ export class Parser {
       case TokenType.EXPLODE_PENETRATING:
       case TokenType.REROLL:
       case TokenType.REROLL_ONCE:
+        return BP.MODIFIER;
       // Comparison operators act as LED-dispatched success-count modifiers
-      // at the Pratt level. Inside `parseComparePoint` (called manually by
-      // explode/reroll) they are consumed directly and this BP is bypassed.
+      // at the Pratt level. Sit below ADD/MUL so arithmetic on a dice pool
+      // completes before success counting wraps it — `5d6+2>4` parses as
+      // `(5d6+2)>4` and then cleanly fails the pool-target guard, rather
+      // than the `>` stealing `2` from the `+`. Inside `parseComparePoint`
+      // (called manually by explode/reroll) this BP is bypassed.
       case TokenType.GREATER:
       case TokenType.GREATER_EQUAL:
       case TokenType.LESS:
       case TokenType.LESS_EQUAL:
       case TokenType.EQUAL:
-        return BP.MODIFIER;
+        return BP.COMPARE;
       case TokenType.RPAREN:
       case TokenType.EOF:
       // Punctuation and keywords that terminate expressions


### PR DESCRIPTION
## Changes

- Replaced `containsDice` with `containsDicePool` in `parseSuccessCount` — rejects non-pool targets like `(1d6*2)>=10` at parse time (Defect A)
- Added `BP.COMPARE = 8` and lowered comparison-token `leftBp` below `ADD_LEFT` — `5d6+2>4` now surfaces a clear pool-target error instead of a misleading literal-binding failure (Defect B)
- Added `rejectSuccessCountTarget` to `parseBinaryOp` (both operands), `parseVersus` (both sides), `parseUnaryMinus`, and `parseFunctionCall` args — enforces full terminality invariant (Defect C)
- Expanded `SuccessCountNode` JSDoc to enumerate all prohibited wrapping contexts
- Removed 3 evaluator tests and inverted 2 parser tests that encoded leaky behavior as correct; added 10 new parser tests covering all three defect classes

Closes #51

<sub>*Drafted with AI assistance*</sub>
