### PR TITLE
fix: stabilize evaluate bench group and variable-work cases #143

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,10 +637,14 @@ Types resolve under `moduleResolution: node16` / `nodenext`, verified in CI by
 (`.gc('inner')`), averaged over two full `bun run bench:json` passes that agreed
 within 15%. Measured 2026-07-27 on Bun 1.3.11, Intel Xeon @ 2.80 GHz, 4 vCPU
 container. p50 rather than mean, because the mean here is effectively a GC-pause
-histogram and swings ±40% between processes. The `roll` column pays for a fresh
+histogram and swings ±40% between processes. Every bench body is JIT-primed
+before measurement and pinned to mitata's batched sampling mode, so all cases
+are timed the same way — mitata otherwise picks the mode from cold calls and
+mis-times mid-weight cases by 10-30x. The `roll` column pays for a fresh
 `SeededRNG` per call, which an injected RNG avoids. Every roll also builds the
 `parts` tree; there is no opt-out and these numbers include it. A 1000-die pool
-costs roughly 130 µs, while lexing and parsing stay flat at ~0.14 / ~0.36 µs.
+costs roughly 60x a `1d20` (~90 µs here), while lexing and parsing stay flat at
+~0.14 / ~0.36 µs.
 
 Run `bun run bench` for the full suite, or `bench:lex` / `bench:parse` /
 `bench:evaluate` / `bench:roll` for one stage. Bundle size is gated in CI by

--- a/bench/_cases.ts
+++ b/bench/_cases.ts
@@ -29,6 +29,10 @@ export type BenchCase = {
    * Marks cases whose dice count depends on rolled values (explode, reroll).
    * Those must never share an RNG across iterations — the work per iteration
    * would drift with the RNG stream and smear the distribution into modes.
+   *
+   * ? Only `roll (injected RNG)` shares one; every other group reseeds per
+   *   iteration, so this flag is not why those cases used to read multi-modal
+   *   there — see {@link primeBenchFn}.
    */
   variableWork?: boolean;
 };
