### PR TITLE
chore: Stage 3 foundation — token allocation and context wiring #79

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -88,6 +88,17 @@ export type EvalEnv = {
    * left-chain check.
    */
   insideVersus: boolean;
+  /**
+   * User-supplied variable map for `@name` / `@{name}` references. Always
+   * defined — `evaluate()` defaults to an empty object so lookups can be
+   * branch-free on presence.
+   */
+  readonly context: Readonly<Record<string, number>>;
+  /**
+   * Behavior when a referenced variable is missing from `context`. Always
+   * defined — `evaluate()` defaults to `'throw'`.
+   */
+  readonly onMissingVariable: 'throw' | 'zero';
 };
 
 /**
@@ -876,6 +887,9 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
       ? Math.floor(options.maxRerollIterations)
       : DEFAULT_MAX_REROLL_ITERATIONS;
 
+  const context = options.context ?? {};
+  const onMissingVariable = options.onMissingVariable ?? 'throw';
+
   const env: EvalEnv = {
     maxDice,
     maxExplodeIterations,
@@ -883,6 +897,8 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
     totalDiceRolled: 0,
     hasSuccessCount: false,
     insideVersus: false,
+    context,
+    onMissingVariable,
   };
   const ctx: EvalContext = {
     rolls: [],

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -561,6 +561,157 @@ describe('Lexer', () => {
     });
   });
 
+  describe('Stage 3 tokens', () => {
+    describe('group braces', () => {
+      it('should tokenize { as LBRACE', () => {
+        const tokens = lex('{');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.LBRACE, value: '{', position: 0 });
+        expect(tokens[1]?.type).toBe(TokenType.EOF);
+      });
+
+      it('should tokenize } as RBRACE', () => {
+        const tokens = lex('}');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.RBRACE, value: '}', position: 0 });
+      });
+
+      it('should tokenize {1d20,2d6} with commas as separators', () => {
+        const tokens = lex('{1d20,2d6}');
+
+        expect(tokens).toHaveLength(10);
+        expect(tokens[0]).toEqual({ type: TokenType.LBRACE, value: '{', position: 0 });
+        expect(tokens[4]).toEqual({ type: TokenType.COMMA, value: ',', position: 5 });
+        expect(tokens[8]).toEqual({ type: TokenType.RBRACE, value: '}', position: 9 });
+      });
+    });
+
+    describe('sort modifiers', () => {
+      it('should tokenize s as SORT_ASC', () => {
+        const tokens = lex('s');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.SORT_ASC, value: 's', position: 0 });
+      });
+
+      it('should tokenize sa as SORT_ASC', () => {
+        const tokens = lex('sa');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.SORT_ASC, value: 'sa', position: 0 });
+      });
+
+      it('should tokenize sd as SORT_DESC', () => {
+        const tokens = lex('sd');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.SORT_DESC, value: 'sd', position: 0 });
+      });
+
+      it('should be case-insensitive for sort modifiers', () => {
+        expect(lex('SA')[0]?.type).toBe(TokenType.SORT_ASC);
+        expect(lex('Sd')[0]?.type).toBe(TokenType.SORT_DESC);
+      });
+    });
+
+    describe('crit threshold modifiers', () => {
+      it('should tokenize cs as CRIT_SUCCESS', () => {
+        const tokens = lex('cs');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.CRIT_SUCCESS, value: 'cs', position: 0 });
+      });
+
+      it('should tokenize cf as CRIT_FAIL', () => {
+        const tokens = lex('cf');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.CRIT_FAIL, value: 'cf', position: 0 });
+      });
+
+      it('should be case-insensitive for crit modifiers', () => {
+        expect(lex('CS')[0]?.type).toBe(TokenType.CRIT_SUCCESS);
+        expect(lex('Cf')[0]?.type).toBe(TokenType.CRIT_FAIL);
+      });
+    });
+
+    describe('@ variable references', () => {
+      it('should tokenize bare @name and preserve case', () => {
+        const tokens = lex('@StrMod');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.AT, value: 'StrMod', position: 0 });
+      });
+
+      it('should allow digits and underscores after the first char', () => {
+        const tokens = lex('@abilities_3');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.AT, value: 'abilities_3', position: 0 });
+      });
+
+      it('should allow an underscore-leading name', () => {
+        const tokens = lex('@_hidden');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({ type: TokenType.AT, value: '_hidden', position: 0 });
+      });
+
+      it('should tokenize @{name with spaces and hyphens} preserving case', () => {
+        const tokens = lex('@{Strength Modifier-1}');
+
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toEqual({
+          type: TokenType.AT,
+          value: 'Strength Modifier-1',
+          position: 0,
+        });
+      });
+
+      it('should stop scanning at non-identifier chars in the bare form', () => {
+        const tokens = lex('@foo+1');
+
+        expect(tokens).toHaveLength(4);
+        expect(tokens[0]).toEqual({ type: TokenType.AT, value: 'foo', position: 0 });
+        expect(tokens[1]).toEqual({ type: TokenType.PLUS, value: '+', position: 4 });
+        expect(tokens[2]).toEqual({ type: TokenType.NUMBER, value: '1', position: 5 });
+      });
+
+      it('should preserve case distinctly (@Foo vs @foo)', () => {
+        expect(lex('@Foo')[0]?.value).toBe('Foo');
+        expect(lex('@foo')[0]?.value).toBe('foo');
+      });
+
+      it('should throw LexerError for bare @ with no name', () => {
+        expect(() => lex('@')).toThrow(LexerError);
+      });
+
+      it('should throw LexerError for bare @ followed by a digit', () => {
+        expect(() => lex('@2')).toThrow(LexerError);
+      });
+
+      it('should throw LexerError for unterminated @{', () => {
+        expect(() => lex('@{foo')).toThrow(LexerError);
+      });
+
+      it('should throw LexerError when @{ contains a newline before }', () => {
+        expect(() => lex('@{foo\n}')).toThrow(LexerError);
+      });
+
+      it('should report position and character on @ errors', () => {
+        try {
+          lex('1d20+@');
+        } catch (e) {
+          expect(e).toBeInstanceOf(LexerError);
+          expect((e as LexerError).position).toBe(5);
+          expect((e as LexerError).character).toBe('@');
+        }
+      });
+    });
+  });
+
   describe('edge cases', () => {
     it('should tokenize 0d6 (zero count dice)', () => {
       const tokens = lex('0d6');
@@ -593,16 +744,16 @@ describe('Lexer', () => {
 
   describe('error handling', () => {
     it('should throw LexerError for invalid characters', () => {
-      expect(() => lex('2d20@')).toThrow(LexerError);
+      expect(() => lex('2d20#')).toThrow(LexerError);
     });
 
     it('should include position in error', () => {
       try {
-        lex('2d20@');
+        lex('2d20#');
       } catch (e) {
         expect(e).toBeInstanceOf(LexerError);
         expect((e as LexerError).position).toBe(4);
-        expect((e as LexerError).character).toBe('@');
+        expect((e as LexerError).character).toBe('#');
       }
     });
 

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -41,6 +41,11 @@ const IDENTIFIER_KEYWORDS: Record<string, TokenType> = {
   abs: TokenType.FUNCTION,
   max: TokenType.FUNCTION,
   min: TokenType.FUNCTION,
+  s: TokenType.SORT_ASC,
+  sa: TokenType.SORT_ASC,
+  sd: TokenType.SORT_DESC,
+  cs: TokenType.CRIT_SUCCESS,
+  cf: TokenType.CRIT_FAIL,
 };
 
 /**
@@ -95,6 +100,11 @@ export class Lexer {
       return this.scanIdentifier();
     }
 
+    // * Variable reference
+    if (char === '@') {
+      return this.scanAt();
+    }
+
     // * Operators and punctuation
     this.advance();
 
@@ -120,6 +130,10 @@ export class Lexer {
         return this.createTokenAt(TokenType.RPAREN, char, startPos);
       case ',':
         return this.createTokenAt(TokenType.COMMA, char, startPos);
+      case '{':
+        return this.createTokenAt(TokenType.LBRACE, char, startPos);
+      case '}':
+        return this.createTokenAt(TokenType.RBRACE, char, startPos);
       case '>':
         if (this.match('=')) {
           return this.createTokenAt(TokenType.GREATER_EQUAL, '>=', startPos);
@@ -218,6 +232,49 @@ export class Lexer {
     throw new LexerError('Unexpected identifier', 'UNEXPECTED_IDENTIFIER', startPos, lower);
   }
 
+  /**
+   * Scans a variable reference introduced by `@`.
+   *
+   * Two forms:
+   * - Bare: `@name` where `name` matches `[A-Za-z_][A-Za-z0-9_]*` (case preserved).
+   * - Braced: `@{name}` where `name` is any run of printable characters except
+   *   `}` and newline (permits spaces, hyphens, digits).
+   *
+   * Case is preserved — distinct from `scanIdentifier`, which lowercases the
+   * captured value. The emitted token's `value` is the variable name without
+   * the leading `@` or the surrounding braces.
+   */
+  private scanAt(): Token {
+    const startPos = this.pos;
+    this.advance(); // consume '@'
+
+    let name: string;
+    if (!this.isAtEnd() && this.peek() === '{') {
+      this.advance(); // consume '{'
+      const nameStart = this.pos;
+      while (!this.isAtEnd() && this.peek() !== '}' && this.peek() !== '\n') {
+        this.advance();
+      }
+      if (this.isAtEnd() || this.peek() !== '}') {
+        throw new LexerError('Unterminated @{...} variable', 'UNEXPECTED_CHARACTER', startPos, '@');
+      }
+      name = this.input.slice(nameStart, this.pos);
+      this.advance(); // consume '}'
+    } else {
+      const nameStart = this.pos;
+      if (this.isAtEnd() || !this.isIdentifierStart(this.peek())) {
+        throw new LexerError('Empty @ variable name', 'UNEXPECTED_CHARACTER', startPos, '@');
+      }
+      this.advance();
+      while (!this.isAtEnd() && this.isIdentifierPart(this.peek())) {
+        this.advance();
+      }
+      name = this.input.slice(nameStart, this.pos);
+    }
+
+    return this.createTokenAt(TokenType.AT, name, startPos);
+  }
+
   private peek(): string {
     return this.input[this.pos] ?? '';
   }
