### PR TITLE
refactor: consolidate AST wrapper unwrapping in parser reject helpers #92

### DIFF
--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -351,6 +351,56 @@ export function isCritThreshold(node: ASTNode): node is CritThresholdNode {
 }
 
 /**
+ * Wrapper kinds that `unwrapTransparent` can peel.
+ *
+ * "Transparent" is relative to the question being asked. `Modifier`/`Sort`/
+ * `CritThreshold` are transparent for "what is the underlying operand?" when
+ * deciding whether to reject a `Group` target — they preserve `containsDicePool`'s
+ * answer for whatever they wrap. They are NOT transparent for "is this a
+ * `SuccessCount`?" or "is this a `Versus`?", because the parsers that build
+ * those wrappers already reject `SuccessCount`/`Versus` operands upstream.
+ */
+export type TransparentWrapperKind = 'Grouped' | 'Modifier' | 'Sort' | 'CritThreshold';
+
+/**
+ * Walks `node` while its `.type` is in `kinds`, returning the first descendant
+ * that is not one of the listed wrappers. Each caller picks the subset that
+ * matches its rejection semantics — see `TransparentWrapperKind` for guidance.
+ *
+ * Used by parser reject helpers to look past wrappers when deciding whether
+ * an operand violates a rule (e.g., `Group` cannot be the target of `cs`/`cf`,
+ * even when wrapped in `Modifier` like `{1d6}kh1cs>5`).
+ */
+export function unwrapTransparent(
+  node: ASTNode,
+  kinds: readonly TransparentWrapperKind[],
+): ASTNode {
+  let current = node;
+  while (true) {
+    switch (current.type) {
+      case 'Grouped':
+        if (!kinds.includes('Grouped')) return current;
+        current = current.expression;
+        break;
+      case 'Modifier':
+        if (!kinds.includes('Modifier')) return current;
+        current = current.target;
+        break;
+      case 'Sort':
+        if (!kinds.includes('Sort')) return current;
+        current = current.target;
+        break;
+      case 'CritThreshold':
+        if (!kinds.includes('CritThreshold')) return current;
+        current = current.target;
+        break;
+      default:
+        return current;
+    }
+  }
+}
+
+/**
  * Returns `true` only when `node`'s direct result is a dice pool —
  * `Dice`, `FateDice`, or a chained pool modifier (`Modifier` / `Explode` /
  * `Reroll`). Does NOT recurse through arithmetic wrappers (`BinaryOp`,

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -2042,6 +2042,35 @@ describe('Parser', () => {
       it('should reject reroll-once on a group', () => {
         expect(() => parse('{4d6}ro<2')).toThrow(ParseError);
       });
+
+      it('should reject explode on a modifier-wrapped group: {4d6}kh1!', () => {
+        expect(() => parse('{4d6}kh1!')).toThrow(ParseError);
+        try {
+          parse('{4d6}kh1!');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+          expect((e as ParseError).message).toContain('Cannot explode a group');
+        }
+      });
+
+      it('should reject reroll on a modifier-wrapped group: {4d6}kh1r<2', () => {
+        expect(() => parse('{4d6}kh1r<2')).toThrow(ParseError);
+        try {
+          parse('{4d6}kh1r<2');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_REROLL_TARGET');
+          expect((e as ParseError).message).toContain('Cannot reroll a group');
+        }
+      });
+
+      it('should reject explode on a sort-wrapped group: {4d6}s!', () => {
+        expect(() => parse('{4d6}s!')).toThrow(ParseError);
+        try {
+          parse('{4d6}s!');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_EXPLODE_TARGET');
+        }
+      });
     });
   });
 
@@ -2349,6 +2378,25 @@ describe('Parser', () => {
 
       it('should reject cf on a group', () => {
         expect(() => parse('{1d6}cf<2')).toThrow(ParseError);
+      });
+
+      it('should reject cs on a modifier-wrapped group: {1d6}kh1cs>5', () => {
+        expect(() => parse('{1d6}kh1cs>5')).toThrow(ParseError);
+        try {
+          parse('{1d6}kh1cs>5');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+          expect((e as ParseError).message).toContain('group');
+        }
+      });
+
+      it('should reject cf on a modifier-wrapped group: {1d6}kh1cf<2', () => {
+        expect(() => parse('{1d6}kh1cf<2')).toThrow(ParseError);
+        try {
+          parse('{1d6}kh1cf<2');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+        }
       });
 
       it('should reject cs on SuccessCount target', () => {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -35,6 +35,7 @@ import {
   deepContainsDicePool,
   isCritThreshold,
   isSuccessCount,
+  unwrapTransparent,
 } from './ast';
 
 /**
@@ -468,10 +469,11 @@ export class Parser {
   }
 
   private rejectSuccessCountTarget(target: ASTNode, token: Token): void {
-    let node = target;
-    while (node.type === 'Grouped') {
-      node = node.expression;
-    }
+    // ? Narrow unwrap: only `Grouped`. A `SuccessCount` cannot live inside
+    //   `Modifier`/`Sort`/`CritThreshold` because each of those parsers calls
+    //   this same reject on their target before constructing the wrapper —
+    //   so widening the set here would never match.
+    const node = unwrapTransparent(target, ['Grouped']);
     if (isSuccessCount(node)) {
       throw new ParseError(
         `Cannot apply modifier after success counting`,
@@ -483,10 +485,12 @@ export class Parser {
   }
 
   /**
-   * Rejects `GroupNode` (or a parens-wrapped group) as the target of `token`.
-   * Explode and reroll wrap bare dice only — a group is fundamentally a
-   * container of sub-expressions, so applying these modifiers has no defined
-   * semantics. Parens are unwrapped so `({1d6})!` rejects the same as `{1d6}!`.
+   * Rejects `GroupNode` (or a wrapper-cloaked group) as the target of `token`.
+   * Explode, reroll, and crit-threshold wrap bare dice pools only — a group
+   * is a container of sub-expressions, so these modifiers have no defined
+   * semantics. Walks `Grouped`/`Modifier`/`Sort`/`CritThreshold` so wrappers
+   * cannot smuggle a group past the check (`{1d6}kh1cs>5`, `({1d6})!`,
+   * `{1d6}scs>5` all reject the same as `{1d6}!`/`{1d6}cs>5`).
    */
   private rejectGroupTarget(
     target: ASTNode,
@@ -494,10 +498,7 @@ export class Parser {
     action: string,
     code: RollParserErrorCode,
   ): void {
-    let node = target;
-    while (node.type === 'Grouped') {
-      node = node.expression;
-    }
+    const node = unwrapTransparent(target, ['Grouped', 'Modifier', 'Sort', 'CritThreshold']);
     if (node.type === 'Group') {
       throw new ParseError(`Cannot ${action} a group`, code, token.position, token);
     }
@@ -509,10 +510,10 @@ export class Parser {
     //   `rejectSuccessCountTarget`; wrappers like `floor(vs)+0` still
     //   propagate `versusMetadata` via `mergeContext`, so this only blocks
     //   `mergeMetaRolls` sites where metadata would silently vanish.
-    let node = target;
-    while (node.type === 'Grouped') {
-      node = node.expression;
-    }
+    // ? Narrow unwrap: only `Grouped`. `Modifier`/`Sort`/`CritThreshold`
+    //   cannot wrap a `Versus` because `containsDicePool` does not recurse
+    //   into `Versus`, so each of those parsers rejects the wrap upstream.
+    const node = unwrapTransparent(target, ['Grouped']);
     if (node.type === 'Versus') {
       throw new ParseError(
         `Versus cannot be used as a meta-expression`,


### PR DESCRIPTION
Replaced the three duplicated `while (node.type === 'Grouped')` loops in `rejectSuccessCountTarget`, `rejectGroupTarget`, and `rejectVersusTarget` with a shared `unwrapTransparent(node, kinds)` helper.

- Added `unwrapTransparent` and `TransparentWrapperKind` (`Grouped` / `Modifier` / `Sort` / `CritThreshold`) in `src/parser/ast.ts`.
- Widened `rejectGroupTarget` to walk the full wrapper set, fixing the silent bypass where `cs` / `cf` / `!` / `r` over a modifier-wrapped group (e.g. `{1d6}kh1cs>5`) was accepted at parse time.
- Documented the narrow `Grouped`-only sets retained for `rejectSuccessCountTarget` and `rejectVersusTarget` — broader wrappers are unreachable because their parsers reject the inner `SuccessCount` / `Versus` upstream.
- Added rejection tests for `{1d6}kh1!`, `{1d6}kh1r<2`, `{1d6}s!`, `{1d6}kh1cs>5`, `{1d6}kh1cf<2`.

Closes #92

<sub>Drafted with AI assistance</sub>
