### PR TITLE
fix: compound explode corrupts natural-d20 detection for vs #52

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1786,6 +1786,41 @@ describe('evaluate', () => {
       expect(getDie(result.rolls, 0).result).toBe(15);
       expect(getDie(result.rolls, 1).result).toBe(8);
     });
+
+    test('Compound explode nat-20: 1d20!! vs 30 rolls=[20,5] → natural=20, upgrade Failure→Success', () => {
+      const ast = parse('1d20!! vs 30');
+      const rng = createMockRng([20, 5]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(25);
+      expect(result.natural).toBe(20);
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
+      expect(getDie(result.rolls, 0).result).toBe(25);
+      expect(getDie(result.rolls, 0).initialResult).toBe(20);
+    });
+
+    test('Compound explode nat-1: 1d20!!<=1 vs 5 rolls=[1,3] → natural=1, downgrade Failure→CriticalFailure', () => {
+      const ast = parse('1d20!!<=1 vs 5');
+      const rng = createMockRng([1, 3]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(4);
+      expect(result.natural).toBe(1);
+      expect(result.degree).toBe(DegreeOfSuccess.CriticalFailure);
+      expect(getDie(result.rolls, 0).result).toBe(4);
+      expect(getDie(result.rolls, 0).initialResult).toBe(1);
+    });
+
+    test('Compound explode without trigger: initialResult is undefined, natural uses result', () => {
+      const ast = parse('1d20!! vs 15');
+      const rng = createMockRng([18]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(18);
+      expect(result.natural).toBe(18);
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
+      expect(getDie(result.rolls, 0).initialResult).toBeUndefined();
+    });
   });
 
   describe('math functions', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -681,7 +681,9 @@ function extractNatural(rolls: DieResult[]): number | undefined {
   const keptD20s = rolls.filter(
     (d) => d.sides === 20 && !d.modifiers.includes('dropped') && !d.modifiers.includes('rerolled'),
   );
-  return keptD20s.length === 1 ? keptD20s[0]?.result : undefined;
+  if (keptD20s.length !== 1) return undefined;
+  const die = keptD20s[0];
+  return die?.initialResult ?? die?.result;
 }
 
 /**

--- a/src/evaluator/modifiers/explode.ts
+++ b/src/evaluator/modifiers/explode.ts
@@ -160,6 +160,7 @@ export function applyCompoundExplode(
     return {
       sides,
       result: accumulated,
+      initialResult: original.result,
       modifiers: original.modifiers.includes('exploded')
         ? original.modifiers
         : [...original.modifiers, 'exploded'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,13 @@ export type DieResult = {
   sides: number;
   /** The rolled value */
   result: number;
+  /**
+   * Raw first roll before any mutation (e.g., compound-explode accumulation).
+   * Only populated when `result` has been overwritten with a computed value.
+   * Consumers that need the original face (nat-20 / nat-1 detection) should
+   * read `initialResult ?? result`.
+   */
+  initialResult?: number;
   /** Modifiers applied to this die */
   modifiers: DieModifier[];
   /** True if rolled the maximum value (always false for Fate dice) */


### PR DESCRIPTION
Fixed compound explode (`!!`) corrupting natural-d20 detection for the PF2e `vs` modifier.

- Added optional `initialResult` field to `DieResult` for raw first-roll preservation
- Populated `initialResult` in `applyCompoundExplode` before accumulating
- Updated `extractNatural` to read `initialResult ?? result`
- Added regression tests for nat-20 upgrade, nat-1 downgrade, and non-exploding baseline

Closes #52

<sub>Drafted with AI assistance</sub>
