### PR TITLE
fix: cs/cf on modifier-wrapped group flags dropped sub-roll dice #97

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -3075,5 +3075,19 @@ describe('evaluate', () => {
       expect(getDie(result.rolls, 0).critical).toBe(true);
       expect(result.expression).toBe('1d20cs>19cs=1');
     });
+
+    test('single-sub-roll group passthrough — {1d20}kh1cs>18 matches 1d20kh1cs>18', () => {
+      // Stage 3 single-sub-roll passthrough: `{1d20}` is the documented
+      // flat-pool escape hatch and must produce the same total and per-die
+      // critical flags as the unwrapped form under the same RNG sequence.
+      const seq = [20, 17, 5, 1];
+      const grouped = evaluate(parse('{1d20}kh1cs>18'), createMockRng([...seq]));
+      const flat = evaluate(parse('1d20kh1cs>18'), createMockRng([...seq]));
+
+      expect(grouped.total).toBe(flat.total);
+      expect(grouped.rolls.map((d) => d.result)).toEqual(flat.rolls.map((d) => d.result));
+      expect(grouped.rolls.map((d) => d.critical)).toEqual(flat.rolls.map((d) => d.critical));
+      expect(grouped.rolls.map((d) => d.fumble)).toEqual(flat.rolls.map((d) => d.fumble));
+    });
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -804,8 +804,8 @@ describe('roll() integration', () => {
       expect(() => roll('5cs', { rng: createMockRng([]) })).toThrow(ParseError);
     });
 
-    test('rejects cs on a group at parse time', () => {
-      expect(() => roll('{1d6}cs>5', { rng: createMockRng([]) })).toThrow(ParseError);
+    test('rejects cs on a multi-sub-roll group at parse time', () => {
+      expect(() => roll('{1d6, 2d8}cs>5', { rng: createMockRng([]) })).toThrow(ParseError);
     });
   });
 });

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -2331,6 +2331,47 @@ describe('Parser', () => {
           ),
         );
       });
