### PR TITLE
fix: Fate cf default flags +1 face as fumble #93

### DIFF
--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -2316,6 +2316,12 @@ describe('Parser', () => {
         );
       });
 
+      it('should accept Fate dice with custom fail threshold', () => {
+        expect(parse('4dFcf=-1')).toEqual(
+          critThreshold([], [cp('=', unary(literal(1)))], fateDice(literal(4))),
+        );
+      });
+
       it('should allow SuccessCount to wrap CritThreshold', () => {
         // CritThreshold contains a dice pool — SuccessCount's pool check passes.
         expect(parse('10d10cs>8>=6')).toEqual(
@@ -2419,6 +2425,43 @@ describe('Parser', () => {
 
       it('should reject cs on a function call over literals', () => {
         expect(() => parse('floor(5)cs>3')).toThrow(ParseError);
+      });
+
+      it('should reject bare cs on Fate dice pool', () => {
+        // Fate results are `{-1, 0, +1}`; the default crit sentinel assumes
+        // max-side semantics that don't apply. Custom thresholds remain valid.
+        expect(() => parse('4dFcs')).toThrow(ParseError);
+        try {
+          parse('4dFcs');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+          expect((e as ParseError).message).toContain('Fate');
+        }
+      });
+
+      it('should reject bare cf on Fate dice pool', () => {
+        // Without this guard, the default fumble check (`result === 1`) flips
+        // a `+1` Fate face into a fumble — a semantic inversion.
+        expect(() => parse('4dFcf')).toThrow(ParseError);
+        try {
+          parse('4dFcf');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+          expect((e as ParseError).message).toContain('Fate');
+        }
+      });
+
+      it('should reject bare cf chained after custom cs on Fate pool', () => {
+        // ? `containsFatePool` recurses through `CritThreshold`, so the bare
+        //   `cf` is caught even when the target is already a wrapping crit
+        //   threshold node from a custom success threshold.
+        expect(() => parse('4dFcs>0cf')).toThrow(ParseError);
+        try {
+          parse('4dFcs>0cf');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+          expect((e as ParseError).message).toContain('Fate');
+        }
       });
     });
   });

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -706,6 +706,20 @@ export class Parser {
       );
     }
 
+    // Bare `cs`/`cf` resolve to a per-die default that assumes max-side / 1
+    // semantics — incompatible with Fate dice (`{-1, 0, +1}`), where the bare
+    // fumble check would flip the best face (`+1`) into a fumble. Custom
+    // thresholds with explicit ComparePoints remain accepted. Mirrors the
+    // Fate-explosion rejection above.
+    if (!this.isComparePointAhead() && containsFatePool(target)) {
+      throw new ParseError(
+        `Bare cs/cf cannot apply to Fate dice`,
+        'INVALID_CRIT_THRESHOLD_TARGET',
+        token.position,
+        token,
+      );
+    }
+
     const threshold: CritThreshold = this.isComparePointAhead()
       ? this.parseComparePoint()
       : 'default';


### PR DESCRIPTION
Rejected bare `cs` / `cf` (no ComparePoint) at parse time when the target wraps a Fate pool — `4dFcs`, `4dFcf`, and chained `4dFcs>0cf` now throw `ParseError(INVALID_CRIT_THRESHOLD_TARGET)` with message `Bare cs/cf cannot apply to Fate dice`.

The default crit/fumble sentinel in `applyCritThresholds` assumes max-face / `result === 1` semantics; on Fate dice (`{-1, 0, +1}`), the default fumble check flipped a `+1` face into a fumble. Parse-time rejection mirrors the existing `4dF!` Fate-explosion guard and makes the asymmetric evaluator path unreachable.

- Added `containsFatePool(target)` guard in `parseCritThreshold` (after `containsDicePool`, before threshold parsing).
- Added parser tests covering accept (`4dFcf=-1`) and reject (`4dFcs`, `4dFcf`, chained `4dFcs>0cf`) paths.

Custom thresholds (`4dFcs>0`, `4dFcf=-1`) and non-Fate defaults (`1d20cs`, `1d20cf`) remain accepted.

Closes #93

<sub>Drafted with AI assistance</sub>
