### PR TITLE
fix: versusMetadata lost when VersusNode is wrapped #53

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1745,26 +1745,67 @@ describe('evaluate', () => {
       }
     });
 
-    test('Sibling versus in arithmetic do not falsely throw NESTED_VERSUS', () => {
-      // `(a vs b) + (c vs d)` — two independent checks under arithmetic.
-      // insideVersus must reset between siblings via try/finally.
+    test('Sibling versus in arithmetic throw NESTED_VERSUS at merge', () => {
+      // `(a vs b) + (c vs d)` — two independent checks collide on one
+      // `RollResult`. There is no semantics for combining two degrees, so the
+      // merge rejects the ambiguity rather than silently dropping one side.
       const ast = parse('(1d20 vs 15) + (1d20 vs 20)');
       const rng = createMockRng([12, 18]);
 
-      expect(() => evaluate(ast, rng)).not.toThrow();
+      try {
+        evaluate(ast, rng);
+        throw new Error('expected evaluate to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(EvaluatorError);
+        expect((err as EvaluatorError).code).toBe('NESTED_VERSUS');
+      }
     });
 
-    test('degree/natural undefined when vs is not the root expression', () => {
-      // `(1d20 vs 15) + 5` — versus is a sub-expression, so versusMetadata
-      // lives on a sub-ctx and does not populate RollResult. Documented
-      // v1 limitation.
+    test('degree/natural populated when vs is wrapped in arithmetic', () => {
       const ast = parse('(1d20 vs 15) + 5');
       const rng = createMockRng([18]);
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(23);
-      expect(result.degree).toBeUndefined();
-      expect(result.natural).toBeUndefined();
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
+      expect(result.natural).toBe(18);
+    });
+
+    test('floor(1d20+10 vs 25) — degree/natural propagate through function call', () => {
+      const ast = parse('floor(1d20+10 vs 25)');
+      const rng = createMockRng([15]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(25);
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
+      expect(result.natural).toBe(15);
+    });
+
+    test('max(1d20+5 vs 20, 0) — metadata propagates through multi-arg function', () => {
+      const ast = parse('max(1d20+5 vs 20, 0)');
+      const rng = createMockRng([12]);
+      const result = evaluate(ast, rng);
+
+      expect(result.degree).toBeDefined();
+      expect(result.natural).toBe(12);
+    });
+
+    test('(1d20+10 vs 25) + 0 — metadata propagates through binary op', () => {
+      const ast = parse('(1d20+10 vs 25) + 0');
+      const rng = createMockRng([15]);
+      const result = evaluate(ast, rng);
+
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
+      expect(result.natural).toBe(15);
+    });
+
+    test('-(1d20 vs 15) — metadata propagates through unary op', () => {
+      const ast = parse('-(1d20 vs 15)');
+      const rng = createMockRng([18]);
+      const result = evaluate(ast, rng);
+
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
+      expect(result.natural).toBe(18);
     });
 
     test('RollResult.total is the numeric roll total, not the degree enum', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -309,6 +309,29 @@ function evalFateDice(node: FateDiceNode, rng: RNG, ctx: EvalContext, env: EvalE
   return total;
 }
 
+/**
+ * Merges a child sub-context back into its parent. Copies `rolls` and
+ * propagates `versusMetadata` so `degree`/`natural` survive wrappers like
+ * `floor(...)`, `(vs) + 0`, or `-(vs)`. Throws `NESTED_VERSUS` if both sides
+ * carry metadata — two versus results cannot occupy the same `RollResult`.
+ *
+ * Does not merge `expressionParts` / `renderedParts` — each wrapper formats
+ * those with its own operator/function syntax.
+ */
+function mergeContext(parent: EvalContext, child: EvalContext): void {
+  parent.rolls.push(...child.rolls);
+  if (child.versusMetadata) {
+    if (parent.versusMetadata) {
+      throw new EvaluatorError(
+        'Multiple versus operators in the same expression',
+        'NESTED_VERSUS',
+        'Versus',
+      );
+    }
+    parent.versusMetadata = child.versusMetadata;
+  }
+}
+
 function evalBinaryOp(node: BinaryOpNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   const leftCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const rightCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
@@ -316,7 +339,8 @@ function evalBinaryOp(node: BinaryOpNode, rng: RNG, ctx: EvalContext, env: EvalE
   const left = evalNode(node.left, rng, leftCtx, env);
   const right = evalNode(node.right, rng, rightCtx, env);
 
-  ctx.rolls.push(...leftCtx.rolls, ...rightCtx.rolls);
+  mergeContext(ctx, leftCtx);
+  mergeContext(ctx, rightCtx);
 
   const leftExpr = leftCtx.expressionParts.join('');
   const rightExpr = rightCtx.expressionParts.join('');
@@ -356,7 +380,7 @@ function evalUnaryOp(node: UnaryOpNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   const innerCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const value = evalNode(node.operand, rng, innerCtx, env);
 
-  ctx.rolls.push(...innerCtx.rolls);
+  mergeContext(ctx, innerCtx);
 
   const innerExpr = innerCtx.expressionParts.join('');
   const innerRendered = innerCtx.renderedParts.join('');
@@ -383,7 +407,7 @@ function evalFunctionCall(
   }
 
   for (const argCtx of argCtxs) {
-    ctx.rolls.push(...argCtx.rolls);
+    mergeContext(ctx, argCtx);
   }
 
   const argExprs = argCtxs.map((c) => c.expressionParts.join(''));


### PR DESCRIPTION
Propagate `versusMetadata` through sub-context merges so `degree` and `natural` survive wrappers (`floor(...)`, `-(...)`, arithmetic, function calls).

- Added `mergeContext(parent, child)` in `evaluator.ts` to copy `rolls` and hand off `versusMetadata`.
- Replaced `ctx.rolls.push(...)` in `evalBinaryOp`, `evalUnaryOp`, `evalFunctionCall` with `mergeContext`.
- Guarded with `NESTED_VERSUS` when both sides carry metadata.
- Updated the sibling-versus test to expect `NESTED_VERSUS`; inverted the prior "v1 limitation" assertion on `(1d20 vs 15) + 5`.
- Added wrapper-propagation tests for `floor`, multi-arg `max`, binary op, and unary op.

Closes #53

[Claude Code session](https://claude.com/claude-code)

<sub>Drafted with AI assistance</sub>