@@ -248,6 +305,14 @@ export class Lexer {
   private isAlpha(char: string): boolean {
     const c = char.toLowerCase();
     return c >= 'a' && c <= 'z';
+  }
+
+  private isIdentifierStart(char: string): boolean {
+    return this.isAlpha(char) || char === '_';
+  }
+
+  private isIdentifierPart(char: string): boolean {
+    return this.isAlpha(char) || this.isDigit(char) || char === '_';
   }
 
   private isWhitespace(char: string): boolean {

--- a/src/lexer/tokens.ts
+++ b/src/lexer/tokens.ts
@@ -127,11 +127,45 @@ export enum TokenType {
   VS = 29,
 
   //
+  // * Group boundaries
+  //
+
+  /** Left brace: '{' */
+  LBRACE = 30,
+  /** Right brace: '}' */
+  RBRACE = 31,
+
+  //
+  // * Variables
+  //
+
+  /** Variable reference prefix: '@' */
+  AT = 32,
+
+  //
+  // * Sort modifiers
+  //
+
+  /** Ascending sort: 's' or 'sa' */
+  SORT_ASC = 33,
+  /** Descending sort: 'sd' */
+  SORT_DESC = 34,
+
+  //
+  // * Crit thresholds
+  //
+
+  /** Critical success threshold: 'cs' */
+  CRIT_SUCCESS = 35,
+  /** Critical failure threshold: 'cf' */
+  CRIT_FAIL = 36,
+
+  //
   // * End of input
   //
 
   /** End of input marker */
-  EOF = 30,
+  EOF = 37,
 }
 
 /**

--- a/src/roll.ts
+++ b/src/roll.ts
@@ -25,6 +25,10 @@ export type RollOptions = {
   maxExplodeIterations?: number;
   /** Maximum reroll iterations allowed per die (default: 1,000) */
   maxRerollIterations?: number;
+  /** Variable context for `@name` / `@{name}` references (default: empty) */
+  context?: Record<string, number>;
+  /** Behavior when a referenced variable is missing from context (default: 'throw') */
+  onMissingVariable?: 'throw' | 'zero';
 };
 
 /**
@@ -61,6 +65,10 @@ export function roll(notation: string, options: RollOptions = {}): RollResult {
   }
   if (options.maxRerollIterations != null) {
     evalOptions.maxRerollIterations = options.maxRerollIterations;
+  }
+  if (options.context != null) evalOptions.context = options.context;
+  if (options.onMissingVariable != null) {
+    evalOptions.onMissingVariable = options.onMissingVariable;
   }
   return evaluate(ast, rng, evalOptions);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,4 +123,8 @@ export type EvaluateOptions = {
   maxExplodeIterations?: number;
   /** Maximum reroll iterations allowed per die (default: 1,000) */
   maxRerollIterations?: number;
+  /** Variable context for `@name` / `@{name}` references (default: empty) */
+  context?: Record<string, number>;
+  /** Behavior when a referenced variable is missing from context (default: 'throw') */
+  onMissingVariable?: 'throw' | 'zero';
 };


### PR DESCRIPTION
Stage 3 Plan 0 — shared infrastructure for the five Stage 3 feature issues (#80–#84). No user-facing behavior changes.

- Added `LBRACE`, `RBRACE`, `AT`, `SORT_ASC`, `SORT_DESC`, `CRIT_SUCCESS`, `CRIT_FAIL` to `TokenType`; moved `EOF` to 37
- Extended `IDENTIFIER_KEYWORDS` with `s`, `sa`, `sd`, `cs`, `cf`; added `{` / `}` to the punctuation switch
- Added case-preserving `scanAt` for bare `@name` and braced `@{name}` forms, throwing `LexerError` on empty and unterminated cases
- Threaded `context: Record<string, number>` and `onMissingVariable: 'throw' | 'zero'` through `RollOptions`, `EvaluateOptions`, and `EvalEnv`; normalized in `evaluate()` with defaults `{}` and `'throw'`
- Added 20 Stage 3 lexer tests; updated the `2d20@` invalid-char tests to `2d20#` since `@` is now a valid prefix

Closes #79

<sub>Drafted with AI assistance</sub>
