### PR TITLE
chore: post-Stage-2 polish for parser and evaluator #59

### DIFF
--- a/.claude/rules/rng.md
+++ b/.claude/rules/rng.md
@@ -31,6 +31,25 @@ mock.nextInt(1, 6); // Throws! (sequence exhausted)
 `MockRNG` MUST throw on exhaustion — this catches incorrect roll counts in tests.
 `MockRNG.nextInt` validates that returned values fall within `[min, max]` — throws `RangeError` if not.
 
+## Draw Order
+
+When authoring `MockRNG` sequences for dice expressions, follow this order:
+
+1. **Inside `evalDice`**: `count` expression → `sides` expression → pool dice (one `nextInt` per die, left-to-right).
+2. **Inside `flattenModifierChain`**: modifier-argument meta-expressions are drawn **before** the base dice pool. For `4d6kh(1d2)` the inner `1d2` draws first, then the `4d6` pool.
+
+Worked example — `4d6kh(1d2)` with `createMockRng([1, 5, 3, 4, 6])`:
+
+| Draw | Source | Value |
+|------|--------|-------|
+| 1 | `1d2` (keep-count meta-expression) | `1` |
+| 2 | `4d6` pool, die 1 | `5` |
+| 3 | `4d6` pool, die 2 | `3` |
+| 4 | `4d6` pool, die 3 | `4` |
+| 5 | `4d6` pool, die 4 | `6` |
+
+Kept result: `6` (highest of `[5, 3, 4, 6]`).
+
 ## Usage in Tests
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ roll-parser --help
   interpreted as the dice operator, so `4d6d1` becomes `(4d6)d1` (roll 4d6, then
   use the result as the count for d1). To drop dice, use the explicit `dl`
   (drop lowest) or `dh` (drop highest) modifiers: `4d6dl1`.
+- **Threshold comparisons bind tight.** In explode and reroll thresholds,
+  `1d6!>=5+2` parses as `(1d6!>=5)+2` and `2d6r<=1+1` as `(2d6r<=1)+1` — the
+  comparison binds to the dice pool, not the arithmetic after it. For a
+  computed threshold, parenthesize: `1d6!>=(5+2)`. Success-count thresholds
+  bind the same way, but wrapping the resulting `SuccessCountNode` is a parse
+  error (terminal by design), so `1d6>=5+2` and `10d10>=6f1+1` throw —
+  parenthesize the threshold to keep everything inside the success-count:
+  `1d6>=(5+2)`, `10d10>=6f(1+1)`.
 
 ## License
 

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1999,6 +1999,13 @@ describe('evaluate', () => {
       expect(result.total).toBe(3);
     });
 
