### PR TITLE
fix: meta-expression parse sites don't enforce SuccessCount terminality #69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parser now rejects `SuccessCount` wrapped in meta-expression positions — modifier count, dice count/sides (infix and prefix), Fate/percentile dice count, SuccessCount threshold and bare `fN` value, and compare-point values used by Explode/Reroll. `mergeMetaRolls` also strips `success`/`failure` modifier tags on meta-forwarded dice as defense-in-depth ([#69](https://github.com/edloidas/roll-parser/issues/69))
+
 ## [3.0.0-alpha.0] - 2026-04-20
 
 First alpha of the v3 rewrite. Stage 1 (core engine) is complete; Stage 2 (dice mechanics) is largely in place.

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -9,7 +9,8 @@ import { parse } from '../parser/parser';
 import { createMockRng } from '../rng/mock';
 import type { DieResult } from '../types';
 import { DegreeOfSuccess } from '../types';
-import { DEFAULT_MAX_DICE, evaluate, EvaluatorError } from './evaluator';
+import type { EvalContext } from './evaluator';
+import { DEFAULT_MAX_DICE, evaluate, EvaluatorError, mergeMetaRolls } from './evaluator';
 
 /**
  * Helper to safely get a die result at index, throwing if not present.
@@ -2273,6 +2274,33 @@ describe('evaluate', () => {
       const result = evaluate(ast, rng, { maxDice: 3 });
 
       expect(result.rolls).toHaveLength(3);
+    });
+
+    test('mergeMetaRolls strips success/failure modifiers (#69)', () => {
+      // Defense-in-depth: parser rejects SuccessCount in meta positions, but
+      // if a die ever arrives with `'success'`/`'failure'` tags inside a meta
+      // sub-context, mergeMetaRolls must drop those tags so they cannot reach
+      // the top-level successes/failures scan.
+      const source: EvalContext = {
+        rolls: [
+          { result: 6, sides: 10, modifiers: ['kept', 'success'], critical: false, fumble: false },
+          { result: 1, sides: 10, modifiers: ['kept', 'failure'], critical: false, fumble: false },
+        ],
+        expressionParts: [],
+        renderedParts: [],
+      };
+      const parent: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
+
+      mergeMetaRolls(parent, source);
+
+      expect(parent.rolls).toHaveLength(2);
+      for (const die of parent.rolls) {
+        expect(die.modifiers).toContain('meta');
+        expect(die.modifiers).toContain('dropped');
+        expect(die.modifiers).not.toContain('success');
+        expect(die.modifiers).not.toContain('failure');
+        expect(die.modifiers).not.toContain('kept');
+      }
     });
   });
 });

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -92,8 +92,10 @@ export type EvalEnv = {
 
 /**
  * Per-branch mutable accumulator for tracking rolls and output during recursion.
+ *
+ * @internal exported for targeted `mergeMetaRolls` tests only; not a public API.
  */
