### PR TITLE
fix: empty-pool SuccessCount drops successes and failures metadata #56

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1494,6 +1494,26 @@ describe('evaluate', () => {
       expect(result.successes).toBe(2);
       expect(result.failures).toBe(0);
     });
+
+    test('empty pool still populates successes/failures — 0d6>=6f1', () => {
+      const ast = parse('0d6>=6f1');
+      const rng = createMockRng([]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(0);
+      expect(result.rolls).toHaveLength(0);
+      expect(result.successes).toBe(0);
+      expect(result.failures).toBe(0);
+    });
+
+    test('empty pool success is numeric — 0d10>=6 arithmetic does not NaN', () => {
+      const ast = parse('0d10>=6');
+      const rng = createMockRng([]);
+      const result = evaluate(ast, rng);
+
+      expect(result.successes).toBe(0);
+      expect((result.successes ?? Number.NaN) + 5).toBe(5);
+    });
   });
 
   describe('versus (PF2e degrees of success)', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -680,6 +680,10 @@ function evalSuccessCount(
   ctx: EvalContext,
   env: EvalEnv,
 ): number {
+  // ? Flag tracks syntactic presence of success-count notation, not pool size —
+  //   set before any early return so empty pools still populate successes/failures.
+  env.hasSuccessCount = true;
+
   const targetCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const targetValue = evalNode(node.target, rng, targetCtx, env);
   const targetExpr = targetCtx.expressionParts.join('');
@@ -709,8 +713,6 @@ function evalSuccessCount(
       ? { operator: node.failThreshold.operator, value: failValue }
       : undefined,
   );
-
-  env.hasSuccessCount = true;
 
   ctx.rolls.push(...targetCtx.rolls);
   ctx.expressionParts.push(`${targetExpr}${code}`);

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -158,6 +158,27 @@ describe('property-based invariants', () => {
       );
     });
 
+    test('success count always defines numeric successes/failures, even on empty pools', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 5 }),
+          fc.integer({ min: 2, max: 20 }),
+          fc.integer({ min: 0, max: 0xffffffff }),
+          (count, sides, seed) => {
+            const threshold = Math.max(1, Math.min(sides, 1 + (seed % sides)));
+            const result = roll(`${count}d${sides}>=${threshold}`, { seed: `prop-sc-${seed}` });
+            return (
+              typeof result.successes === 'number' &&
+              typeof result.failures === 'number' &&
+              result.successes >= 0 &&
+              result.failures >= 0
+            );
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
+
     test('keep highest total >= keep lowest total (for same rolls)', () => {
       fc.assert(
         fc.property(


### PR DESCRIPTION
Hoisted `env.hasSuccessCount = true` to the top of `evalSuccessCount` so the flag fires before the empty-pool early return. Added empty-pool unit test and NaN-contamination regression test in `evaluator.test.ts`, plus a fast-check property test in `property.test.ts` asserting `successes`/`failures` are always numeric.

Closes #56

[Claude Code session](https://claude.com/claude-code)

<sub>Drafted with AI assistance</sub>
