### PR TITLE
chore: drop dead containsDice, add meta-expression coverage gaps #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ roll-parser --help
   kept d20" rule makes natural-value detection return `undefined`. Use the
   compound form when the nat-20 upgrade must be preserved through an
   explode.
+- **Meta-expressions in `result.expression` are substituted with their
+  resolved values.** Dice counts, sides, modifier counts, and threshold
+  expressions are rendered as the integer they evaluated to, not the original
+  sub-expression — so `result.expression` does not round-trip through `parse`
+  when meta-expressions are present.
+
+  ```typescript
+  roll('(1d4)d6').expression;       // '2d6' (if 1d4 rolled 2)
+  roll('1d6!>(1d2+3)').expression;  // '1d6!>5'
+  ```
+
+  The round-trip property test does not exercise meta-expressions, so the
+  gap is invisible to CI. Do not rely on `result.expression` as a faithful
+  re-parseable form when your notation contains meta-expressions.
 
 ## License
 

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1968,6 +1968,33 @@ describe('evaluate', () => {
       expect(result.degree).toBe(DegreeOfSuccess.Success);
       expect(getDie(result.rolls, 0).initialResult).toBeUndefined();
     });
+
+    test('Meta-d20 on count side: (1d20)d20!! vs 30 — meta d20 filtered from natural', () => {
+      // Draw order: meta count `(1d20)` → 1 (stamped 'dropped'), then outer
+      // `1d20!!` rolls [20, 20, 5] and compound-explodes to 45.
+      // `extractNatural` must skip the meta d20 and use the outer pool's 20.
+      const ast = parse('(1d20)d20!! vs 30');
+      const rng = createMockRng([1, 20, 20, 5]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(45);
+      expect(result.natural).toBe(20);
+      expect(result.degree).toBe(DegreeOfSuccess.CriticalSuccess);
+    });
+
+    test('Meta-d20 on sides: 1d(1d20) vs 15 — meta d20 filtered from natural', () => {
+      // Draw order: meta sides `(1d20)` → 20 (stamped 'dropped'), then outer
+      // `1d20` rolls 3. If `extractNatural` leaked the meta d20, two kept
+      // d20s would render natural undefined (ambiguous); correct behavior
+      // returns the outer result (3).
+      const ast = parse('1d(1d20) vs 15');
+      const rng = createMockRng([20, 3]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(3);
+      expect(result.natural).toBe(3);
+      expect(result.degree).toBe(DegreeOfSuccess.CriticalFailure);
+    });
   });
 
   describe('math functions', () => {

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -250,46 +250,10 @@ export function isGrouped(node: ASTNode): node is GroupedNode {
 }
 
 /**
- * Returns `true` if the AST contains a `Dice` or `FateDice` node reachable
- * through structural composition (BinaryOp, UnaryOp, keep/drop, explode,
- * reroll, success-count wrappers). Meta-expressions — dice count/sides,
- * modifier counts, and ComparePoint values — are treated as leaves and
- * never recursed into.
- *
- * Used by the parser to reject success-counting targets that don't actually
- * roll any dice (e.g. `1>=3`, `(1+2)>=3`).
- */
-export function containsDice(node: ASTNode): boolean {
-  switch (node.type) {
-    case 'Dice':
-    case 'FateDice':
-      return true;
-    case 'Literal':
-      return false;
-    case 'BinaryOp':
-      return containsDice(node.left) || containsDice(node.right);
-    case 'UnaryOp':
-      return containsDice(node.operand);
-    case 'Modifier':
-    case 'Explode':
-    case 'Reroll':
-    case 'SuccessCount':
-      return containsDice(node.target);
-    case 'Versus':
-      return containsDice(node.roll) || containsDice(node.dc);
-    case 'FunctionCall':
-      return node.args.some(containsDice);
-    case 'Grouped':
-      return containsDice(node.expression);
-  }
-}
-
-/**
  * Returns `true` only when `node`'s direct result is a dice pool —
  * `Dice`, `FateDice`, or a chained pool modifier (`Modifier` / `Explode` /
- * `Reroll`). Unlike `containsDice`, this does NOT recurse through arithmetic
- * wrappers (`BinaryOp`, `UnaryOp`, `FunctionCall`), so `(1d6+5)` and
- * `floor(1d6/2)` are rejected.
+ * `Reroll`). Does NOT recurse through arithmetic wrappers (`BinaryOp`,
+ * `UnaryOp`, `FunctionCall`), so `(1d6+5)` and `floor(1d6/2)` are rejected.
  *
  * Used by the parser to reject postfix pool-modifier targets (kh/kl/dh/dl,
  * !/!!/!p, r/ro) that wrap a non-pool expression. Operating on the inner


### PR DESCRIPTION
Removed unused `containsDice` export and trimmed the JSDoc comparison note in `containsDicePool`.
Added regression tests for meta-d20 × `vs` covering both count-side (`(1d20)d20!! vs 30`) and sides-side (`1d(1d20) vs 15`) meta-expressions.
Documented meta-expression substitution in `result.expression` as a known limitation in the README.

Closes #72

[Claude Code session](https://claude.com/claude-code)

<sub>Drafted with AI assistance</sub>