+
+      // Single-sub-roll groups are the documented flat-pool escape hatch
+      // (STAGE3.md "Group Semantics: Single vs Multi Sub-Roll") and pass
+      // through to cs/cf as if they were the unwrapped form.
+      it('should accept cs on a single-sub-roll group: {1d6}cs>5', () => {
+        expect(parse('{1d6}cs>5')).toEqual(
+          critThreshold([cp('>', literal(5))], [], group([dice(literal(1), literal(6))])),
+        );
+      });
+
+      it('should accept cf on a single-sub-roll group: {1d6}cf<2', () => {
+        expect(parse('{1d6}cf<2')).toEqual(
+          critThreshold([], [cp('<', literal(2))], group([dice(literal(1), literal(6))])),
+        );
+      });
+
+      it('should accept cs on a parens-wrapped single-sub-roll group: ({1d6})cs>5', () => {
+        expect(parse('({1d6})cs>5')).toEqual(
+          critThreshold([cp('>', literal(5))], [], grouped(group([dice(literal(1), literal(6))]))),
+        );
+      });
+
+      it('should accept cs on a modifier-wrapped single-sub-roll group: {1d20}kh1cs>18', () => {
+        expect(parse('{1d20}kh1cs>18')).toEqual(
+          critThreshold(
+            [cp('>', literal(18))],
+            [],
+            modifier('keep', 'highest', literal(1), group([dice(literal(1), literal(20))])),
+          ),
+        );
+      });
+
+      it('should accept cf on a modifier-wrapped single-sub-roll group: {1d6}kh1cf<2', () => {
+        expect(parse('{1d6}kh1cf<2')).toEqual(
+          critThreshold(
+            [],
+            [cp('<', literal(2))],
+            modifier('keep', 'highest', literal(1), group([dice(literal(1), literal(6))])),
+          ),
+        );
+      });
     });
 
     describe('errors', () => {
@@ -2359,47 +2400,57 @@ describe('Parser', () => {
         }
       });
 
-      it('should reject cs on a single-sub-roll group', () => {
-        expect(() => parse('{1d6}cs>5')).toThrow(ParseError);
-        try {
-          parse('{1d6}cs>5');
-        } catch (e) {
-          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
-          expect((e as ParseError).message).toContain('group');
-        }
-      });
-
       it('should reject cs on a multi-sub-roll group', () => {
         expect(() => parse('{1d6, 2d8}cs>5')).toThrow(ParseError);
-      });
-
-      it('should reject cs on parens-wrapped group', () => {
-        expect(() => parse('({1d6})cs>5')).toThrow(ParseError);
         try {
-          parse('({1d6})cs>5');
-        } catch (e) {
-          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
-        }
-      });
-
-      it('should reject cf on a group', () => {
-        expect(() => parse('{1d6}cf<2')).toThrow(ParseError);
-      });
-
-      it('should reject cs on a modifier-wrapped group: {1d6}kh1cs>5', () => {
-        expect(() => parse('{1d6}kh1cs>5')).toThrow(ParseError);
-        try {
-          parse('{1d6}kh1cs>5');
+          parse('{1d6, 2d8}cs>5');
         } catch (e) {
           expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
           expect((e as ParseError).message).toContain('group');
         }
       });
 
-      it('should reject cf on a modifier-wrapped group: {1d6}kh1cf<2', () => {
-        expect(() => parse('{1d6}kh1cf<2')).toThrow(ParseError);
+      it('should reject cf on a multi-sub-roll group', () => {
+        expect(() => parse('{1d6, 2d8}cf<2')).toThrow(ParseError);
+      });
+
+      it('should reject cs on a parens-wrapped multi-sub-roll group', () => {
+        expect(() => parse('({1d6, 2d8})cs>5')).toThrow(ParseError);
         try {
-          parse('{1d6}kh1cf<2');
+          parse('({1d6, 2d8})cs>5');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+        }
+      });
+
+      it('should reject cs on a modifier-wrapped multi-sub-roll group: {1d20, 1d20}kh1cs>18', () => {
+        // Without the unwrap-through-Modifier check, the evaluator overrides
+        // critical/fumble on dropped sub-roll dice from each branch.
+        expect(() => parse('{1d20, 1d20}kh1cs>18')).toThrow(ParseError);
+        try {
+          parse('{1d20, 1d20}kh1cs>18');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+          expect((e as ParseError).message).toContain('group');
+        }
+      });
+
+      it('should reject cf on a modifier-wrapped multi-sub-roll group: {1d20, 1d20}kh1cf<3', () => {
+        expect(() => parse('{1d20, 1d20}kh1cf<3')).toThrow(ParseError);
+        try {
+          parse('{1d20, 1d20}kh1cf<3');
+        } catch (e) {
+          expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
+        }
+      });
+
+      it('should reject cs on a parens-wrapped modifier-wrapped multi-sub-roll group', () => {
+        // ? Acceptance criterion 5 from #97 — Grouped wrapper around the
+        //   Modifier(Group([...])) chain still resolves to a Group via the
+        //   shared unwrap.
+        expect(() => parse('({1d20, 1d20}kh1)cs>18')).toThrow(ParseError);
+        try {
+          parse('({1d20, 1d20}kh1)cs>18');
         } catch (e) {
           expect((e as ParseError).code).toBe('INVALID_CRIT_THRESHOLD_TARGET');
         }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -491,17 +491,25 @@ export class Parser {
    * semantics. Walks `Grouped`/`Modifier`/`Sort`/`CritThreshold` so wrappers
    * cannot smuggle a group past the check (`{1d6}kh1cs>5`, `({1d6})!`,
    * `{1d6}scs>5` all reject the same as `{1d6}!`/`{1d6}cs>5`).
+   *
+   * `singleSubRollPasses` opts the caller into the Stage 3 single-sub-roll
+   * passthrough rule (STAGE3.md "Group Semantics: Single vs Multi Sub-Roll"):
+   * a `Group` with one expression is the user's explicit flat-pool escape
+   * hatch and is equivalent to its unwrapped form. Currently only
+   * `parseCritThreshold` opts in — explode/reroll keep the strict reject so
+   * existing notation contracts don't shift.
    */
   private rejectGroupTarget(
     target: ASTNode,
     token: Token,
     action: string,
     code: RollParserErrorCode,
+    singleSubRollPasses = false,
   ): void {
     const node = unwrapTransparent(target, ['Grouped', 'Modifier', 'Sort', 'CritThreshold']);
-    if (node.type === 'Group') {
-      throw new ParseError(`Cannot ${action} a group`, code, token.position, token);
-    }
+    if (node.type !== 'Group') return;
+    if (singleSubRollPasses && node.expressions.length === 1) return;
+    throw new ParseError(`Cannot ${action} a group`, code, token.position, token);
   }
 
   private rejectVersusTarget(target: ASTNode, token: Token): void {
@@ -683,14 +691,18 @@ export class Parser {
     this.rejectSuccessCountTarget(target, token);
     this.rejectVersusTarget(target, token);
 
-    // Groups have no crit-threshold semantics per Stage 3 spec — a group is a
-    // container of sub-expressions, not a dice pool. Must run before
+    // Multi-sub-roll groups have no crit-threshold semantics per Stage 3 spec
+    // — a group there is a container of sub-roll subtotals, not a dice pool,
+    // and applying cs/cf would override `critical`/`fumble` on dropped
+    // sub-roll dice. Single-sub-roll groups pass through under the documented
+    // flat-pool rule (`{1d20}kh1cs>18` ≡ `(1d20)kh1cs>18`). Must run before
     // `containsDicePool`, which recurses into `Group`.
     this.rejectGroupTarget(
       target,
       token,
       'apply crit threshold to',
       'INVALID_CRIT_THRESHOLD_TARGET',
+      true,
     );
 
     // Shallow dice-pool check (bare dice only) — rejects `(1d6+2d8)cs>5`,


### PR DESCRIPTION
Allows single-sub-roll groups to pass through `parseCritThreshold` while continuing to reject multi-sub-roll groups, so `{1d20}kh1cs>18` evaluates as `1d20kh1cs>18` and `{1d20, 1d20}kh1cs>18` rejects with `INVALID_CRIT_THRESHOLD_TARGET`.

- Extended `rejectGroupTarget` with an opt-in `singleSubRollPasses` flag; only `parseCritThreshold` opts in, so explode/reroll keep their strict group rejection.
- Updated `parseCritThreshold` to call `rejectGroupTarget(..., true)` and clarified the inline comment with the dropped-sub-roll-dice rationale.
- Flipped five parser error tests covering `{1d6}cs>5`, `({1d6})cs>5`, `{1d6}cf<2`, `{1d6}kh1cs>5`, `{1d6}kh1cf<2` from reject to accept, asserting the resulting `CritThreshold(Modifier(Group([...])))` AST shape.
- Added explicit reject coverage in `parser.test.ts` for the multi-sub-roll variants from the issue's acceptance criteria (`{1d6, 2d8}cs>5`, `{1d6, 2d8}cf<2`, `({1d6, 2d8})cs>5`, `{1d20, 1d20}kh1cs>18`, `{1d20, 1d20}kh1cf<3`, `({1d20, 1d20}kh1)cs>18`).
- Added an evaluator round-trip test asserting identical `total` and per-die `critical`/`fumble` flags between `{1d20}kh1cs>18` and `1d20kh1cs>18` under a shared MockRNG sequence.
- Updated the integration test that asserted parse-time rejection of `{1d6}cs>5` to use the multi-sub-roll case.

Closes #97

<sub>Drafted with AI assistance</sub>