+    test('round uses half-toward-+∞ for negatives: round(-2.5) = -2', () => {
+      const ast = parse('round(-2.5)');
+      const result = evaluate(ast, createMockRng([]));
+
+      expect(result.total).toBe(-2);
+    });
+
     test('abs of negative literal: abs(-5)', () => {
       const ast = parse('abs(-5)');
       const result = evaluate(ast, createMockRng([]));

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -254,6 +254,14 @@ function evalLiteral(value: number, ctx: EvalContext): number {
   return value;
 }
 
+/**
+ * RNG draw order: `count` expression → `sides` expression → pool dice
+ * (one `nextInt` per die, left-to-right). Meta-expressions on `count`/`sides`
+ * (e.g. `(1+1)d(3*2)`) draw before the pool. For modifier-argument
+ * meta-expressions like `4d6kh(1d2)`, `flattenModifierChain` draws the
+ * modifier args first, then `evalModifier` calls `evalDice` for the base
+ * pool. See `.claude/rules/rng.md` for the full draw-order spec.
+ */
 function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   const countCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   const count = evalNode(node.count, rng, countCtx, env);
@@ -462,6 +470,9 @@ function applyFunction(name: string, values: number[]): number {
     case 'ceil':
       return Math.ceil(requireUnaryArg(name, values));
     case 'round':
+      // ? Delegates to `Math.round`, which rounds half-values toward +∞
+      //   (IEEE-754 half-up). So `round(2.5) === 3` but `round(-2.5) === -2`,
+      //   not `-3`. Users needing symmetric rounding must compose via `floor`.
       return Math.round(requireUnaryArg(name, values));
     case 'abs':
       return Math.abs(requireUnaryArg(name, values));
@@ -741,14 +752,14 @@ function evalSuccessCount(
  * Extracts the "natural" d20 value from a roll-side dice pool. Returns the
  * single value when exactly one kept d20 is present; otherwise `undefined`.
  *
- * Excludes dropped (`kh`/`kl`/`dh`/`dl`) and rerolled (`r`/`ro`) dice — these
- * aren't the final kept result. Multiple kept d20s (e.g., `1d20+1d20`) yield
- * `undefined` so no ambiguous upgrade/downgrade is applied.
+ * Excludes dropped (`kh`/`kl`/`dh`/`dl`/`r`/`ro`) dice — these aren't the
+ * final kept result. Multiple kept d20s (e.g., `1d20+1d20`) yield `undefined`
+ * so no ambiguous upgrade/downgrade is applied.
  */
 function extractNatural(rolls: DieResult[]): number | undefined {
-  const keptD20s = rolls.filter(
-    (d) => d.sides === 20 && !d.modifiers.includes('dropped') && !d.modifiers.includes('rerolled'),
-  );
+  // Rerolled intermediates are always stamped `['rerolled', 'dropped']`
+  // (see `modifiers/reroll.ts`), so filtering by `'dropped'` covers them.
+  const keptD20s = rolls.filter((d) => d.sides === 20 && !d.modifiers.includes('dropped'));
   if (keptD20s.length !== 1) return undefined;
   const die = keptD20s[0];
   return die?.initialResult ?? die?.result;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -551,6 +551,7 @@ export class Parser {
     }
 
     const operator = this.getCompareOp(token);
+    // ? Threshold binding: `BP.DICE_LEFT` — see `parseComparePoint` JSDoc.
     const value = this.parseExpression(BP.DICE_LEFT);
     const node: SuccessCountNode = {
       type: 'SuccessCount',
@@ -563,6 +564,7 @@ export class Parser {
       if (this.isComparePointAhead()) {
         node.failThreshold = this.parseComparePoint();
       } else {
+        // ? Same threshold binding as above (BP.DICE_LEFT).
         const failValue = this.parseExpression(BP.DICE_LEFT);
         node.failThreshold = { operator: '=', value: failValue };
       }
@@ -606,6 +608,13 @@ export class Parser {
   /**
    * Parses a comparison operator followed by a value expression.
    * Called by modifier parsers (explode, reroll, success counting).
+   *
+   * The threshold value is parsed at `BP.DICE_LEFT`, which binds tighter than
+   * arithmetic. This keeps the comparison bound to the dice pool on the left
+   * rather than letting arithmetic to the right be consumed into the
+   * threshold. As a consequence, `1d6>=5+2` parses as `(1d6>=5)+2` with
+   * threshold `5` — not `7`. Computed thresholds require parens:
+   * `1d6>=(5+2)`. Same binding applies to `parseSuccessCount` below.
    *
    * @returns A ComparePoint with the operator and value AST node
    * @throws {ParseError} If the next token is not a comparison operator


### PR DESCRIPTION
Removed the redundant `'rerolled'` filter in `extractNatural`.
Documented `Math.round` half-toward-+∞ behavior (`round(-2.5) === -2`) in JSDoc and added a regression test.
Documented RNG draw order for meta-expressions in `.claude/rules/rng.md` and the `evalDice` JSDoc.
Documented `ComparePoint` threshold binding at `BP.DICE_LEFT` in the `parseComparePoint` JSDoc and the README — bullet scoped to Explode/Reroll (where wrapping is valid); SuccessCount thresholds throw on wrapping (terminal per #51), with parenthesization as the workaround for each case.

Closes #59

<sub>*Drafted with AI assistance*</sub>
