### PR TITLE
test: strengthen weak assertions in test suite #116

### DIFF
--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -49,11 +49,11 @@ describe('CLI integration', () => {
   });
 
   test('--verbose shows rendered breakdown', async () => {
+    // Deterministic with --seed test: rolls [3, 6, 3, 3], kh3 keeps {6, 3, 3} = 12,
+    // dropped die is rendered as `(3)`.
     const { stdout, exitCode } = await runCli(['4d6kh3', '--verbose', '--seed', 'test']);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('4d6');
-    expect(stdout).toContain('[');
-    expect(stdout).toContain('=');
+    expect(stdout.trim()).toBe('4d6[3, 6, 3, (3)] = 12');
   });
 
   test('verbose mode shows dropped dice in parentheses', async () => {

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -873,17 +873,18 @@ describe('evaluate', () => {
       expect(result.rolls).toHaveLength(0);
     });
 
-    test('invalid maxDice falls back to default', () => {
-      const ast = parse('3d6');
-      const vals = [1, 2, 3];
+    test('invalid maxDice falls back to DEFAULT_MAX_DICE', () => {
+      // Roll DEFAULT_MAX_DICE+1 dice with invalid maxDice values and assert the
+      // resulting error message references DEFAULT_MAX_DICE — proves the
+      // fallback used the documented default and not Infinity (would not throw)
+      // or some other value (different limit in the message).
+      const overCount = DEFAULT_MAX_DICE + 1;
+      const ast = parse(`${overCount}d6`);
+      const expectedMsg = `Total dice count ${overCount} exceeds limit of ${DEFAULT_MAX_DICE}`;
 
-      // NaN, negative, Infinity, zero — all fall back to DEFAULT_MAX_DICE
-      expect(() => evaluate(ast, createMockRng(vals), { maxDice: Number.NaN })).not.toThrow();
-      expect(() => evaluate(ast, createMockRng(vals), { maxDice: -1 })).not.toThrow();
-      expect(() =>
-        evaluate(ast, createMockRng(vals), { maxDice: Number.POSITIVE_INFINITY }),
-      ).not.toThrow();
-      expect(() => evaluate(ast, createMockRng(vals), { maxDice: 0 })).not.toThrow();
+      for (const maxDice of [Number.NaN, -1, Number.POSITIVE_INFINITY, 0]) {
+        expect(() => evaluate(ast, createMockRng([]), { maxDice })).toThrow(expectedMsg);
+      }
     });
 
     test('float maxDice is floored', () => {
@@ -1892,7 +1893,8 @@ describe('evaluate', () => {
       const rng = createMockRng([12]);
       const result = evaluate(ast, rng);
 
-      expect(result.degree).toBeDefined();
+      // 1d20+5=17 vs DC=20 → 17 < 20 and 17 > dc-10=10 → Failure.
+      expect(result.degree).toBe(DegreeOfSuccess.Failure);
       expect(result.natural).toBe(12);
     });
 

--- a/src/rng/rng.test.ts
+++ b/src/rng/rng.test.ts
@@ -76,33 +76,33 @@ describe('SeededRNG', () => {
       }
     });
 
-    it('should handle floating-point seeds (truncates to integer)', () => {
-      const rng1 = new SeededRNG(42.999);
-      const rng2 = new SeededRNG(42.999);
+    it('should handle floating-point seeds (truncates via uint32 coercion)', () => {
+      // `42.999 >>> 0 === 42`, so SeededRNG(42.999) must match SeededRNG(42).
+      const fractional = new SeededRNG(42.999);
+      const truncated = new SeededRNG(42);
 
-      // Should produce consistent results
       for (let i = 0; i < 10; i++) {
-        expect(rng1.nextInt(1, 100)).toBe(rng2.nextInt(1, 100));
+        expect(fractional.nextInt(1, 100)).toBe(truncated.nextInt(1, 100));
       }
     });
 
     it('should handle NaN seed (treated as 0)', () => {
-      const rng1 = new SeededRNG(Number.NaN);
-      const rng2 = new SeededRNG(Number.NaN);
+      // `NaN >>> 0 === 0`, so SeededRNG(NaN) must match SeededRNG(0).
+      const nanSeed = new SeededRNG(Number.NaN);
+      const zeroSeed = new SeededRNG(0);
 
-      // NaN >>> 0 === 0, so both should behave like seed 0
       for (let i = 0; i < 10; i++) {
-        expect(rng1.nextInt(1, 100)).toBe(rng2.nextInt(1, 100));
+        expect(nanSeed.nextInt(1, 100)).toBe(zeroSeed.nextInt(1, 100));
       }
     });
 
-    it('should handle Infinity seed', () => {
-      const rng1 = new SeededRNG(Number.POSITIVE_INFINITY);
-      const rng2 = new SeededRNG(Number.POSITIVE_INFINITY);
+    it('should handle Infinity seed (treated as 0)', () => {
+      // `Infinity >>> 0 === 0`, so SeededRNG(Infinity) must match SeededRNG(0).
+      const infSeed = new SeededRNG(Number.POSITIVE_INFINITY);
+      const zeroSeed = new SeededRNG(0);
 
-      // Infinity >>> 0 === 0
       for (let i = 0; i < 10; i++) {
-        expect(rng1.nextInt(1, 100)).toBe(rng2.nextInt(1, 100));
+        expect(infSeed.nextInt(1, 100)).toBe(zeroSeed.nextInt(1, 100));
       }
     });
 
@@ -172,21 +172,27 @@ describe('SeededRNG', () => {
       }
     });
 
-    it('should handle min === max', () => {
+    it('should handle min === max without consuming RNG state', () => {
       const rng = new SeededRNG(42);
+      const reference = new SeededRNG(42);
 
       for (let i = 0; i < 100; i++) {
         expect(rng.nextInt(5, 5)).toBe(5);
       }
+
+      // Trivial-range early-return must not advance state — the next
+      // non-trivial draw must match a fresh RNG with the same seed.
+      expect(rng.nextInt(1, 6)).toBe(reference.nextInt(1, 6));
     });
 
     it('should handle inverted bounds (swap min/max)', () => {
-      const rng = new SeededRNG(42);
+      // nextInt(10, 1) must produce the same sequence as nextInt(1, 10) on the
+      // same seed — bounds normalization, not just clamping to range.
+      const inverted = new SeededRNG(42);
+      const normal = new SeededRNG(42);
 
       for (let i = 0; i < 100; i++) {
-        const value = rng.nextInt(10, 1);
-        expect(value).toBeGreaterThanOrEqual(1);
-        expect(value).toBeLessThanOrEqual(10);
+        expect(inverted.nextInt(10, 1)).toBe(normal.nextInt(1, 10));
       }
     });
 
@@ -516,7 +522,7 @@ describe('MockRNG', () => {
 
       try {
         rng.nextInt(1, 6);
-        expect(true).toBe(false); // Should not reach here
+        expect.unreachable('expected MockRNGExhaustedError');
       } catch (e) {
         expect(e).toBeInstanceOf(MockRNGExhaustedError);
         expect((e as MockRNGExhaustedError).consumed).toBe(3);
@@ -535,7 +541,7 @@ describe('MockRNG', () => {
 
       try {
         rng.nextInt(1, 6);
-        expect(true).toBe(false);
+        expect.unreachable('expected MockRNGExhaustedError');
       } catch (e) {
         expect((e as MockRNGExhaustedError).consumed).toBe(0);
       }


### PR DESCRIPTION
Audited the test suite for assertions weak enough to let real regressions pass and tightened the worst offenders. Test-only changes — no production code touched.

- `SeededRNG` float / `NaN` / `Infinity` seed tests now assert documented uint32 coercion (`SeededRNG(42.999)` matches `SeededRNG(42)`; `NaN` and `Infinity` match `0`) instead of only same-seed reproducibility.
- `nextInt(min === max)` test asserts the trivial-range early-return does not advance RNG state; inverted-bounds test asserts `nextInt(10, 1)` produces the same sequence as `nextInt(1, 10)`.
- `invalid maxDice falls back to default` rolls `DEFAULT_MAX_DICE+1` dice and asserts the error message references `DEFAULT_MAX_DICE` — proves the fallback used the documented default and not `Infinity`, `0`, or any other value.
- `max(1d20+5 vs 20, 0)` versus-propagation test asserts `DegreeOfSuccess.Failure` instead of `toBeDefined()`.
- CLI `--verbose` test asserts the exact deterministic seeded output (`4d6[3, 6, 3, (3)] = 12`) instead of three loose `toContain` checks.
- Two `MockRNG` exhaustion tests use `expect.unreachable(...)` instead of `expect(true).toBe(false)` for diagnostic failure messages.

Closes #116

<sub>Drafted with AI assistance</sub>
