### PR TITLE
fix: meta-expression dice orphaned from RollResult.rolls #54

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1993,4 +1993,174 @@ describe('evaluate', () => {
       }
     });
   });
+
+  describe('meta-expression dice (#54)', () => {
+    test('computed dice count preserves sub-expression dice as meta', () => {
+      const ast = parse('(1d4)d6');
+      const rng = createMockRng([2, 3, 5]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rolls).toHaveLength(3);
+
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.sides).toBe(4);
+      expect(metaDie.result).toBe(2);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+
+      expect(getDie(result.rolls, 1).sides).toBe(6);
+      expect(getDie(result.rolls, 2).sides).toBe(6);
+      expect(result.total).toBe(8);
+    });
+
+    test('computed dice sides preserves sub-expression dice as meta', () => {
+      const ast = parse('2d(1d4+2)');
+      const rng = createMockRng([4, 3, 5]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rolls).toHaveLength(3);
+
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.sides).toBe(4);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+
+      expect(getDie(result.rolls, 1).sides).toBe(6);
+      expect(getDie(result.rolls, 2).sides).toBe(6);
+      expect(result.total).toBe(8);
+    });
+
+    test('computed Fate dice count preserves meta die', () => {
+      const ast = parse('(1d2)dF');
+      const rng = createMockRng([2, 0, -1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rolls).toHaveLength(3);
+
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.sides).toBe(2);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+
+      expect(getDie(result.rolls, 1).sides).toBe(0);
+      expect(getDie(result.rolls, 2).sides).toBe(0);
+      expect(result.total).toBe(-1);
+    });
+
+    test('computed modifier count (kh) preserves meta die', () => {
+      // d2 rolls 2 → kh2 → keep the two highest of [1, 3, 5, 6] = [5, 6].
+      const ast = parse('4d6kh(1d2)');
+      const rng = createMockRng([2, 1, 3, 5, 6]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rolls).toHaveLength(5);
+
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.sides).toBe(2);
+      expect(metaDie.result).toBe(2);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+
+      expect(result.total).toBe(5 + 6);
+    });
+
+    test('computed explode threshold preserves meta die', () => {
+      // RNG order: d6 target → d2 threshold → explosion d6.
+      // ctx.rolls order: [meta, target, exploded] — meta pushed before target.
+      const ast = parse('1d6!>(1d2+3)');
+      const rng = createMockRng([6, 2, 3]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rolls).toHaveLength(3);
+
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.sides).toBe(2);
+      expect(metaDie.result).toBe(2);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+
+      const target = getDie(result.rolls, 1);
+      expect(target.sides).toBe(6);
+      expect(target.result).toBe(6);
+
+      const exploded = getDie(result.rolls, 2);
+      expect(exploded.sides).toBe(6);
+      expect(exploded.result).toBe(3);
+      expect(exploded.modifiers).toContain('exploded');
+      expect(result.total).toBe(6 + 3);
+    });
+
+    test('computed reroll threshold preserves meta die', () => {
+      // RNG order: 2d6 target → d2 threshold → reroll for low d6.
+      // ctx.rolls order: [meta, rerolled-original, new-roll, untouched-kept].
+      const ast = parse('2d6r<(1d2+1)');
+      const rng = createMockRng([1, 5, 1, 3]);
+      const result = evaluate(ast, rng);
+
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.sides).toBe(2);
+      expect(metaDie.result).toBe(1);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+
+      const rerolled = getDie(result.rolls, 1);
+      expect(rerolled.sides).toBe(6);
+      expect(rerolled.result).toBe(1);
+      expect(rerolled.modifiers).toContain('rerolled');
+
+      const newRoll = getDie(result.rolls, 2);
+      expect(newRoll.sides).toBe(6);
+      expect(newRoll.result).toBe(3);
+
+      const kept = getDie(result.rolls, 3);
+      expect(kept.sides).toBe(6);
+      expect(kept.result).toBe(5);
+
+      expect(result.total).toBe(3 + 5);
+    });
+
+    test('computed success threshold and fail threshold both preserved', () => {
+      // RNG order: 4d6 target → d2 threshold → d2 fail threshold.
+      // ctx.rolls order: [meta-threshold, meta-fail, ...4d6] — meta pushed before pool.
+      const ast = parse('4d6>=(1d2+3)f(1d2)');
+      const rng = createMockRng([5, 3, 6, 2, 2, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rolls).toHaveLength(6);
+
+      const thresholdMeta = getDie(result.rolls, 0);
+      expect(thresholdMeta.sides).toBe(2);
+      expect(thresholdMeta.result).toBe(2);
+      expect(thresholdMeta.modifiers).toContain('meta');
+      expect(thresholdMeta.modifiers).toContain('dropped');
+
+      const failMeta = getDie(result.rolls, 1);
+      expect(failMeta.sides).toBe(2);
+      expect(failMeta.result).toBe(1);
+      expect(failMeta.modifiers).toContain('meta');
+      expect(failMeta.modifiers).toContain('dropped');
+
+      const pool = result.rolls.slice(2);
+      expect(pool).toHaveLength(4);
+      expect(pool.every((d) => d.sides === 6)).toBe(true);
+    });
+
+    test('meta dice do not appear in rendered output', () => {
+      const ast = parse('(1d4)d6');
+      const rng = createMockRng([2, 3, 5]);
+      const result = evaluate(ast, rng);
+
+      expect(result.rendered).not.toContain('~~2~~');
+      expect(result.rendered).toContain('3');
+      expect(result.rendered).toContain('5');
+    });
+
+    test('meta dice count against maxDice (budget enforced)', () => {
+      const ast = parse('(1d4)d6');
+      const rng = createMockRng([2, 3, 5]);
+      const result = evaluate(ast, rng, { maxDice: 3 });
+
+      expect(result.rolls).toHaveLength(3);
+    });
+  });
 });

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -150,21 +150,49 @@ function createFateDieResult(result: number): DieResult {
  * Renders dice results for display. Marker priority: dropped wins over
  * success/failure (dropped dice are never counted), success wins over
  * failure (a die cannot be both). Example: `[~~1~~, **6**, __1__, 3]`.
+ *
+ * Dice tagged `'meta'` (rolled to compute sub-expression parameters such as
+ * count/sides/threshold) are hidden from the rendered output — they exist in
+ * `RollResult.rolls` for audit, not for display.
  */
 function renderDice(dice: DieResult[]): string {
-  const parts = dice.map((die) => {
-    if (die.modifiers.includes('dropped')) {
-      return `~~${die.result}~~`;
-    }
-    if (die.modifiers.includes('success')) {
-      return `**${die.result}**`;
-    }
-    if (die.modifiers.includes('failure')) {
-      return `__${die.result}__`;
-    }
-    return String(die.result);
-  });
+  const parts = dice
+    .filter((die) => !die.modifiers.includes('meta'))
+    .map((die) => {
+      if (die.modifiers.includes('dropped')) {
+        return `~~${die.result}~~`;
+      }
+      if (die.modifiers.includes('success')) {
+        return `**${die.result}**`;
+      }
+      if (die.modifiers.includes('failure')) {
+        return `__${die.result}__`;
+      }
+      return String(die.result);
+    });
   return `[${parts.join(', ')}]`;
+}
+
+/**
+ * Forwards rolls from a throwaway sub-expression context into the parent
+ * audit trail, tagging them as `'meta'` + `'dropped'`. Meta dice are dice
+ * rolled to compute parameters (dice count, sides, threshold, modifier
+ * count) — they consume RNG and count against `maxDice`, so they must be
+ * inspectable. Tagging them `'dropped'` keeps totals correct via
+ * `sumKeptDice`; `'meta'` lets renderers hide them and lets callers
+ * distinguish them from ordinary pool dice.
+ */
+function mergeMetaRolls(parent: EvalContext, source: EvalContext): void {
+  for (const die of source.rolls) {
+    parent.rolls.push({
+      ...die,
+      modifiers: [
+        ...die.modifiers.filter((m) => m !== 'kept' && m !== 'dropped'),
+        'meta',
+        'dropped',
+      ],
+    });
+  }
 }
 
 /**
@@ -223,18 +251,13 @@ function evalLiteral(value: number, ctx: EvalContext): number {
 }
 
 function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
-  const count = evalNode(
-    node.count,
-    rng,
-    { rolls: [], expressionParts: [], renderedParts: [] },
-    env,
-  );
-  const sides = evalNode(
-    node.sides,
-    rng,
-    { rolls: [], expressionParts: [], renderedParts: [] },
-    env,
-  );
+  const countCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
+  const count = evalNode(node.count, rng, countCtx, env);
+  mergeMetaRolls(ctx, countCtx);
+
+  const sidesCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
+  const sides = evalNode(node.sides, rng, sidesCtx, env);
+  mergeMetaRolls(ctx, sidesCtx);
 
   if (!Number.isInteger(count) || count < 0) {
     throw new EvaluatorError(`Invalid dice count: ${count}`, 'INVALID_DICE_COUNT', 'Dice');
@@ -271,12 +294,9 @@ function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): num
 }
 
 function evalFateDice(node: FateDiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
-  const count = evalNode(
-    node.count,
-    rng,
-    { rolls: [], expressionParts: [], renderedParts: [] },
-    env,
-  );
+  const countCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
+  const count = evalNode(node.count, rng, countCtx, env);
+  mergeMetaRolls(ctx, countCtx);
 
   if (!Number.isInteger(count) || count < 0) {
     throw new EvaluatorError(`Invalid dice count: ${count}`, 'INVALID_DICE_COUNT', 'FateDice');
@@ -459,6 +479,7 @@ function requireUnaryArg(name: string, values: number[]): number {
 function flattenModifierChain(
   node: ModifierNode,
   rng: RNG,
+  ctx: EvalContext,
   env: EvalEnv,
 ): { specs: ModifierSpec[]; baseTarget: ASTNode } {
   const specs: ModifierSpec[] = [];
@@ -467,6 +488,7 @@ function flattenModifierChain(
   while (isModifier(current)) {
     const countCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
     const modCount = evalNode(current.count, rng, countCtx, env);
+    mergeMetaRolls(ctx, countCtx);
 
     if (!Number.isInteger(modCount) || modCount < 0) {
       throw new EvaluatorError(
@@ -553,6 +575,7 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   if (node.threshold != null) {
     const thresholdCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
     thresholdValue = evalNode(node.threshold.value, rng, thresholdCtx, env);
+    mergeMetaRolls(ctx, thresholdCtx);
   }
 
   const code = formatExplodeCode(node.variant, node.threshold, thresholdValue);
@@ -590,6 +613,7 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
 
   const thresholdCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const thresholdValue = evalNode(node.condition.value, rng, thresholdCtx, env);
+  mergeMetaRolls(ctx, thresholdCtx);
 
   const code = `${node.once ? 'ro' : 'r'}${node.condition.operator}${thresholdValue}`;
 
@@ -612,7 +636,7 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
 }
 
 function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
-  const { specs, baseTarget } = flattenModifierChain(node, rng, env);
+  const { specs, baseTarget } = flattenModifierChain(node, rng, ctx, env);
 
   const targetCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   evalNode(baseTarget, rng, targetCtx, env);
@@ -635,11 +659,13 @@ function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext, env: EvalE
 function resolveThreshold(
   value: ASTNode,
   rng: RNG,
+  ctx: EvalContext,
   env: EvalEnv,
   role: 'threshold' | 'fail threshold',
 ): number {
   const thresholdCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const resolved = evalNode(value, rng, thresholdCtx, env);
+  mergeMetaRolls(ctx, thresholdCtx);
 
   if (!Number.isFinite(resolved)) {
     throw new EvaluatorError(`Invalid ${role}: ${resolved}`, 'INVALID_THRESHOLD', 'SuccessCount');
@@ -658,10 +684,10 @@ function evalSuccessCount(
   const targetValue = evalNode(node.target, rng, targetCtx, env);
   const targetExpr = targetCtx.expressionParts.join('');
 
-  const thresholdValue = resolveThreshold(node.threshold.value, rng, env, 'threshold');
+  const thresholdValue = resolveThreshold(node.threshold.value, rng, ctx, env, 'threshold');
   const failValue =
     node.failThreshold != null
-      ? resolveThreshold(node.failThreshold.value, rng, env, 'fail threshold')
+      ? resolveThreshold(node.failThreshold.value, rng, ctx, env, 'fail threshold')
       : undefined;
 
   const code = `${node.threshold.operator}${thresholdValue}${

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,14 @@ export type ComparePoint = {
 /**
  * Modifier flags applied to individual die results.
  */
-export type DieModifier = 'dropped' | 'kept' | 'exploded' | 'rerolled' | 'success' | 'failure';
+export type DieModifier =
+  | 'dropped'
+  | 'kept'
+  | 'exploded'
+  | 'rerolled'
+  | 'success'
+  | 'failure'
+  | 'meta';
 
 /**
  * PF2e Degree of Success. Produced by the `vs` operator when comparing a


### PR DESCRIPTION
Added `'meta'` to `DieModifier` so dice rolled for sub-expression parameters are distinguishable from pool dice. Introduced `mergeMetaRolls` helper that forwards throwaway-context rolls into the parent with `['meta', 'dropped']` so `sumKeptDice` leaves totals unchanged. Fixed seven discard sites across `evalDice`, `evalFateDice`, `flattenModifierChain`, `evalExplode`, `evalReroll`, and `resolveThreshold` — threading parent `ctx` through `flattenModifierChain` and `resolveThreshold` signatures. Updated `renderDice` to filter `'meta'` dice so `expression`/`rendered` stay clean while `RollResult.rolls` preserves the full audit trail.

Closes #54

[Claude Code session](https://claude.ai/chat)

<sub>Drafted with AI assistance</sub>
