### PR TITLE
fix: versusMetadata dropped in meta-expressions and NESTED_VERSUS not Grouped-aware #70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parser now rejects `SuccessCount` wrapped in meta-expression positions — modifier count, dice count/sides (infix and prefix), Fate/percentile dice count, SuccessCount threshold and bare `fN` value, and compare-point values used by Explode/Reroll. `mergeMetaRolls` also strips `success`/`failure` modifier tags on meta-forwarded dice as defense-in-depth ([#69](https://github.com/edloidas/roll-parser/issues/69))
+- Parser now rejects `Versus` wrapped in the same meta-expression positions so a PF2e `vs` outcome cannot be silently dropped by `mergeMetaRolls`, and the `parseVersus` chain guard unwraps `Grouped` so `(1d20 vs 15) vs 10` throws `NESTED_VERSUS` at parse time instead of at eval ([#70](https://github.com/edloidas/roll-parser/issues/70))
 
 ## [3.0.0-alpha.0] - 2026-04-20
 

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1225,6 +1225,103 @@ describe('Parser', () => {
     });
   });
 
+  describe('versus rejected in meta-expression positions', () => {
+    // Versus produces a PF2e degree — a terminal scalar, not a valid
+    // meta-expression input. Symmetric with the SuccessCount rejections
+    // above; prevents `versusMetadata` from being silently dropped in
+    // `mergeMetaRolls` sites.
+
+    it('should reject Versus as keep-modifier count: 4d6kh(1d20 vs 10)', () => {
+      expect(() => parse('4d6kh(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('4d6kh(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as prefix dice sides: d(1d20 vs 10)', () => {
+      expect(() => parse('d(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('d(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as infix dice sides: 4d(1d20 vs 10)', () => {
+      expect(() => parse('4d(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('4d(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as infix dice count: (1d20 vs 10)d6', () => {
+      expect(() => parse('(1d20 vs 10)d6')).toThrow(ParseError);
+      try {
+        parse('(1d20 vs 10)d6');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as percentile dice count: (1d20 vs 10)d%', () => {
+      expect(() => parse('(1d20 vs 10)d%')).toThrow(ParseError);
+      try {
+        parse('(1d20 vs 10)d%');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as Fate dice count: (1d20 vs 10)dF', () => {
+      expect(() => parse('(1d20 vs 10)dF')).toThrow(ParseError);
+      try {
+        parse('(1d20 vs 10)dF');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as threshold value: 5d10>=(1d20 vs 10)', () => {
+      expect(() => parse('5d10>=(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('5d10>=(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as bare fN value: 5d10>=6f(1d20 vs 10)', () => {
+      expect(() => parse('5d10>=6f(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('5d10>=6f(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as explode compare-point value: 1d6!>=(1d20 vs 10)', () => {
+      expect(() => parse('1d6!>=(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('1d6!>=(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject Versus as reroll compare-point value: 1d6r<=(1d20 vs 10)', () => {
+      expect(() => parse('1d6r<=(1d20 vs 10)')).toThrow(ParseError);
+      try {
+        parse('1d6r<=(1d20 vs 10)');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+  });
+
   describe('postfix modifier target validation', () => {
     // Postfix pool modifiers (kh/kl/dh/dl, !/!!/!p, r/ro) require a dice-pool
     // target. Wrapping arithmetic silently drops user math — must parse-error.
@@ -1532,6 +1629,17 @@ describe('Parser', () => {
       expect(() => parse('1d20+5 vs 15 vs 20')).toThrow(ParseError);
       try {
         parse('1d20+5 vs 15 vs 20');
+      } catch (err) {
+        expect((err as ParseError).code).toBe('NESTED_VERSUS');
+      }
+    });
+
+    it('should reject paren-wrapped chained versus at parse: (1d20 vs 15) vs 10', () => {
+      // Chain guard unwraps `Grouped`, so parens do not bypass the parse-time
+      // check. Previously parsed and threw at eval via `mergeContext`.
+      expect(() => parse('(1d20 vs 15) vs 10')).toThrow(ParseError);
+      try {
+        parse('(1d20 vs 15) vs 10');
       } catch (err) {
         expect((err as ParseError).code).toBe('NESTED_VERSUS');
       }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -273,6 +273,7 @@ export class Parser {
     // d20 → Dice(1, 20)
     const sides = this.parseExpression(BP.DICE_RIGHT);
     this.rejectSuccessCountTarget(sides, token);
+    this.rejectVersusTarget(sides, token);
     return {
       type: 'Dice',
       count: { type: 'Literal', value: 1 },
@@ -283,8 +284,10 @@ export class Parser {
   private parseInfixDice(left: ASTNode, token: Token): DiceNode {
     // 4d6 → Dice(4, 6)
     this.rejectSuccessCountTarget(left, token);
+    this.rejectVersusTarget(left, token);
     const sides = this.parseExpression(BP.DICE_RIGHT);
     this.rejectSuccessCountTarget(sides, token);
+    this.rejectVersusTarget(sides, token);
     return {
       type: 'Dice',
       count: left,
@@ -304,6 +307,7 @@ export class Parser {
   private parseInfixDicePercent(left: ASTNode, token: Token): DiceNode {
     // 2d% → Dice(2, 100)
     this.rejectSuccessCountTarget(left, token);
+    this.rejectVersusTarget(left, token);
     return {
       type: 'Dice',
       count: left,
@@ -324,6 +328,7 @@ export class Parser {
     // so modifiers (`kh`, `dl`, …) naturally bind at the outer Pratt loop
     // without BP competition against a right-operand.
     this.rejectSuccessCountTarget(left, token);
+    this.rejectVersusTarget(left, token);
     return {
       type: 'FateDice',
       count: left,
@@ -420,6 +425,26 @@ export class Parser {
     }
   }
 
+  private rejectVersusTarget(target: ASTNode, token: Token): void {
+    // ? Versus produces a PF2e degree outcome — a terminal scalar, not a
+    //   valid input to dice count/sides/thresholds. Symmetric with
+    //   `rejectSuccessCountTarget`; wrappers like `floor(vs)+0` still
+    //   propagate `versusMetadata` via `mergeContext`, so this only blocks
+    //   `mergeMetaRolls` sites where metadata would silently vanish.
+    let node = target;
+    while (node.type === 'Grouped') {
+      node = node.expression;
+    }
+    if (node.type === 'Versus') {
+      throw new ParseError(
+        `Versus cannot be used as a meta-expression`,
+        'NESTED_VERSUS',
+        token.position,
+        token,
+      );
+    }
+  }
+
   private parseModifier(target: ASTNode, token: Token): ModifierNode {
     this.rejectSuccessCountTarget(target, token);
 
@@ -449,6 +474,7 @@ export class Parser {
         ? this.parseExpression(BP.DICE_LEFT)
         : { type: 'Literal', value: 1 };
     this.rejectSuccessCountTarget(count, token);
+    this.rejectVersusTarget(count, token);
 
     return {
       type: 'Modifier',
@@ -560,6 +586,7 @@ export class Parser {
     // ? Threshold binding: `BP.DICE_LEFT` — see `parseComparePoint` JSDoc.
     const value = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(value, token);
+    this.rejectVersusTarget(value, token);
     const node: SuccessCountNode = {
       type: 'SuccessCount',
       target,
@@ -574,6 +601,7 @@ export class Parser {
         // ? Same threshold binding as above (BP.DICE_LEFT).
         const failValue = this.parseExpression(BP.DICE_LEFT);
         this.rejectSuccessCountTarget(failValue, token);
+        this.rejectVersusTarget(failValue, token);
         node.failThreshold = { operator: '=', value: failValue };
       }
     }
@@ -585,9 +613,14 @@ export class Parser {
     this.rejectSuccessCountTarget(left, token);
 
     // ? Chained `a vs b vs c` has no semantics — a degree is a scalar, not a
-    //   comparable. Parens (`a vs (b vs c)`) slip past this check and are
-    //   caught by the evaluator via `EvalEnv.insideVersus`.
-    if (left.type === 'Versus') {
+    //   comparable. Unwrap `Grouped` so `(a vs b) vs c` rejects at parse
+    //   time like the bare form; paren-nested DC (`a vs (b vs c)`) is still
+    //   caught by the evaluator via `mergeContext`.
+    let leftChain: ASTNode = left;
+    while (leftChain.type === 'Grouped') {
+      leftChain = leftChain.expression;
+    }
+    if (leftChain.type === 'Versus') {
       throw new ParseError('Cannot chain versus operators', 'NESTED_VERSUS', token.position, token);
     }
 
@@ -635,6 +668,7 @@ export class Parser {
 
     const value = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(value, token);
+    this.rejectVersusTarget(value, token);
 
     return { operator, value };
   }


### PR DESCRIPTION
Added `rejectVersusTarget` parser helper (unwraps `Grouped`, throws `NESTED_VERSUS`) and wired it into the nine meta-expression parse sites so a `VersusNode` wrapped in dice count/sides, Fate/percentile count, modifier count, `SuccessCount` threshold or bare `fN` value, or explode/reroll compare-point values now errors at parse instead of silently dropping `versusMetadata`.
Updated `parseVersus` chain guard to unwrap `Grouped` on the left operand so `(1d20 vs 15) vs 10` throws `NESTED_VERSUS` at parse time rather than at eval.
Added eleven parser regression tests.

Closes #70

[Claude Code session](https://claude.ai/)

<sub>Drafted with AI assistance</sub>
