### PR TITLE
fix: evalGroupModifier surfaces versusMetadata from dropped sub-rolls #99

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -2677,6 +2677,44 @@ describe('evaluate', () => {
         const d8s = result.rolls.filter((d) => d.sides === 8);
         expect(d8s.map((d) => d.result)).toEqual([5, 6]);
       });
+
+      test('dropped versus sub-roll does not propagate degree', () => {
+        // Subtotals: [5, 18] — kh1 keeps sub 1 (1d20=18), drops sub 0 (1d20 vs 15).
+        // The dropped vs sub-roll's degree must NOT surface on the result.
+        const ast = parse('{1d20 vs 15, 1d20}kh1');
+        const rng = createMockRng([5, 18]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(18);
+        expect(result.degree).toBeUndefined();
+      });
+
+      test('kept versus sub-roll propagates degree', () => {
+        // Subtotals: [18, 5] — kh1 keeps sub 0 (1d20 vs 15, d20=18), drops sub 1.
+        // 18 >= 15 (Success); not >= 25, so no Critical upgrade.
+        const ast = parse('{1d20 vs 15, 1d20}kh1');
+        const rng = createMockRng([18, 5]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(18);
+        expect(result.degree).toBe(DegreeOfSuccess.Success);
+      });
+
+      test('two kept versus sub-rolls still throw NESTED_VERSUS', () => {
+        // kh2 on a 3-sub group keeps subs 0 and 1 (subtotals 18, 6 — sub 2 d4=4
+        // dropped). Both kept subs carry versus metadata, so propagation must
+        // collide via the NESTED_VERSUS guard.
+        const ast = parse('{1d20 vs 15, 1d6 vs 10, 1d4}kh2');
+        const rng = createMockRng([18, 6, 4]);
+
+        try {
+          evaluate(ast, rng);
+          throw new Error('expected evaluate to throw');
+        } catch (err) {
+          expect(err).toBeInstanceOf(EvaluatorError);
+          expect((err as EvaluatorError).code).toBe('NESTED_VERSUS');
+        }
+      });
     });
 
     describe('group inside arithmetic', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -988,11 +988,13 @@ function evalGroupModifier(
       total += sub.subtotal;
     }
 
-    // Propagate Versus metadata from kept OR dropped sub-rolls — dropping
-    // a sub-roll doesn't make its degree result disappear; two versus
-    // results in the same group still collide via the same guard used by
-    // `mergeContext`.
-    propagateMetadata(ctx, sub.versusMetadata);
+    // Propagate Versus metadata only from kept sub-rolls — `RollResult.degree`
+    // must reflect dice that contributed to `RollResult.total`. Two kept
+    // versus sub-rolls still collide here via the `NESTED_VERSUS` guard
+    // inside `propagateMetadata`.
+    if (!isDropped) {
+      propagateMetadata(ctx, sub.versusMetadata);
+    }
   }
 
   const subExprStrs = subRolls.map((s) => s.expr);


### PR DESCRIPTION
Gated `propagateMetadata` in `evalGroupModifier` on `!isDropped` so dropped sub-rolls' Versus metadata no longer surfaces on `RollResult.degree`. The unconditional propagation contradicted the invariant that `degree` must reflect dice contributing to `total` — `kh`/`kl`/`dh`/`dl` over a Group with a `vs` sub-roll could leak the dropped outcome's degree.

- Wrapped the per-sub `propagateMetadata` call in `if (!isDropped) { … }` and rewrote the inline comment to reflect kept-only propagation and the surviving `NESTED_VERSUS` collision path.
- Added three tests under `sub-roll mode (multi sub-roll with keep/drop)`: dropped `vs` sub leaves `degree` undefined, kept `vs` sub propagates `Success`, two kept `vs` subs (3-sub group with `kh2`) still throw `NESTED_VERSUS`.

Closes #99

<sub>Drafted with AI assistance</sub>