@@ -91,6 +95,18 @@ export function getRollOptions(benchCase: BenchCase): RollOptions {
 
 const WARMUP_ITERATIONS = 100;
 
+/**
+ * Bounds on the per-bench priming loop. The minimum is what buys JIT tier-up;
+ * the budget stops heavy cases (`1000d6kh500` at ~420 µs/iter) from spending
+ * minutes on it.
+ */
+const PRIME_MIN_ITERATIONS = 64;
+const PRIME_MAX_ITERATIONS = 4096;
+const PRIME_BUDGET_MS = 25;
+
+/** Warm-up calls mitata makes before it commits to a sampling mode. */
+const MITATA_WARMUP_CALLS = 3;
+
 let hasWarmedUp = false;
 
 /**
@@ -112,4 +128,57 @@ export function warmUpPipeline(): void {
       evaluate(ast, new SeededRNG(BENCH_SEED), getEvaluateOptions(benchCase));
     }
   }
+}
+
+/** Runs `benchFn` until the JIT has tiered it up, bounded by time and count. */
+function tierUp(benchFn: () => void): void {
+  const deadline = performance.now() + PRIME_BUDGET_MS;
+
+  for (let iteration = 0; iteration < PRIME_MAX_ITERATIONS; iteration++) {
+    benchFn();
+
+    if (iteration >= PRIME_MIN_ITERATIONS && performance.now() >= deadline) break;
+  }
+}
+
+/**
+ * Tiers a bench body up and pins mitata to batch sampling for it. Every bench
+ * in this suite must go through this.
+ *
+ * mitata picks one of two sampling modes from its first three calls of the
+ * body: if any comes in at or under 65,536 ns it batches 4096 calls per sample,
+ * otherwise it times a single call per sample taken right after a full GC. The
+ * two are not comparable — a single post-GC call on a sub-10 µs body reads
+ * 10-30x its steady-state cost — and those three calls are *cold*, so a body
+ * reads 5-135 µs regardless of what it really costs. Mid-weight cases therefore
+ * picked a mode at random per process: `evaluate('4d6kh3')` reported 42-82 µs
+ * against a true 2.3 µs (below end-to-end `roll('4d6kh3')`, which is
+ * impossible), and `{2d20kh1+5, 3d8!}kh1` swung 1075% across five runs (#143).
+ *
+ * Two things fix that. The body is tiered up first — inside a generator body,
+ * which mitata runs immediately before those calls; {@link warmUpPipeline}
+ * cannot do it, because it warms the *library*, not the per-bench closure
+ * mitata actually times. Then the three warm-up calls are swallowed, so the
+ * mode is always batch, for every case, on every machine. That is the mode the
+ * whole suite was already reporting in but for a handful of heavy cases, and
+ * it is the stabler one even for those: `1000d6kh500` holds a 6% p50 spread
+ * batched against 8-12% single.
+ *
+ * ! Do not "simplify" this to `bench(id, () => …)` or drop the warm-up counter.
+ *   Either change hands the mode decision back to a cold measurement, and the
+ *   multi-modal p50s come back with it.
+ */
+export function primeBenchFn(benchFn: () => void): () => void {
+  tierUp(benchFn);
+
+  let warmUpCallsLeft = MITATA_WARMUP_CALLS;
+
+  return () => {
+    if (warmUpCallsLeft > 0) {
+      warmUpCallsLeft--;
+      return;
+    }
+
+    benchFn();
+  };
 }

--- a/bench/evaluate.bench.ts
+++ b/bench/evaluate.bench.ts
@@ -5,9 +5,14 @@
  *
  * A fresh `SeededRNG` is constructed inside every iteration. That charges each
  * sample a constant ~205 ns (isolated by the `roll` group's injected-RNG
- * variant), but it is the only way to give explode and reroll cases the same
- * RNG stream every iteration — a shared RNG lets them do different amounts of
- * work per sample and the distribution goes multi-modal.
+ * variant), but it is what makes every iteration replay the identical RNG
+ * stream, so even explode and reroll cases do byte-for-byte the same work per
+ * sample.
+ *
+ * Every bench body is handed to `primeBenchFn` before mitata sees it. Without
+ * that this group was the least trustworthy in the suite — `4d6kh3` reported
+ * 42-82 µs against a true 2.3 µs, and `{2d20kh1+5, 3d8!}kh1` swung 1075%
+ * between processes. See `primeBenchFn` for the mechanism (#143).
  *
  * Run with `bun run bench:evaluate`, or as part of `bun run bench`.
  */
@@ -19,6 +24,7 @@ import {
   BENCH_CASES,
   BENCH_SEED,
   getEvaluateOptions,
+  primeBenchFn,
   warmUpPipeline,
 } from './_cases.js';
 
@@ -31,8 +37,10 @@ export function registerEvaluateBenches(): void {
         const ast = parse(benchCase.notation);
         const options = getEvaluateOptions(benchCase);
 
-        bench(benchCase.id, () => {
-          do_not_optimize(evaluate(ast, new SeededRNG(BENCH_SEED), options));
+        bench(benchCase.id, function* () {
+          yield primeBenchFn(() => {
+            do_not_optimize(evaluate(ast, new SeededRNG(BENCH_SEED), options));
+          });
         })
           .gc('inner')
           .baseline(benchCase.id === BASELINE_ID);
@@ -47,9 +55,9 @@ export function registerEvaluateBenches(): void {
       const size = state.get('n');
       const ast = parse(`${size}d6`);
 
-      yield () => {
+      yield primeBenchFn(() => {
         do_not_optimize(evaluate(ast, new SeededRNG(BENCH_SEED), {}));
-      };
+      });
     })
       .range('n', 1, 1000, 10)
       .gc('inner');
@@ -58,9 +66,9 @@ export function registerEvaluateBenches(): void {
       const size = state.get('n');
       const ast = parse(`${size}d6kh${Math.max(1, Math.floor(size / 2))}`);
 
-      yield () => {
+      yield primeBenchFn(() => {
         do_not_optimize(evaluate(ast, new SeededRNG(BENCH_SEED), {}));
-      };
+      });
     })
       .range('n', 1, 1000, 10)
       .gc('inner');

--- a/bench/lex.bench.ts
+++ b/bench/lex.bench.ts
@@ -6,7 +6,7 @@
 
 import { bench, do_not_optimize, group, run, summary } from 'mitata';
 import { lex } from '../src/lexer/lexer.js';
-import { BASELINE_ID, BENCH_CASES, warmUpPipeline } from './_cases.js';
+import { BASELINE_ID, BENCH_CASES, primeBenchFn, warmUpPipeline } from './_cases.js';
 
 export function registerLexBenches(): void {
   warmUpPipeline();
@@ -14,8 +14,12 @@ export function registerLexBenches(): void {
   group('lex', () => {
     summary(() => {
       for (const { id, notation } of BENCH_CASES) {
-        bench(id, () => {
-          do_not_optimize(lex(notation));
+        // ? Generator form so `primeBenchFn` runs right before mitata's
+        //   warm-up — see its doc comment for why that is load-bearing.
+        bench(id, function* () {
+          yield primeBenchFn(() => {
+            do_not_optimize(lex(notation));
+          });
         })
           .gc('inner')
           .baseline(id === BASELINE_ID);

--- a/bench/parse.bench.ts
+++ b/bench/parse.bench.ts
@@ -6,7 +6,7 @@
 
 import { bench, do_not_optimize, group, run, summary } from 'mitata';
 import { parse } from '../src/index.js';
-import { BASELINE_ID, BENCH_CASES, warmUpPipeline } from './_cases.js';
+import { BASELINE_ID, BENCH_CASES, primeBenchFn, warmUpPipeline } from './_cases.js';
 
 export function registerParseBenches(): void {
   warmUpPipeline();
@@ -14,8 +14,12 @@ export function registerParseBenches(): void {
   group('parse', () => {
     summary(() => {
       for (const { id, notation } of BENCH_CASES) {
-        bench(id, () => {
-          do_not_optimize(parse(notation));
+        // ? Generator form so `primeBenchFn` runs right before mitata's
+        //   warm-up — see its doc comment for why that is load-bearing.
+        bench(id, function* () {
+          yield primeBenchFn(() => {
+            do_not_optimize(parse(notation));
+          });
         })
           .gc('inner')
           .baseline(id === BASELINE_ID);

--- a/bench/roll.bench.ts
+++ b/bench/roll.bench.ts
@@ -18,6 +18,7 @@ import {
   BENCH_SEED,
   FIXED_WORK_CASES,
   getRollOptions,
+  primeBenchFn,
   warmUpPipeline,
 } from './_cases.js';
 
@@ -29,8 +30,12 @@ export function registerRollBenches(): void {
       for (const benchCase of BENCH_CASES) {
         const options = { ...getRollOptions(benchCase), seed: BENCH_SEED };
 
-        bench(benchCase.id, () => {
-          do_not_optimize(roll(benchCase.notation, options));
+        // ? Generator form so `primeBenchFn` runs right before mitata's
+        //   warm-up — see its doc comment for why that is load-bearing.
+        bench(benchCase.id, function* () {
+          yield primeBenchFn(() => {
+            do_not_optimize(roll(benchCase.notation, options));
+          });
         })
           .gc('inner')
           .baseline(benchCase.id === BASELINE_ID);
@@ -45,8 +50,10 @@ export function registerRollBenches(): void {
       for (const benchCase of FIXED_WORK_CASES) {
         const options = { ...getRollOptions(benchCase), rng };
 
-        bench(benchCase.id, () => {
-          do_not_optimize(roll(benchCase.notation, options));
+        bench(benchCase.id, function* () {
+          yield primeBenchFn(() => {
+            do_not_optimize(roll(benchCase.notation, options));
+          });
         })
           .gc('inner')
           .baseline(benchCase.id === BASELINE_ID);

--- a/scripts/bench-json.ts
+++ b/scripts/bench-json.ts
@@ -16,7 +16,7 @@ import { dirname, join, resolve } from 'node:path';
 import { run } from 'mitata';
 import { registerAllBenches } from '../bench/index.bench.js';
 
-type MitataStats = { p50: number; p75: number };
+type MitataStats = { p50: number; p75: number; ticks: number };
 
 type MitataRun = { name: string; stats?: MitataStats };
 
@@ -35,8 +35,23 @@ type BenchmarkRecord = {
 
 const DEFAULT_OUTPUT_PATH = join(import.meta.dir, '..', '.tmp', 'bench-results.json');
 
+/** mitata's batch size — `ticks` is a multiple of it whenever batching kicked in. */
+const MITATA_BATCH_SAMPLES = 4096;
+
 function round(value: number): number {
   return Math.round(value * 100) / 100;
+}
+
+/**
+ * Which sampling mode mitata settled on. `primeBenchFn` pins every bench to
+ * `batch`, so `single` here means that pin broke — the two modes are not
+ * comparable (`single` times one post-GC call per sample and reads 10-30x high
+ * on sub-10 µs work), and a series that changes mode between runs shows a
+ * measurement artefact, not a regression (#143). Recorded in `extra` so the CI
+ * trend artefact carries the evidence.
+ */
+function getSamplingMode(ticks: number): 'batch' | 'single' {
+  return ticks % MITATA_BATCH_SAMPLES === 0 ? 'batch' : 'single';
 }
 
 function toRecords(dump: MitataDump): BenchmarkRecord[] {
@@ -50,14 +65,15 @@ function toRecords(dump: MitataDump): BenchmarkRecord[] {
     for (const trialRun of trial.runs) {
       if (trialRun.stats == null) continue;
 
-      const { p50, p75 } = trialRun.stats;
+      const { p50, p75, ticks } = trialRun.stats;
+      const mode = getSamplingMode(ticks);
 
       records.push({
         name: `${group} / ${trialRun.name}`,
         unit: 'ns',
         value: round(p50),
         range: `± ${round(p75 - p50)} ns`,
-        extra: `group=${group} case=${trialRun.name} p50=${round(p50)}ns p75=${round(p75)}ns`,
+        extra: `group=${group} case=${trialRun.name} p50=${round(p50)}ns p75=${round(p75)}ns mode=${mode}`,
       });
     }
   }


### PR DESCRIPTION
Root cause: mitata decides between batch sampling (4096 calls/sample) and single-call sampling from its first three still-cold calls of each bench body. Cold closures straddle the hardcoded 65 µs threshold at random, and single mode reads 10–30x high on sub-10 µs bodies right after a full GC — one mechanism behind both the impossible `evaluate > roll` orderings and the "multi-modal" cases. A counting-RNG probe showed the supposedly variable-work cases do byte-identical work every iteration, so the issue's `variableWork` premise was wrong; the docs now say so.

Fix: `primeBenchFn` in `bench/_cases.ts` tiers each body up before mitata's warm-up and swallows the three warm-up calls, pinning every bench to batch mode. All 85 series now sample in batch mode with zero flips; previously 400–1200% cross-process spreads are down to 15–24%, and orderings are physical again (`evaluate/4d6kh3` 2.5 µs < `roll/4d6kh3` 3.6 µs). `bench-json.ts` records the sampling mode as a tripwire, and the README performance protocol was corrected (the "~130 µs for 1000d6" figure was a single-mode artefact).

Closes #143

[Claude Code session](https://claude.ai/code/session_01CxeoookzYqNRNVjp6xPAy9)

<sub>Drafted with AI assistance</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxeoookzYqNRNVjp6xPAy9)_