### PR TITLE
docs: surface Stage 3 user-facing footguns in README and CHANGELOG #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parser now rejects `SuccessCount` wrapped in meta-expression positions — modifier count, dice count/sides (infix and prefix), Fate/percentile dice count, SuccessCount threshold and bare `fN` value, and compare-point values used by Explode/Reroll. `mergeMetaRolls` also strips `success`/`failure` modifier tags on meta-forwarded dice as defense-in-depth ([#69](https://github.com/edloidas/roll-parser/issues/69))
 - Parser now rejects `Versus` wrapped in the same meta-expression positions so a PF2e `vs` outcome cannot be silently dropped by `mergeMetaRolls`, and the `parseVersus` chain guard unwraps `Grouped` so `(1d20 vs 15) vs 10` throws `NESTED_VERSUS` at parse time instead of at eval ([#70](https://github.com/edloidas/roll-parser/issues/70))
 
+### Notes
+
+These are intentional behaviours documented for the first time, not changes — semantics are unchanged.
+
+- `cs`/`cf` use replace semantics on `critical`/`fumble`: supplying only `cf<3` clears default crit on a natural 20. Chain `cs` first (`1d20cscf<3`) to keep the default crit alongside a custom fumble ([#96](https://github.com/edloidas/roll-parser/issues/96))
+- Sort flattens additive pools: `(2d6+1d8)s` renders as one combined sorted list rather than per-pool brackets. Same applies to wrapped pools like `floor(4d6)s`. Totals are preserved ([#96](https://github.com/edloidas/roll-parser/issues/96))
+- Outer parens drop from `result.expression` when chained `cs`/`cf` thresholds collapse: `(1d20cs>19)cs=1` renders as `1d20cs>19cs=1`. Re-parses to the same AST; only the textual form differs ([#96](https://github.com/edloidas/roll-parser/issues/96))
+
 ## [3.0.0-alpha.0] - 2026-04-20
 
 First alpha of the v3 rewrite. Stage 1 (core engine) is complete; Stage 2 (dice mechanics) is largely in place.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ roll-parser --help
   The round-trip property test does not exercise meta-expressions, so the
   gap is invisible to CI. Do not rely on `result.expression` as a faithful
   re-parseable form when your notation contains meta-expressions.
+- **`cs`/`cf` use replace semantics on `critical`/`fumble`.** Supplying only
+  `cf<3` clears every die's `critical` to `false` — including a natural 20
+  on `1d20cf<3` — because the empty `successThresholds` array overrides the
+  default crit. Chain `cs` first to preserve the default crit alongside a
+  custom fumble: `1d20cscf<3`.
+- **Sort flattens additive pools and drops per-pool brackets.** `(2d6+1d8)s`
+  renders the combined pool as one sorted list — `(2d6 + 1d8)s[3, 4, 5]` —
+  rather than the per-pool form `2d6[3, 4] + 1d8[5]` that bare `2d6+1d8`
+  produces. The same flattening applies inside wrapped pools like
+  `floor(4d6)s`. Totals are preserved; only the rendered breakdown loses
+  pool boundaries.
+- **Outer parens drop from `result.expression` after threshold collapse.**
+  `(1d20cs>19)cs=1` evaluates with `result.expression = '1d20cs>19cs=1'`
+  because chained `cs` thresholds collapse into a single `CritThresholdNode`
+  with merged thresholds. The notation re-parses to the same AST, so
+  behaviour is harmless — but tools diffing the original notation against
+  `expression` will see a spurious change.
 
 ## License
 


### PR DESCRIPTION
Documents three intentional Stage 3 behaviours that surprise users without a written note. No code changes.

- Added three notes to `README.md` Known Limitations: `cs`/`cf` replace semantics on `critical`/`fumble`, sort flattening across additive pools, and outer-paren drop in `result.expression` after threshold collapse.
- Added `### Notes` subsection to `CHANGELOG.md` `[Unreleased]` mirroring the same three behaviours, framed as intended (not breaking).

Closes #96

<sub>Drafted with AI assistance</sub>
