### PR TITLE
ci: update dependencies via the bun ecosystem #170

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,12 +21,16 @@ updates:
         patterns:
           - '*'
 
-  # Every npm dependency here is devDependencies-only — the package ships zero
+  # Every dependency here is devDependencies-only — the package ships zero
   # runtime dependencies — so these updates affect the toolchain and the docs
   # workspace, never a consumer's tree. Without this block nothing watched the
   # lockfile, which is how a `brace-expansion` advisory reached the build
   # unnoticed.
-  - package-ecosystem: npm
+  #
+  # ! Must be `bun`, not `npm`. The npm updater rewrites `package.json` and
+  # ! leaves `bun.lock` untouched, so every PR it opened landed with a stale
+  # ! lockfile and died on CI's `bun install --frozen-lockfile`.
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
@@ -34,6 +38,11 @@ updates:
       prefix: chore
     labels:
       - improvement
+    # Mirrors `minimumReleaseAge` in bunfig.toml. Without it Dependabot can
+    # propose a version Bun then refuses to resolve, which puts the PR back in
+    # the stale-lockfile state this block exists to avoid.
+    cooldown:
+      default-days: 3
     groups:
       npm-development:
         patterns:


### PR DESCRIPTION
Dependabot's npm updater rewrites `package.json` and never writes `bun.lock`, so every PR from the dependency block landed with a stale lockfile and died on `bun install --frozen-lockfile`. Bun is a separate Dependabot ecosystem, not a variant of `npm_and_yarn` for lockfile purposes.

- Switched `package-ecosystem` from `npm` to `bun`
- Added a 3-day `cooldown` mirroring `minimumReleaseAge` in `bunfig.toml`, so Dependabot cannot propose a version Bun then refuses to resolve

Supersedes #168, which was closed — the config change cannot repair an already-pushed branch. Verified separately that the `size-limit` 13 bump itself is clean: `check:size` passes all four budgets, and the v13 Node 20 drop is covered by `engines` requiring >=22.12.

Closes #170
