### PR TITLE
ci: gate benchmarks to master and pack the tarball once #166

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches: ['**']
   pull_request:
     branches: [master, '[0-9]+.[0-9]+']
+  # Exists for the `bench` job, which is the only job a push cannot reach on a
+  # feature branch. Dispatch is not restricted to master on purpose — that is
+  # how a branch gets bench numbers now.
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
@@ -91,6 +95,28 @@ jobs:
           path: dist/
           retention-days: 1
 
+      # Mirrors release.yml: pinned npm, `--ignore-scripts`, packed once on
+      # Linux. Every smoke job consumes this artifact, so all of them test the
+      # same bytes — and the same way the published tarball is produced.
+      - name: Setup Node.js (pinned npm for packing)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          # ! No package-lock.json in this repo — setup-node's npm auto-cache
+          # ! (on by default since v5) hard-fails when it cannot find one.
+          package-manager-cache: false
+
+      - name: Pack tarball
+        run: npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/roll-parser-*.tgz
+          retention-days: 1
+          if-no-files-found: error
+
   size:
     name: Size Limit
     runs-on: ubuntu-latest
@@ -167,10 +193,18 @@ jobs:
   # Unprivileged on purpose: this job executes branch-controlled code and
   # dependencies, so the gh-pages write lives in `bench-trend` below, which
   # only ever runs on the default branch.
+  # Restricted to default-branch pushes and manual dispatches: the suite costs
+  # ~150s against ~80s for every blocking job combined, and anywhere else its
+  # artifact expires unread — `bench-trend` is the only consumer. `needs: check`
+  # stays; it keeps a commit that fails lint from spending those 150s.
   bench:
     name: Benchmarks (non-blocking)
     runs-on: ubuntu-latest
     needs: check
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     continue-on-error: true
     steps:
       - name: Checkout
@@ -274,7 +308,9 @@ jobs:
         run: node dist/cli/index.js 4d6kh3 --verbose --seed test
 
   # Tests the packed tarball, not the working tree: `files` + `exports` + bin
-  # wiring + real Node resolution, across the supported Node range.
+  # wiring + real Node resolution, across the supported Node range. Consumes the
+  # tarball `build` packed, so the Windows leg tests the Linux-packed bytes that
+  # actually ship — and needs neither a checkout nor the `dist` artifact.
   node-smoke:
     name: Node.js Smoke Test (${{ matrix.node-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -297,31 +333,23 @@ jobs:
         # across both platforms (Git Bash on the Windows runner).
         shell: bash
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Download build artifacts
+      - name: Download tarball
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist
-          path: dist/
-
-      - name: Pack tarball
-        run: npm pack --pack-destination "$RUNNER_TEMP"
+          name: npm-tarball
+          path: ${{ runner.temp }}/tarball
 
       - name: Install tarball in scratch project
         run: |
           mkdir "$RUNNER_TEMP/smoke"
           cd "$RUNNER_TEMP/smoke"
           npm init -y > /dev/null
-          npm install --no-audit --no-fund "$RUNNER_TEMP"/roll-parser-*.tgz
+          npm install --no-audit --no-fund "$RUNNER_TEMP"/tarball/roll-parser-*.tgz
 
       - name: Test ESM import and testing subpath
         working-directory: ${{ runner.temp }}/smoke
@@ -411,13 +439,18 @@ jobs:
             exit 1
           fi
 
+      - name: Download tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/tarball
+
       - name: Install tarball in scratch project
         run: |
-          npm pack --pack-destination "$RUNNER_TEMP"
           mkdir "$RUNNER_TEMP/browser-smoke"
           cd "$RUNNER_TEMP/browser-smoke"
           npm init -y > /dev/null
-          npm install --no-audit --no-fund "$RUNNER_TEMP"/roll-parser-*.tgz
+          npm install --no-audit --no-fund "$RUNNER_TEMP"/tarball/roll-parser-*.tgz
 
       - name: Write browser fixture importing both entry points
         working-directory: ${{ runner.temp }}/browser-smoke


### PR DESCRIPTION
Two CI changes to `.github/workflows/ci.yml`.

Gated the `bench` job to default-branch pushes and `workflow_dispatch`, adding the dispatch trigger. Off master nothing read its artifact — `bench-trend` is the only consumer and is already default-branch-only — so a branch push spent ~150s producing a file that expired unread. Measured against two recent runs: `bench` took 165s and 164s while every other job finished in 7-30s. `needs: check` stays. Dispatch is deliberately not restricted to master, so a branch can still get numbers on demand; a dispatched run does not write to the trend history.

Moved `npm pack` into the `build` job as a pinned-npm, `--ignore-scripts` step mirroring release.yml, uploaded as the `npm-tarball` artifact, and pointed all five `node-smoke` legs plus `browser-smoke` at it. That drops six packs to one. Primarily a correctness fix: the Windows leg previously tested a Windows-packed tarball that will never ship, where the release job packs once on Linux. `node-smoke` no longer needs a checkout or the `dist` artifact either, since packing was the only thing using them.

Verified locally by replaying both smoke paths against a single `npm pack --ignore-scripts` tarball: ESM import, `require(esm)`, and the installed bin all pass, and the esbuild browser bundle stays free of Node internals and executes. Workflow wiring checked with `yq` — `npm pack` appears only in `build`, and every artifact consumer's `needs` covers its producer.

Trigger behavior on this PR is itself partial evidence: `bench` should be absent from the branch-push run, with all blocking jobs green.

Closes #166
