### PR TITLE
fix: SuccessCount fail threshold only supports = operator #57

### DIFF
--- a/.claude/docs/STAGE2.md
+++ b/.claude/docs/STAGE2.md
@@ -413,7 +413,8 @@ negative values in strikethrough.
 - LED handler for comparison tokens (GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, EQUAL)
   when they appear after a dice expression
 - After parsing threshold, check for `FAIL` token → if present, consume and parse
-  fail value as `ComparePoint` with `operator: '='`
+  fail value as `ComparePoint` via `parseComparePoint()` when a comparison operator
+  follows, or as `{ operator: '=', value: … }` for the bare `fN` shorthand
 - `getLeftBp` for comparison tokens: `BP.MODIFIER` (35)
 - `FAIL` has `BP = -1` (consumed inside `parseSuccessCount`, never standalone)
 - Terminal constraint: if `target.type === 'SuccessCount'`, throw ParseError

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1374,6 +1374,28 @@ describe('evaluate', () => {
       expect(result.failures).toBe(1);
     });
 
+    test('fail threshold with < operator — 4dF>=0f<0', () => {
+      const ast = parse('4dF>=0f<0');
+      const rng = createMockRng([-1, 0, 1, -1]);
+      const result = evaluate(ast, rng);
+
+      // `>=0` matches 0 and 1 (2 successes); `<0` matches the two -1s (2 failures).
+      expect(result.successes).toBe(2);
+      expect(result.failures).toBe(2);
+      expect(result.total).toBe(0);
+    });
+
+    test('fail threshold with <= operator — 10d10>=8f<=2', () => {
+      const ast = parse('10d10>=8f<=2');
+      const rng = createMockRng([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      const result = evaluate(ast, rng);
+
+      // `>=8` matches 8,9,10 (3 successes); `<=2` matches 1,2 (2 failures).
+      expect(result.successes).toBe(3);
+      expect(result.failures).toBe(2);
+      expect(result.total).toBe(1);
+    });
+
     test('success wins on overlap — 3d6>=3f3 with [3,5,1]', () => {
       const ast = parse('3d6>=3f3');
       const rng = createMockRng([3, 5, 1]);

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -96,7 +96,7 @@ export type RerollNode = {
  * adds +1, each die meeting `failThreshold` subtracts 1. Terminal — a
  * `SuccessCountNode` may not be wrapped by any postfix modifier, binary
  * operator, unary operator, versus operand, or function argument. The
- * `failThreshold` operator is always `=` (fail on an exact value).
+ * `failThreshold` accepts any `CompareOp`; bare `fN` defaults to `operator: '='`.
  */
 export type SuccessCountNode = {
   type: 'SuccessCount';

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -847,6 +847,42 @@ describe('Parser', () => {
       );
     });
 
+    it('should parse fail threshold with <: 10d10>=6f<2', () => {
+      expect(parse('10d10>=6f<2')).toEqual(
+        successCount(dice(literal(10), literal(10)), cp('>=', literal(6)), cp('<', literal(2))),
+      );
+    });
+
+    it('should parse fail threshold with <=: 10d10>=6f<=2', () => {
+      expect(parse('10d10>=6f<=2')).toEqual(
+        successCount(dice(literal(10), literal(10)), cp('>=', literal(6)), cp('<=', literal(2))),
+      );
+    });
+
+    it('should parse fail threshold with >: 10d10>=6f>8', () => {
+      expect(parse('10d10>=6f>8')).toEqual(
+        successCount(dice(literal(10), literal(10)), cp('>=', literal(6)), cp('>', literal(8))),
+      );
+    });
+
+    it('should parse fail threshold with >=: 10d10>=6f>=8', () => {
+      expect(parse('10d10>=6f>=8')).toEqual(
+        successCount(dice(literal(10), literal(10)), cp('>=', literal(6)), cp('>=', literal(8))),
+      );
+    });
+
+    it('should parse fail threshold with explicit =: 10d10>=6f=1', () => {
+      expect(parse('10d10>=6f=1')).toEqual(
+        successCount(dice(literal(10), literal(10)), cp('>=', literal(6)), cp('=', literal(1))),
+      );
+    });
+
+    it('should parse Fate success with <: 4dF>=0f<0', () => {
+      expect(parse('4dF>=0f<0')).toEqual(
+        successCount(fateDice(literal(4)), cp('>=', literal(0)), cp('<', literal(0))),
+      );
+    });
+
     it('should reject outer + on SuccessCount: 5d6>=5+3', () => {
       expect(() => parse('5d6>=5+3')).toThrow(ParseError);
       try {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -555,8 +555,12 @@ export class Parser {
 
     if (this.peek().type === TokenType.FAIL) {
       this.advance();
-      const failValue = this.parseExpression(BP.DICE_LEFT);
-      node.failThreshold = { operator: '=', value: failValue };
+      if (this.isComparePointAhead()) {
+        node.failThreshold = this.parseComparePoint();
+      } else {
+        const failValue = this.parseExpression(BP.DICE_LEFT);
+        node.failThreshold = { operator: '=', value: failValue };
+      }
     }
 
     return node;


### PR DESCRIPTION
Routed the fail-threshold branch in `parseSuccessCount` through `parseComparePoint()` when a comparison operator follows `f`, keeping the bare `fN` shorthand as `{ operator: '=', value }`.

Updated `SuccessCountNode` docstring in `ast.ts` to reflect that `failThreshold` accepts any `CompareOp`.

Updated `.claude/docs/STAGE2.md` design note.

Added parser tests covering `f<`, `f<=`, `f>`, `f>=`, `f=`, and the Fate example `4dF>=0f<0`.

Added evaluator tests confirming non-`=` fail operators work end-to-end.

Closes #57

<sub>Drafted with AI assistance</sub>