-type EvalContext = {
+export type EvalContext = {
   rolls: DieResult[];
   expressionParts: string[];
   renderedParts: string[];
@@ -182,13 +184,21 @@ function renderDice(dice: DieResult[]): string {
  * inspectable. Tagging them `'dropped'` keeps totals correct via
  * `sumKeptDice`; `'meta'` lets renderers hide them and lets callers
  * distinguish them from ordinary pool dice.
+ *
+ * `'success'`/`'failure'` tags are stripped here as defense-in-depth against
+ * a SuccessCount leaking into a meta sub-expression (parser rejects all such
+ * wrappings; this strip ensures a future parse regression cannot leak tags
+ * into the top-level `successes`/`failures` scan).
  */
-function mergeMetaRolls(parent: EvalContext, source: EvalContext): void {
+/** @internal exported for targeted defense-in-depth tests only. */
+export function mergeMetaRolls(parent: EvalContext, source: EvalContext): void {
   for (const die of source.rolls) {
     parent.rolls.push({
       ...die,
       modifiers: [
-        ...die.modifiers.filter((m) => m !== 'kept' && m !== 'dropped'),
+        ...die.modifiers.filter(
+          (m) => m !== 'kept' && m !== 'dropped' && m !== 'success' && m !== 'failure',
+        ),
         'meta',
         'dropped',
       ],

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1128,6 +1128,103 @@ describe('Parser', () => {
     });
   });
 
+  describe('success count rejected in meta-expression positions', () => {
+    // SuccessCount is terminal at every meta-expression parse site: modifier
+    // count, dice sides/count (infix + prefix), Fate/percent dice count,
+    // SuccessCount threshold value, bare `fN` value, and compare-point values
+    // (Explode / Reroll). Wrapping in parens used to bypass the #51 guards.
+
+    it('should reject SuccessCount as keep-modifier count: 4d6kh(3d6>=3)', () => {
+      expect(() => parse('4d6kh(3d6>=3)')).toThrow(ParseError);
+      try {
+        parse('4d6kh(3d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as prefix dice sides: d(1d6>=3)', () => {
+      expect(() => parse('d(1d6>=3)')).toThrow(ParseError);
+      try {
+        parse('d(1d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as infix dice sides: 4d(1d6>=3)', () => {
+      expect(() => parse('4d(1d6>=3)')).toThrow(ParseError);
+      try {
+        parse('4d(1d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as infix dice count: (1d6>=3)d6', () => {
+      expect(() => parse('(1d6>=3)d6')).toThrow(ParseError);
+      try {
+        parse('(1d6>=3)d6');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as percentile dice count: (1d6>=3)d%', () => {
+      expect(() => parse('(1d6>=3)d%')).toThrow(ParseError);
+      try {
+        parse('(1d6>=3)d%');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as Fate dice count: (1d6>=3)dF', () => {
+      expect(() => parse('(1d6>=3)dF')).toThrow(ParseError);
+      try {
+        parse('(1d6>=3)dF');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as threshold value: 5d10>=(1d6>=3)', () => {
+      expect(() => parse('5d10>=(1d6>=3)')).toThrow(ParseError);
+      try {
+        parse('5d10>=(1d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as bare fN value: 5d10>=6f(1d6>=3)', () => {
+      expect(() => parse('5d10>=6f(1d6>=3)')).toThrow(ParseError);
+      try {
+        parse('5d10>=6f(1d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as explode compare-point value: 1d6!>=(1d6>=3)', () => {
+      expect(() => parse('1d6!>=(1d6>=3)')).toThrow(ParseError);
+      try {
+        parse('1d6!>=(1d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+
+    it('should reject SuccessCount as reroll compare-point value: 1d6r<=(1d6>=3)', () => {
+      expect(() => parse('1d6r<=(1d6>=3)')).toThrow(ParseError);
+      try {
+        parse('1d6r<=(1d6>=3)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('INVALID_SUCCESS_COUNT_TARGET');
+      }
+    });
+  });
+
   describe('postfix modifier target validation', () => {
     // Postfix pool modifiers (kh/kl/dh/dl, !/!!/!p, r/ro) require a dice-pool
     // target. Wrapping arithmetic silently drops user math — must parse-error.

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -165,7 +165,7 @@ export class Parser {
         return this.parseUnaryMinus(token);
 
       case TokenType.DICE:
-        return this.parsePrefixDice();
+        return this.parsePrefixDice(token);
 
       case TokenType.DICE_PERCENT:
         return this.parsePrefixDicePercent();
@@ -199,13 +199,13 @@ export class Parser {
   private parseLed(left: ASTNode, token: Token): ASTNode {
     switch (token.type) {
       case TokenType.DICE:
-        return this.parseInfixDice(left);
+        return this.parseInfixDice(left, token);
 
       case TokenType.DICE_PERCENT:
-        return this.parseInfixDicePercent(left);
+        return this.parseInfixDicePercent(left, token);
 
       case TokenType.DICE_FATE:
-        return this.parseInfixFateDice(left);
+        return this.parseInfixFateDice(left, token);
 
       case TokenType.PLUS:
       case TokenType.MINUS:
@@ -269,9 +269,10 @@ export class Parser {
     };
   }
 
-  private parsePrefixDice(): DiceNode {
+  private parsePrefixDice(token: Token): DiceNode {
     // d20 → Dice(1, 20)
     const sides = this.parseExpression(BP.DICE_RIGHT);
+    this.rejectSuccessCountTarget(sides, token);
     return {
       type: 'Dice',
       count: { type: 'Literal', value: 1 },
@@ -279,9 +280,11 @@ export class Parser {
     };
   }
 
-  private parseInfixDice(left: ASTNode): DiceNode {
+  private parseInfixDice(left: ASTNode, token: Token): DiceNode {
     // 4d6 → Dice(4, 6)
+    this.rejectSuccessCountTarget(left, token);
     const sides = this.parseExpression(BP.DICE_RIGHT);
+    this.rejectSuccessCountTarget(sides, token);
     return {
       type: 'Dice',
       count: left,
@@ -298,8 +301,9 @@ export class Parser {
     };
   }
 
-  private parseInfixDicePercent(left: ASTNode): DiceNode {
+  private parseInfixDicePercent(left: ASTNode, token: Token): DiceNode {
     // 2d% → Dice(2, 100)
+    this.rejectSuccessCountTarget(left, token);
     return {
       type: 'Dice',
       count: left,
@@ -315,10 +319,11 @@ export class Parser {
     };
   }
 
-  private parseInfixFateDice(left: ASTNode): FateDiceNode {
+  private parseInfixFateDice(left: ASTNode, token: Token): FateDiceNode {
     // 4dF → FateDice(4). Unlike parseInfixDice, there is no sides sub-parse,
     // so modifiers (`kh`, `dl`, …) naturally bind at the outer Pratt loop
     // without BP competition against a right-operand.
+    this.rejectSuccessCountTarget(left, token);
     return {
       type: 'FateDice',
       count: left,
@@ -443,6 +448,7 @@ export class Parser {
       nextToken === TokenType.NUMBER || nextToken === TokenType.LPAREN
         ? this.parseExpression(BP.DICE_LEFT)
         : { type: 'Literal', value: 1 };
+    this.rejectSuccessCountTarget(count, token);
 
     return {
       type: 'Modifier',
@@ -553,6 +559,7 @@ export class Parser {
     const operator = this.getCompareOp(token);
     // ? Threshold binding: `BP.DICE_LEFT` — see `parseComparePoint` JSDoc.
     const value = this.parseExpression(BP.DICE_LEFT);
+    this.rejectSuccessCountTarget(value, token);
     const node: SuccessCountNode = {
       type: 'SuccessCount',
       target,
@@ -566,6 +573,7 @@ export class Parser {
       } else {
         // ? Same threshold binding as above (BP.DICE_LEFT).
         const failValue = this.parseExpression(BP.DICE_LEFT);
+        this.rejectSuccessCountTarget(failValue, token);
         node.failThreshold = { operator: '=', value: failValue };
       }
     }
@@ -626,6 +634,7 @@ export class Parser {
     this.advance();
 
     const value = this.parseExpression(BP.DICE_LEFT);
+    this.rejectSuccessCountTarget(value, token);
 
     return { operator, value };
   }


### PR DESCRIPTION
Extends `#51`'s `SuccessCount` terminality guard to the seven meta-expression parse sites — dice count and sides (infix + prefix), Fate and percentile dice count, modifier count, SuccessCount threshold and bare `fN` value, and `parseComparePoint` value (Explode / Reroll). Hardens `mergeMetaRolls` to strip `success`/`failure` modifier tags as defense-in-depth.

Closes #69

[Claude Code session](https://claude.com/claude-code)

<sub>Drafted with AI assistance</sub>
