### PR TITLE
feat: add grouped rolls #81

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -2469,4 +2469,208 @@ describe('evaluate', () => {
       expect(result.expression).toBe('2 + 3 + 1d6');
     });
   });
+
+  describe('grouped rolls', () => {
+    describe('without modifier', () => {
+      test('single-sub-roll group is a pass-through: {4d6}', () => {
+        const ast = parse('{4d6}');
+        const rng = createMockRng([1, 2, 3, 4]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(10);
+        expect(result.rolls).toHaveLength(4);
+        expect(result.expression).toBe('{4d6}');
+        expect(result.rendered).toBe('{4d6[1, 2, 3, 4]} = 10');
+      });
+
+      test('multi-sub-roll group sums subtotals: {1d6, 1d8}', () => {
+        const ast = parse('{1d6, 1d8}');
+        const rng = createMockRng([3, 5]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(8);
+        expect(result.rolls).toHaveLength(2);
+        expect(result.expression).toBe('{1d6, 1d8}');
+        expect(result.rendered).toBe('{1d6[3], 1d8[5]} = 8');
+      });
+
+      test('literal-only group sums: {3, 5, 7}', () => {
+        const ast = parse('{3, 5, 7}');
+        const result = evaluate(ast, createMockRng([]));
+
+        expect(result.total).toBe(15);
+        expect(result.rolls).toHaveLength(0);
+        expect(result.expression).toBe('{3, 5, 7}');
+      });
+
+      test('nested group: {1d6, {5}}', () => {
+        const ast = parse('{1d6, {5}}');
+        const rng = createMockRng([4]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(9);
+        expect(result.rolls).toHaveLength(1);
+        expect(getDie(result.rolls, 0).result).toBe(4);
+      });
+
+      test('sub-roll with versus propagates degree', () => {
+        const ast = parse('{1d20+5 vs 15}');
+        const rng = createMockRng([10]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(15);
+        expect(result.degree).toBe(DegreeOfSuccess.Success);
+      });
+    });
+
+    describe('flat-pool mode (single sub-roll with keep/drop)', () => {
+      test('{4d10+5d6}kh2 keeps 2 highest across combined 9-die pool', () => {
+        const ast = parse('{4d10+5d6}kh2');
+        // 4 d10 draws: [10, 9, 8, 7], 5 d6 draws: [6, 5, 4, 3, 2]
+        // Combined sorted: 10, 9, 8, 7, 6, 5, 4, 3, 2 — kh2 keeps [10, 9]
+        const rng = createMockRng([10, 9, 8, 7, 6, 5, 4, 3, 2]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(19);
+        expect(result.rolls).toHaveLength(9);
+        const kept = result.rolls.filter((d) => !d.modifiers.includes('dropped'));
+        expect(kept.map((d) => d.result).sort((a, b) => b - a)).toEqual([10, 9]);
+      });
+
+      test('{4d6}kh2 passes through to ordinary keep-highest', () => {
+        const ast = parse('{4d6}kh2');
+        const rng = createMockRng([1, 2, 3, 4]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(7);
+        const kept = result.rolls.filter((d) => !d.modifiers.includes('dropped'));
+        expect(kept).toHaveLength(2);
+      });
+    });
+
+    describe('sub-roll mode (multi sub-roll with keep/drop)', () => {
+      test('{4d6+2d8, 3d20+3, 5d10+1}kh1 keeps highest subtotal', () => {
+        const ast = parse('{4d6+2d8, 3d20+3, 5d10+1}kh1');
+        // Sub 1: 4d6 = [1,1,1,1]=4, 2d8 = [1,1]=2 → 6
+        // Sub 2: 3d20 = [5,5,5]=15 → 15+3=18
+        // Sub 3: 5d10 = [1,1,1,1,1]=5 → 5+1=6
+        // Subtotals: [6, 18, 6] — kh1 picks 18
+        const rng = createMockRng([1, 1, 1, 1, 1, 1, 5, 5, 5, 1, 1, 1, 1, 1]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(18);
+        expect(result.rolls).toHaveLength(14);
+      });
+
+      test('dropped sub-roll flags all inner dice dropped', () => {
+        const ast = parse('{1d6, 1d8}kh1');
+        // Subtotals: [2, 7] — kh1 keeps sub 2 (1d8=7), drops sub 1 (1d6=2)
+        const rng = createMockRng([2, 7]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(7);
+        expect(result.rolls).toHaveLength(2);
+        const d6 = result.rolls.find((d) => d.sides === 6);
+        const d8 = result.rolls.find((d) => d.sides === 8);
+        expect(d6?.modifiers).toContain('dropped');
+        expect(d8?.modifiers).not.toContain('dropped');
+      });
+
+      test('literal-only multi-sub-roll: {3, 5, 7}kh1 returns 7', () => {
+        const ast = parse('{3, 5, 7}kh1');
+        const result = evaluate(ast, createMockRng([]));
+
+        expect(result.total).toBe(7);
+        expect(result.rolls).toHaveLength(0);
+      });
+
+      test('kl1 keeps lowest subtotal', () => {
+        const ast = parse('{1d6, 1d8}kl1');
+        // Subtotals: [5, 2] — kl1 keeps sub 2 (1d8=2)
+        const rng = createMockRng([5, 2]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(2);
+      });
+
+      test('dh1 drops highest subtotal', () => {
+        const ast = parse('{1d6, 1d8, 1d10}dh1');
+        // Subtotals: [2, 5, 8] — dh1 drops 8, keeps [2, 5] = 7
+        const rng = createMockRng([2, 5, 8]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(7);
+      });
+
+      test('dl1 drops lowest subtotal', () => {
+        const ast = parse('{1d6, 1d8, 1d10}dl1');
+        // Subtotals: [2, 5, 8] — dl1 drops 2, keeps [5, 8] = 13
+        const rng = createMockRng([2, 5, 8]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(13);
+      });
+
+      test('rendered form shows strikethrough for dropped sub-rolls', () => {
+        const ast = parse('{1d6, 1d8}kh1');
+        const rng = createMockRng([2, 7]);
+        const result = evaluate(ast, rng);
+
+        expect(result.rendered).toBe('{~~1d6[2]~~, 1d8[7]} = 7');
+        expect(result.expression).toBe('{1d6, 1d8}kh1');
+      });
+
+      test('RNG draw order is left-to-right across sub-expressions', () => {
+        const ast = parse('{1d6, 2d8}kh1');
+        // Expected draws: 1d6 first, then 2d8 left-to-right.
+        // Subtotals: [3, 5+6]=[3, 11] — kh1 picks sub 2
+        const rng = createMockRng([3, 5, 6]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(11);
+        const d8s = result.rolls.filter((d) => d.sides === 8);
+        expect(d8s.map((d) => d.result)).toEqual([5, 6]);
+      });
+    });
+
+    describe('group inside arithmetic', () => {
+      test('2 * {1d6, 1d8}kh1', () => {
+        const ast = parse('2 * {1d6, 1d8}kh1');
+        const rng = createMockRng([4, 3]);
+        const result = evaluate(ast, rng);
+
+        // Subtotals: [4, 3] — kh1 picks 4. 2 * 4 = 8.
+        expect(result.total).toBe(8);
+      });
+
+      test('{1d6, 1d8}kh1 + 5', () => {
+        const ast = parse('{1d6, 1d8}kh1 + 5');
+        const rng = createMockRng([4, 3]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(9);
+      });
+
+      test('-{1d6, 2d8}kh1 negates the kept subtotal', () => {
+        const ast = parse('-{1d6, 2d8}kh1');
+        const rng = createMockRng([3, 4, 5]);
+        const result = evaluate(ast, rng);
+
+        // Subtotals: [3, 9]. kh1 picks 9. Negate: -9.
+        expect(result.total).toBe(-9);
+      });
+    });
+
+    describe('nested keep/drop', () => {
+      test('{{1d6, 2d8}kh1, 3d10}kl1 — two levels of keep/drop', () => {
+        const ast = parse('{{1d6, 2d8}kh1, 3d10}kl1');
+        // Inner group: subtotals [1d6=2, 2d8=5+6=11] — kh1 picks 11.
+        // Outer group: subtotals [11, 3d10=1+2+3=6] — kl1 picks 6.
+        const rng = createMockRng([2, 5, 6, 1, 2, 3]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(6);
+      });
+    });
+  });
 });

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -14,6 +14,7 @@ import type {
   FateDiceNode,
   FunctionCallNode,
   GroupedNode,
+  GroupNode,
   ModifierNode,
   RerollNode,
   SuccessCountNode,
@@ -259,6 +260,9 @@ function evalNode(node: ASTNode, rng: RNG, ctx: EvalContext, env: EvalEnv): numb
     case 'Grouped':
       return evalGrouped(node, rng, ctx, env);
 
+    case 'Group':
+      return evalGroup(node, rng, ctx, env);
+
     case 'Variable':
       return evalVariable(node, ctx, env);
 
@@ -502,6 +506,36 @@ function evalGrouped(node: GroupedNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   return value;
 }
 
+/**
+ * Evaluates a grouped roll `{expr1, expr2, ...}`.
+ *
+ * Each sub-expression is evaluated in an isolated context, then its rolls
+ * and `versusMetadata` propagate up via `mergeContext`. Sub-roll subtotals
+ * sum to the group's total. When the group is the base target of a
+ * keep/drop modifier with `expressions.length >= 2`, `evalModifier`
+ * intercepts first and never calls this function — dual semantics
+ * (flat-pool vs sub-roll) are decided there.
+ */
+function evalGroup(node: GroupNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
+  const subExprs: string[] = [];
+  const subRendered: string[] = [];
+  let total = 0;
+
+  for (const expr of node.expressions) {
+    const subCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
+    const subtotal = evalNode(expr, rng, subCtx, env);
+    mergeContext(ctx, subCtx);
+    subExprs.push(subCtx.expressionParts.join(''));
+    subRendered.push(subCtx.renderedParts.join(''));
+    total += subtotal;
+  }
+
+  ctx.expressionParts.push(`{${subExprs.join(', ')}}`);
+  ctx.renderedParts.push(`{${subRendered.join(', ')}}`);
+
+  return total;
+}
+
 function evalFunctionCall(
   node: FunctionCallNode,
   rng: RNG,
@@ -732,6 +766,14 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
 function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   const { specs, baseTarget } = flattenModifierChain(node, rng, ctx, env);
 
+  // Multi-sub-roll group: keep/drop operates on sub-roll subtotals as if
+  // each subtotal were a compound die. Single-sub-roll groups fall through
+  // to the flat-pool path below — `evalGroup` evaluates the inner expression
+  // into `targetCtx.rolls`, and `mergeDropSets` selects individual dice.
+  if (baseTarget.type === 'Group' && baseTarget.expressions.length >= 2) {
+    return evalGroupModifier(baseTarget, specs, rng, ctx, env);
+  }
+
   const targetCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
   evalNode(baseTarget, rng, targetCtx, env);
 
@@ -746,6 +788,107 @@ function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext, env: EvalE
 
   ctx.expressionParts.push(`${targetExpr}${modifierCodes}`);
   ctx.renderedParts.push(`${targetExpr}${renderDice(mergedDice)}`);
+
+  return total;
+}
+
+/**
+ * Evaluates a keep/drop modifier chain whose base target is a multi
+ * sub-roll group. Each sub-roll is evaluated in isolation so its subtotal
+ * and dice are captured separately. Synthetic dice — one per sub-roll,
+ * `result = subtotal` — feed `mergeDropSets` to pick kept/dropped indices.
+ * Dropped sub-rolls' inner dice are re-flagged `'dropped'` so `sumKeptDice`
+ * on the propagated rolls still agrees with the group total, and the
+ * rendered form wraps them in strikethrough `~~...~~`.
+ */
+function evalGroupModifier(
+  group: GroupNode,
+  specs: ModifierSpec[],
+  rng: RNG,
+  ctx: EvalContext,
+  env: EvalEnv,
+): number {
+  type SubRoll = {
+    subtotal: number;
+    rolls: DieResult[];
+    expr: string;
+    rendered: string;
+    versusMetadata: EvalContext['versusMetadata'];
+  };
+
+  const subRolls: SubRoll[] = group.expressions.map((expr) => {
+    const subCtx: EvalContext = { rolls: [], expressionParts: [], renderedParts: [] };
+    const subtotal = evalNode(expr, rng, subCtx, env);
+    return {
+      subtotal,
+      rolls: subCtx.rolls,
+      expr: subCtx.expressionParts.join(''),
+      rendered: subCtx.renderedParts.join(''),
+      versusMetadata: subCtx.versusMetadata,
+    };
+  });
+
+  // ? Synthetic dice carry `sides = 0` as a sentinel — they're never
+  //   surfaced in `ctx.rolls`, only used as input to `mergeDropSets`. Any
+  //   `critical`/`fumble` flags would be meaningless for a subtotal.
+  const syntheticDice: DieResult[] = subRolls.map((sub) => ({
+    sides: 0,
+    result: sub.subtotal,
+    modifiers: [],
+    critical: false,
+    fumble: false,
+  }));
+
+  const mergedSynthetic = mergeDropSets(syntheticDice, specs);
+
+  const outerRendered: string[] = [];
+  let total = 0;
+
+  for (let i = 0; i < subRolls.length; i++) {
+    const sub = subRolls[i] as SubRoll;
+    const synth = mergedSynthetic[i] as DieResult;
+    const isDropped = synth.modifiers.includes('dropped');
+
+    if (isDropped) {
+      // Flag every inner die dropped so propagated rolls match the total.
+      // Keep existing `'kept'` stripped — the sub-roll didn't contribute,
+      // so its die-level kept annotation no longer applies.
+      const droppedRolls: DieResult[] = sub.rolls.map((d) => ({
+        ...d,
+        modifiers: [...d.modifiers.filter((m) => m !== 'kept' && m !== 'dropped'), 'dropped'],
+      }));
+      ctx.rolls.push(...droppedRolls);
+      outerRendered.push(`~~${sub.rendered}~~`);
+    } else {
+      ctx.rolls.push(...sub.rolls);
+      outerRendered.push(sub.rendered);
+      total += sub.subtotal;
+    }
+
+    // Propagate Versus metadata from kept OR dropped sub-rolls — dropping
+    // a sub-roll doesn't make its degree result disappear; two versus
+    // results in the same group still collide via the same guard used by
+    // `mergeContext`.
+    if (sub.versusMetadata) {
+      if (ctx.versusMetadata) {
+        throw new EvaluatorError(
+          'Multiple versus operators in the same expression',
+          'NESTED_VERSUS',
+          'Versus',
+        );
+      }
+      ctx.versusMetadata = sub.versusMetadata;
+    }
+  }
+
+  const subExprStrs = subRolls.map((s) => s.expr);
+  const modifierCodes = specs.map((s) => `${s.code}${s.count}`).join('');
+
+  ctx.expressionParts.push(`{${subExprStrs.join(', ')}}${modifierCodes}`);
+  // ? Mirror `evalModifier`'s flat-pool rendering: modifier codes live in
+  //   `expressionParts` only — the per-sub strikethrough already signals
+  //   which sub-rolls were kept vs dropped.
+  ctx.renderedParts.push(`{${outerRendered.join(', ')}}`);
 
   return total;
 }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -688,4 +688,59 @@ describe('roll() integration', () => {
       );
     });
   });
+
+  describe('grouped rolls', () => {
+    test('advantage-style: {1d20+5, 1d20+5}kh1 picks highest total', () => {
+      // Sub 1: 1d20=8 → 13, Sub 2: 1d20=17 → 22. kh1 picks 22.
+      const result = roll('{1d20+5, 1d20+5}kh1', { rng: createMockRng([8, 17]) });
+
+      expect(result.total).toBe(22);
+      expect(result.notation).toBe('{1d20+5, 1d20+5}kh1');
+    });
+
+    test('flat-pool: {4d6+2d8}kh3 keeps 3 highest across combined pool', () => {
+      // 4d6: [6, 6, 6, 1], 2d8: [8, 1]. Combined [6, 6, 6, 1, 8, 1]. kh3 → 8+6+6 = 20
+      const result = roll('{4d6+2d8}kh3', { rng: createMockRng([6, 6, 6, 1, 8, 1]) });
+
+      expect(result.total).toBe(20);
+    });
+
+    test('literal group: {3, 5, 7}kh1 returns 7', () => {
+      const result = roll('{3, 5, 7}kh1', { rng: createMockRng([]) });
+
+      expect(result.total).toBe(7);
+    });
+
+    test('group arithmetic combine: 2 * {1d6, 1d8}kh1', () => {
+      const result = roll('2 * {1d6, 1d8}kh1', { rng: createMockRng([4, 3]) });
+
+      expect(result.total).toBe(8);
+    });
+
+    test('nested: {1d6, {5}} passes inner literal through', () => {
+      const result = roll('{1d6, {5}}', { rng: createMockRng([4]) });
+
+      expect(result.total).toBe(9);
+    });
+
+    test('rejects empty group at parse time', () => {
+      expect(() => roll('{}', { rng: createMockRng([]) })).toThrow(ParseError);
+    });
+
+    test('rejects explode on group at parse time', () => {
+      expect(() => roll('{4d6}!', { rng: createMockRng([]) })).toThrow(ParseError);
+    });
+
+    test('rejects reroll on group at parse time', () => {
+      expect(() => roll('{4d6}r<2', { rng: createMockRng([]) })).toThrow(ParseError);
+    });
+
+    test('works with seeded RNG for reproducibility', () => {
+      const r1 = roll('{1d20+5, 1d20+5}kh1', { seed: 'test-seed' });
+      const r2 = roll('{1d20+5, 1d20+5}kh1', { seed: 'test-seed' });
+
+      expect(r1.total).toBe(r2.total);
+      expect(r1.rolls).toEqual(r2.rolls);
+    });
+  });
 });

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -163,6 +163,20 @@ export type VariableNode = {
 };
 
 /**
+ * Grouped-roll node (`{expr}`, `{expr1, expr2, ...}`).
+ *
+ * Distinct from `GroupedNode` (parenthesized wrapper) — a `GroupNode`
+ * collects one or more sub-expressions whose evaluation semantics change
+ * with the sub-roll count. `expressions.length === 1` is a passthrough
+ * (flat-pool when wrapped by keep/drop); `expressions.length >= 2` treats
+ * each sub-roll's subtotal as a compound die for keep/drop selection.
+ */
+export type GroupNode = {
+  type: 'Group';
+  expressions: ASTNode[];
+};
+
+/**
  * Union type of all AST nodes.
  */
 export type ASTNode =
@@ -178,7 +192,8 @@ export type ASTNode =
   | VersusNode
   | FunctionCallNode
   | GroupedNode
-  | VariableNode;
+  | VariableNode
+  | GroupNode;
 
 /**
  * Type guard for LiteralNode.
@@ -272,6 +287,13 @@ export function isVariable(node: ASTNode): node is VariableNode {
 }
 
 /**
+ * Type guard for GroupNode.
+ */
+export function isGroup(node: ASTNode): node is GroupNode {
+  return node.type === 'Group';
+}
+
+/**
  * Returns `true` only when `node`'s direct result is a dice pool —
  * `Dice`, `FateDice`, or a chained pool modifier (`Modifier` / `Explode` /
  * `Reroll`). Does NOT recurse through arithmetic wrappers (`BinaryOp`,
@@ -291,6 +313,47 @@ export function containsDicePool(node: ASTNode): boolean {
       return true;
     case 'Grouped':
       return containsDicePool(node.expression);
+    case 'Group':
+      // ? Multi-sub-roll groups (`{a, b, c}kh1`) always accept: keep/drop
+      //   operates on subtotals, which are "compound dice" by definition —
+      //   even a literal-only `{3, 5, 7}kh1` is valid. Single-sub-roll
+      //   groups are the user's explicit opt-in to flat-pool semantics, so
+      //   we deep-walk through arithmetic that a raw `(1d6+5)kh1` would
+      //   reject. This is the `{}` escape hatch per Stage 3 spec.
+      return node.expressions.length >= 2 || node.expressions.some(deepContainsDicePool);
+    default:
+      return false;
+  }
+}
+
+/**
+ * Deeper variant of `containsDicePool` that recurses through arithmetic and
+ * function wrappers. Used only from the `Group` case above — ordinary
+ * parenthesized arithmetic (`(1d6+5)kh1`) must still reject, so the shallow
+ * `containsDicePool` handles those directly.
+ */
+function deepContainsDicePool(node: ASTNode): boolean {
+  switch (node.type) {
+    case 'Dice':
+    case 'FateDice':
+      return true;
+    case 'BinaryOp':
+      return deepContainsDicePool(node.left) || deepContainsDicePool(node.right);
+    case 'UnaryOp':
+      return deepContainsDicePool(node.operand);
+    case 'Modifier':
+    case 'Explode':
+    case 'Reroll':
+    case 'SuccessCount':
+      return deepContainsDicePool(node.target);
+    case 'Versus':
+      return deepContainsDicePool(node.roll) || deepContainsDicePool(node.dc);
+    case 'FunctionCall':
+      return node.args.some(deepContainsDicePool);
+    case 'Grouped':
+      return deepContainsDicePool(node.expression);
+    case 'Group':
+      return node.expressions.length >= 2 || node.expressions.some(deepContainsDicePool);
     default:
       return false;
   }
@@ -316,6 +379,8 @@ export function containsFatePool(node: ASTNode): boolean {
       return containsFatePool(node.target);
     case 'Grouped':
       return containsFatePool(node.expression);
+    case 'Group':
+      return node.expressions.some(containsFatePool);
     default:
       return false;
   }

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -10,6 +10,7 @@ import type {
   FateDiceNode,
   FunctionCallNode,
   GroupedNode,
+  GroupNode,
   LiteralNode,
   ModifierNode,
   RerollNode,
@@ -88,6 +89,10 @@ function functionCall(name: string, args: ASTNode[]): FunctionCallNode {
 
 function grouped(expression: ASTNode): GroupedNode {
   return { type: 'Grouped', expression };
+}
+
+function group(expressions: ASTNode[]): GroupNode {
+  return { type: 'Group', expressions };
 }
 
 function variable(name: string): VariableNode {
@@ -1809,6 +1814,219 @@ describe('Parser', () => {
 
     it('should parse variable as a leaf with no LED — @str+@dex', () => {
       expect(parse('@str+@dex')).toEqual(binary('+', variable('str'), variable('dex')));
+    });
+  });
+
+  describe('grouped rolls', () => {
+    describe('shape', () => {
+      it('should parse single-sub-roll group as Group with one expression', () => {
+        expect(parse('{4d6}')).toEqual(group([dice(literal(4), literal(6))]));
+      });
+
+      it('should parse literal group', () => {
+        expect(parse('{3, 5, 7}')).toEqual(group([literal(3), literal(5), literal(7)]));
+      });
+
+      it('should parse multi-sub-roll group with arithmetic sub-expressions', () => {
+        expect(parse('{4d6+2d8, 3d20+3, 5d10+1}')).toEqual(
+          group([
+            binary('+', dice(literal(4), literal(6)), dice(literal(2), literal(8))),
+            binary('+', dice(literal(3), literal(20)), literal(3)),
+            binary('+', dice(literal(5), literal(10)), literal(1)),
+          ]),
+        );
+      });
+
+      it('should parse single-expression flat-pool group', () => {
+        expect(parse('{4d10+5d6}')).toEqual(
+          group([binary('+', dice(literal(4), literal(10)), dice(literal(5), literal(6)))]),
+        );
+      });
+
+      it('should parse nested group', () => {
+        expect(parse('{1d6, {5}}')).toEqual(
+          group([dice(literal(1), literal(6)), group([literal(5)])]),
+        );
+      });
+
+      it('should parse doubly nested group with outer keep/drop', () => {
+        expect(parse('{{1d6, 2d8}kh1, 3d10}kl1')).toEqual(
+          modifier(
+            'keep',
+            'lowest',
+            literal(1),
+            group([
+              modifier(
+                'keep',
+                'highest',
+                literal(1),
+                group([dice(literal(1), literal(6)), dice(literal(2), literal(8))]),
+              ),
+              dice(literal(3), literal(10)),
+            ]),
+          ),
+        );
+      });
+    });
+
+    describe('keep/drop modifiers', () => {
+      it('should parse group + kh modifier', () => {
+        expect(parse('{1d6, 1d8}kh1')).toEqual(
+          modifier(
+            'keep',
+            'highest',
+            literal(1),
+            group([dice(literal(1), literal(6)), dice(literal(1), literal(8))]),
+          ),
+        );
+      });
+
+      it('should parse group + kl modifier', () => {
+        expect(parse('{1d20, 1d20}kl1')).toEqual(
+          modifier(
+            'keep',
+            'lowest',
+            literal(1),
+            group([dice(literal(1), literal(20)), dice(literal(1), literal(20))]),
+          ),
+        );
+      });
+
+      it('should parse flat-pool group + kh with implicit count', () => {
+        expect(parse('{4d10+5d6}kh2')).toEqual(
+          modifier(
+            'keep',
+            'highest',
+            literal(2),
+            group([binary('+', dice(literal(4), literal(10)), dice(literal(5), literal(6)))]),
+          ),
+        );
+      });
+
+      it('should accept literal-only multi-sub-roll group with keep/drop', () => {
+        expect(parse('{3, 5, 7}kh1')).toEqual(
+          modifier('keep', 'highest', literal(1), group([literal(3), literal(5), literal(7)])),
+        );
+      });
+
+      it('should reject keep/drop on a single-sub-roll group with no dice', () => {
+        expect(() => parse('{5}kh1')).toThrow(ParseError);
+      });
+    });
+
+    describe('group inside arithmetic and unary', () => {
+      it('should parse group on the right of +', () => {
+        expect(parse('5 + {1d6, 1d8}kh1')).toEqual(
+          binary(
+            '+',
+            literal(5),
+            modifier(
+              'keep',
+              'highest',
+              literal(1),
+              group([dice(literal(1), literal(6)), dice(literal(1), literal(8))]),
+            ),
+          ),
+        );
+      });
+
+      it('should parse group multiplied by a literal', () => {
+        expect(parse('2 * {1d6, 1d8}kh1')).toEqual(
+          binary(
+            '*',
+            literal(2),
+            modifier(
+              'keep',
+              'highest',
+              literal(1),
+              group([dice(literal(1), literal(6)), dice(literal(1), literal(8))]),
+            ),
+          ),
+        );
+      });
+
+      it('should parse unary minus before group', () => {
+        expect(parse('-{1d6, 2d8}kh1')).toEqual(
+          unary(
+            modifier(
+              'keep',
+              'highest',
+              literal(1),
+              group([dice(literal(1), literal(6)), dice(literal(2), literal(8))]),
+            ),
+          ),
+        );
+      });
+    });
+
+    describe('errors', () => {
+      it('should reject empty group', () => {
+        expect(() => parse('{}')).toThrow(ParseError);
+        try {
+          parse('{}');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('UNEXPECTED_TOKEN');
+          expect((e as ParseError).message).toContain('Empty group');
+        }
+      });
+
+      it('should reject unterminated group with EOF', () => {
+        expect(() => parse('{1d6, 2d8')).toThrow(ParseError);
+        try {
+          parse('{1d6, 2d8');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('EXPECTED_TOKEN');
+          expect((e as ParseError).message).toContain('Unterminated group');
+        }
+      });
+
+      it('should reject unterminated group with stray token', () => {
+        expect(() => parse('{1d6 +}')).toThrow(ParseError);
+      });
+
+      it('should reject stray closing brace at top level', () => {
+        expect(() => parse('1d6}')).toThrow(ParseError);
+      });
+
+      it('should reject stray opening brace after an expression', () => {
+        expect(() => parse('1d6{1d8}')).toThrow(ParseError);
+      });
+
+      it('should reject explode on a group: {4d6}!', () => {
+        expect(() => parse('{4d6}!')).toThrow(ParseError);
+        try {
+          parse('{4d6}!');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+          expect((e as ParseError).message).toContain('Cannot explode a group');
+        }
+      });
+
+      it('should reject explode on a parenthesized group: ({4d6})!', () => {
+        expect(() => parse('({4d6})!')).toThrow(ParseError);
+      });
+
+      it('should reject compound explode on a group', () => {
+        expect(() => parse('{4d6}!!')).toThrow(ParseError);
+      });
+
+      it('should reject penetrating explode on a group', () => {
+        expect(() => parse('{4d6}!p')).toThrow(ParseError);
+      });
+
+      it('should reject reroll on a group: {4d6}r<2', () => {
+        expect(() => parse('{4d6}r<2')).toThrow(ParseError);
+        try {
+          parse('{4d6}r<2');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_REROLL_TARGET');
+          expect((e as ParseError).message).toContain('Cannot reroll a group');
+        }
+      });
+
+      it('should reject reroll-once on a group', () => {
+        expect(() => parse('{4d6}ro<2')).toThrow(ParseError);
+      });
     });
   });
 });

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -17,6 +17,7 @@ import type {
   FateDiceNode,
   FunctionCallNode,
   GroupedNode,
+  GroupNode,
   LiteralNode,
   ModifierNode,
   RerollNode,
@@ -176,6 +177,9 @@ export class Parser {
 
       case TokenType.LPAREN:
         return this.parseGrouped();
+
+      case TokenType.LBRACE:
+        return this.parseGroup(token);
 
       case TokenType.FUNCTION:
         return this.parseFunctionCall(token);
@@ -345,6 +349,34 @@ export class Parser {
     return { type: 'Grouped', expression };
   }
 
+  private parseGroup(startToken: Token): GroupNode {
+    // ? `LBRACE`/`RBRACE`/`COMMA` all have `getLeftBp === -1`, so inner
+    //   `parseExpression(0)` calls terminate at the first `,` or `}` without
+    //   competing with modifier/arithmetic BPs.
+    if (this.peek().type === TokenType.RBRACE) {
+      throw new ParseError('Empty group', 'UNEXPECTED_TOKEN', startToken.position, startToken);
+    }
+
+    const expressions: ASTNode[] = [this.parseExpression(0)];
+    while (this.peek().type === TokenType.COMMA) {
+      this.advance();
+      expressions.push(this.parseExpression(0));
+    }
+
+    if (this.peek().type !== TokenType.RBRACE) {
+      const unterminated = this.peek();
+      throw new ParseError(
+        `Unterminated group: expected '}' or ','`,
+        'EXPECTED_TOKEN',
+        unterminated.position,
+        unterminated,
+      );
+    }
+    this.advance();
+
+    return { type: 'Group', expressions };
+  }
+
   private parseVariable(token: Token): VariableNode {
     return { type: 'Variable', name: token.value };
   }
@@ -433,6 +465,27 @@ export class Parser {
     }
   }
 
+  /**
+   * Rejects `GroupNode` (or a parens-wrapped group) as the target of `token`.
+   * Explode and reroll wrap bare dice only — a group is fundamentally a
+   * container of sub-expressions, so applying these modifiers has no defined
+   * semantics. Parens are unwrapped so `({1d6})!` rejects the same as `{1d6}!`.
+   */
+  private rejectGroupTarget(
+    target: ASTNode,
+    token: Token,
+    action: string,
+    code: RollParserErrorCode,
+  ): void {
+    let node = target;
+    while (node.type === 'Grouped') {
+      node = node.expression;
+    }
+    if (node.type === 'Group') {
+      throw new ParseError(`Cannot ${action} a group`, code, token.position, token);
+    }
+  }
+
   private rejectVersusTarget(target: ASTNode, token: Token): void {
     // ? Versus produces a PF2e degree outcome — a terminal scalar, not a
     //   valid input to dice count/sides/thresholds. Symmetric with
@@ -496,6 +549,11 @@ export class Parser {
   private parseExplode(target: ASTNode, token: Token): ExplodeNode {
     this.rejectSuccessCountTarget(target, token);
 
+    // Groups have no explode semantics — reject outright. Must come before
+    // `containsDicePool`, which recurses into `Group` and would otherwise
+    // let `{4d6}!` slip through.
+    this.rejectGroupTarget(target, token, 'explode', 'INVALID_EXPLODE_TARGET');
+
     // Explode needs a dice pool to explode on. Wrapping arithmetic (e.g.
     // `(1d6+5)!`, `floor(1d6/2)!`) would silently drop user math.
     if (!containsDicePool(target)) {
@@ -546,6 +604,10 @@ export class Parser {
 
   private parseReroll(target: ASTNode, token: Token): RerollNode {
     this.rejectSuccessCountTarget(target, token);
+
+    // Groups have no reroll semantics — reject outright. Must come before
+    // `containsDicePool`, which recurses into `Group`.
+    this.rejectGroupTarget(target, token, 'reroll', 'INVALID_REROLL_TARGET');
 
     // Reroll needs a dice pool to inspect. Wrapping arithmetic (e.g.
     // `(1d6+5)r<3`, `floor(1d6/2)ro<3`) would silently drop user math.
@@ -773,6 +835,11 @@ export class Parser {
       // Punctuation and keywords that terminate expressions
       case TokenType.COMMA:
       case TokenType.FUNCTION:
+      // Group boundaries: `}` closes the current group (consumed inside
+      // `parseGroup`), and a stray `{` after a complete expression is an
+      // error. Both terminate the outer Pratt loop at -1.
+      case TokenType.LBRACE:
+      case TokenType.RBRACE:
         return -1;
       default:
         return 0;


### PR DESCRIPTION
Added `GroupNode` to the AST with `isGroup` type guard and deep-recursive `containsDicePool`/`containsFatePool`.

Implemented `LBRACE` NUD handler, `BP=-1` terminators, and `rejectGroupTarget` wired into `parseExplode`/`parseReroll`.

Added `evalGroup` with `versusMetadata` propagation and `evalGroupModifier` dispatch in `evalModifier` for multi-sub-roll keep/drop via synthetic subtotal dice.

Covered parser, evaluator, and integration scenarios including flat-pool `{4d10+5d6}kh2`, sub-roll mode `{...}kh1`, literal-only `{3, 5, 7}kh1`, nested groups, and rejection paths.

Closes #81

<sub>Drafted with AI assistance</sub>
