### PR TITLE
docs: document RNG draw-order across modifier types #94

### DIFF
--- a/.claude/rules/rng.md
+++ b/.claude/rules/rng.md
@@ -36,9 +36,16 @@ mock.nextInt(1, 6); // Throws! (sequence exhausted)
 When authoring `MockRNG` sequences for dice expressions, follow this order:
 
 1. **Inside `evalDice`**: `count` expression → `sides` expression → pool dice (one `nextInt` per die, left-to-right).
-2. **Inside `flattenModifierChain`**: modifier-argument meta-expressions are drawn **before** the base dice pool. For `4d6kh(1d2)` the inner `1d2` draws first, then the `4d6` pool.
+2. **Inside `flattenModifierChain` (keep/drop modifiers)**: modifier-argument meta-expressions are drawn **before** the base dice pool. Applies to `kh`, `kl`, `dh`, `dl`. For `4d6kh(1d2)` the inner `1d2` draws first, then the `4d6` pool.
+3. **Inside threshold-style modifier evaluators**: the target dice pool is drawn **before** any threshold meta-expressions. Applies to `evalExplode` (`!`, `!!`, `!p`), `evalReroll` (`r`, `ro`), `evalCritThreshold` (`cs`, `cf`), and `evalSuccessCount` (`>`, `<`, `=` success counters with optional `f` failure threshold). For `4d6cs>(1d2)` the `4d6` pool draws first, then the `1d2` threshold meta.
 
-Worked example — `4d6kh(1d2)` with `createMockRng([1, 5, 3, 4, 6])`:
+### Why the asymmetry
+
+Keep/drop modifiers need their counts up-front to drive selection on the produced pool — `flattenModifierChain` resolves all modifier args before `evalModifier` rolls the base dice. Threshold-style modifiers post-process a pool that already exists (marking dice as exploded/rerolled/critical/successful), so threshold evaluation can be deferred until after the pool is rolled.
+
+### Worked example — keep/drop
+
+`4d6kh(1d2)` with `createMockRng([1, 5, 3, 4, 6])`:
 
 | Draw | Source | Value |
 |------|--------|-------|
@@ -49,6 +56,20 @@ Worked example — `4d6kh(1d2)` with `createMockRng([1, 5, 3, 4, 6])`:
 | 5 | `4d6` pool, die 4 | `6` |
 
 Kept result: `6` (highest of `[5, 3, 4, 6]`).
+
+### Worked example — threshold
+
+`4d6cs>(1d2)` with `createMockRng([5, 3, 4, 6, 1])`:
+
+| Draw | Source | Value |
+|------|--------|-------|
+| 1 | `4d6` pool, die 1 | `5` |
+| 2 | `4d6` pool, die 2 | `3` |
+| 3 | `4d6` pool, die 3 | `4` |
+| 4 | `4d6` pool, die 4 | `6` |
+| 5 | `1d2` (crit-success-threshold meta-expression) | `1` |
+
+Crit threshold resolves to `>1`; all four dice qualify as critical successes. Total: `18`.
 
 ## Usage in Tests
 


### PR DESCRIPTION
Documents the asymmetric RNG draw order between keep/drop and threshold-style modifier evaluators in `.claude/rules/rng.md`.

- Extended `Draw Order` section with a third rule covering `evalExplode`, `evalReroll`, `evalCritThreshold`, `evalSuccessCount` — target pool draws before threshold meta-expressions.
- Added rationale paragraph explaining the asymmetry: keep/drop needs counts up-front to drive selection; threshold modifiers post-process an existing pool.
- Added worked example for `4d6cs>(1d2)` mirroring the existing `4d6kh(1d2)` table.

Closes #94

<sub>Drafted with AI assistance</sub>
