### PR TITLE
fix: Fate dice combined with explode silently no-ops #55

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1067,16 +1067,6 @@ describe('evaluate', () => {
         expect(result.rolls).toHaveLength(0);
       });
 
-      test('Fate dice + explode: defensive skip (sides=0 never explodes)', () => {
-        const ast = parse('1dF!');
-        const rng = createMockRng([0]);
-        const result = evaluate(ast, rng);
-
-        expect(result.total).toBe(0);
-        expect(result.rolls).toHaveLength(1);
-        expect(getDie(result.rolls, 0).modifiers).not.toContain('exploded');
-      });
-
       test('expression string includes explode notation', () => {
         const ast = parse('1d6!');
         const rng = createMockRng([3]);

--- a/src/evaluator/modifiers/explode.ts
+++ b/src/evaluator/modifiers/explode.ts
@@ -75,8 +75,11 @@ function explodeLimitError(maxIterations: number): EvaluatorError {
  * Returns true when the die is eligible to start exploding: it must not
  * already be dropped by a prior modifier, and its `sides` must be rollable.
  *
- * Fate dice (sides = 0) are skipped defensively — `rng.nextInt(1, 0)` is
- * invalid. Fate + explode is out of scope for the current feature set.
+ * The `sides < 1` branch is a defense-in-depth fallback — Fate dice
+ * (sides = 0) are rejected at parse time via `INVALID_EXPLODE_TARGET`
+ * (see `parseExplode` in `src/parser/parser.ts`), so this guard should
+ * never fire during normal flow. Keeping it ensures `rng.nextInt(1, 0)`
+ * can never be reached if a future AST path slips past the parser gate.
  */
 function canExplode(die: DieResult): boolean {
   if (die.modifiers.includes('dropped')) return false;

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -284,3 +284,26 @@ export function containsDicePool(node: ASTNode): boolean {
       return false;
   }
 }
+
+/**
+ * Returns `true` if the pool this node resolves to is (or wraps) a `FateDice`
+ * pool. Walks through chained pool modifiers (`Modifier` / `Explode` /
+ * `Reroll`) but not arithmetic wrappers — callers should run
+ * `containsDicePool` first to reject those.
+ *
+ * Used by the parser to reject `!`, `!!`, `!p` applied to Fate pools
+ * (`4dF!`, `(4dF)kh2!`, etc.). Fate explosion semantics are undefined, so
+ * parse-time rejection is preferred over a silent evaluator no-op.
+ */
+export function containsFatePool(node: ASTNode): boolean {
+  switch (node.type) {
+    case 'FateDice':
+      return true;
+    case 'Modifier':
+    case 'Explode':
+    case 'Reroll':
+      return containsFatePool(node.target);
+    default:
+      return false;
+  }
+}

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1159,6 +1159,88 @@ describe('Parser', () => {
       });
     });
 
+    describe('explode rejects Fate dice pools', () => {
+      it('should reject 4dF!', () => {
+        expect(() => parse('4dF!')).toThrow(ParseError);
+        try {
+          parse('4dF!');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject 4dF!>0', () => {
+        expect(() => parse('4dF!>0')).toThrow(ParseError);
+        try {
+          parse('4dF!>0');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject 4dF!!', () => {
+        expect(() => parse('4dF!!')).toThrow(ParseError);
+        try {
+          parse('4dF!!');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject 4dF!!>0', () => {
+        expect(() => parse('4dF!!>0')).toThrow(ParseError);
+        try {
+          parse('4dF!!>0');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject 4dF!p', () => {
+        expect(() => parse('4dF!p')).toThrow(ParseError);
+        try {
+          parse('4dF!p');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject 4dF!p>0', () => {
+        expect(() => parse('4dF!p>0')).toThrow(ParseError);
+        try {
+          parse('4dF!p>0');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject (4dF)!', () => {
+        expect(() => parse('(4dF)!')).toThrow(ParseError);
+        try {
+          parse('(4dF)!');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should reject Fate pool wrapped in a chained pool modifier (4dFr=-1)!', () => {
+        expect(() => parse('(4dFr=-1)!')).toThrow(ParseError);
+        try {
+          parse('(4dFr=-1)!');
+        } catch (err) {
+          expect((err as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
+
+      it('should carry a descriptive message mentioning Fate dice', () => {
+        try {
+          parse('4dF!');
+        } catch (err) {
+          expect((err as ParseError).message).toContain('Fate');
+        }
+      });
+    });
+
     describe('reroll rejects non-pool targets', () => {
       it('should reject (1d6+5)r<3', () => {
         expect(() => parse('(1d6+5)r<3')).toThrow(ParseError);

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -23,7 +23,7 @@ import type {
   UnaryOpNode,
   VersusNode,
 } from './ast';
-import { containsDicePool, isSuccessCount } from './ast';
+import { containsDicePool, containsFatePool, isSuccessCount } from './ast';
 
 /**
  * Error thrown when the parser encounters invalid syntax.
@@ -456,6 +456,18 @@ export class Parser {
     if (!containsDicePool(target)) {
       throw new ParseError(
         `Explode modifier requires a dice pool target`,
+        'INVALID_EXPLODE_TARGET',
+        token.position,
+        token,
+      );
+    }
+
+    // Fate dice (sides = 0) cannot explode — the symmetric -1/0/+1 range has
+    // no natural "max" trigger, so semantics are undefined. Reject at parse
+    // time rather than silently no-op in the evaluator.
+    if (containsFatePool(target)) {
+      throw new ParseError(
+        `Fate dice cannot explode`,
         'INVALID_EXPLODE_TARGET',
         token.position,
         token,


### PR DESCRIPTION
Rejects `!`, `!!`, `!p` applied to Fate dice pools at parse time via `INVALID_EXPLODE_TARGET` instead of silently evaluating to a no-op. Adds `containsFatePool` helper, wires the check into `parseExplode`, updates the `canExplode` JSDoc to document its `sides < 1` branch as defense-in-depth, and adjusts tests accordingly.

Closes #55

[Claude Code session](https://claude.ai/)

<sub>Drafted with AI assistance</sub>
