### PR TITLE
perf: add keep/drop count === 1 fast path #164

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -642,6 +642,115 @@ describe('evaluate', () => {
     });
   });
 
+  describe('single keep/drop selection (count 1)', () => {
+    test('kh1 tie keeps the first occurrence of the highest', () => {
+      const ast = parse('3d6kh1');
+      const rng = createMockRng([5, 5, 2]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(5);
+      expect(getDie(result.rolls, 0).modifiers).toContain('kept');
+      expect(getDie(result.rolls, 1).modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 2).modifiers).toContain('dropped');
+    });
+
+    test('kl1 tie keeps the first occurrence of the lowest', () => {
+      const ast = parse('3d6kl1');
+      const rng = createMockRng([4, 2, 2]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(2);
+      expect(getDie(result.rolls, 0).modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 1).modifiers).toContain('kept');
+      expect(getDie(result.rolls, 2).modifiers).toContain('dropped');
+    });
+
+    test('dh1 tie drops the first occurrence of the highest', () => {
+      const ast = parse('3d6dh1');
+      const rng = createMockRng([5, 5, 2]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(7); // 5 + 2
+      expect(getDie(result.rolls, 0).modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 1).modifiers).toContain('kept');
+      expect(getDie(result.rolls, 2).modifiers).toContain('kept');
+    });
+
+    test('dl1 tie drops the first occurrence of the lowest', () => {
+      const ast = parse('3d6dl1');
+      const rng = createMockRng([4, 2, 2]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(6); // 4 + 2
+      expect(getDie(result.rolls, 0).modifiers).toContain('kept');
+      expect(getDie(result.rolls, 1).modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 2).modifiers).toContain('kept');
+    });
+
+    test('all-tied pool selects exactly one die', () => {
+      const kh = evaluate(parse('3d6kh1'), createMockRng([4, 4, 4]));
+      expect(kh.total).toBe(4);
+      expect(getDie(kh.rolls, 0).modifiers).toContain('kept');
+      expect(kh.rolls.filter((r) => r.modifiers.includes('dropped'))).toHaveLength(2);
+
+      const dl = evaluate(parse('3d6dl1'), createMockRng([4, 4, 4]));
+      expect(dl.total).toBe(8);
+      expect(getDie(dl.rolls, 0).modifiers).toContain('dropped');
+      expect(dl.rolls.filter((r) => r.modifiers.includes('dropped'))).toHaveLength(1);
+    });
+
+    test('kh1kl1 chain unions both drop sets on the shared mask', () => {
+      // [7,15]: kh1 drops idx0; kl1 drops idx1 and must not clear kh1's mark.
+      const ast = parse('2d20kh1kl1');
+      const rng = createMockRng([7, 15]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(0);
+      expect(result.rolls.every((r) => r.modifiers.includes('dropped'))).toBe(true);
+    });
+
+    test('dl1 skips rerolled intermediates', () => {
+      // Die 0: 1 (r<2 matches) → 4. Die 1: 3. Final pool [4, 3] — the
+      // intermediate 1 stays dropped and must not absorb the dl1.
+      const ast = parse('2d6r<2dl1');
+      const rng = createMockRng([1, 3, 4]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(4);
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['rerolled', 'dropped']);
+      expect(getDie(result.rolls, 1).modifiers).toContain('kept');
+      expect(getDie(result.rolls, 2).modifiers).toContain('dropped');
+    });
+
+    test('computed kl count skips the meta die', () => {
+      // Meta d2 → 1, pool [15, 7]. kl1 keeps 7 — the meta die's 1 is not
+      // eligible to win lowest.
+      const ast = parse('2d20kl(1d2)');
+      const rng = createMockRng([1, 15, 7]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(7);
+      const metaDie = getDie(result.rolls, 0);
+      expect(metaDie.modifiers).toContain('meta');
+      expect(metaDie.modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 1).modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 2).modifiers).toContain('kept');
+    });
+
+    test("kh1 skips a preceding chain's losers", () => {
+      // Parse: Modifier(kh1, Reroll(r>6, Modifier(dh1, Dice))). dh1 drops
+      // the 5; the no-op reroll splits the chains, so kh1 sees it already
+      // dropped and must keep the 2 instead.
+      const ast = parse('2d6dh1r>6kh1');
+      const rng = createMockRng([5, 2]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(2);
+      expect(getDie(result.rolls, 0).modifiers).toContain('dropped');
+      expect(getDie(result.rolls, 1).modifiers).toContain('kept');
+    });
+  });
+
   describe('critical and fumble detection', () => {
     test('detects critical (max value)', () => {
       const ast = parse('1d20');
@@ -1357,6 +1466,17 @@ describe('evaluate', () => {
         const result = evaluate(ast, rng);
 
         expect(result.total).toBe(3);
+      });
+
+      test('reroll then keep-2 skips the intermediate in the sorted path', () => {
+        // Die 0: 1 (r<2 matches) → 4. Dice 1-2: 5, 3. kh2 sorts [4, 5, 3]
+        // and keeps 5 + 4 — the dropped intermediate 1 is never eligible.
+        const ast = parse('3d6r<2kh2');
+        const rng = createMockRng([1, 5, 3, 4]);
+        const result = evaluate(ast, rng);
+
+        expect(result.total).toBe(9);
+        expect(getDie(result.rolls, 0).modifiers).toEqual(['rerolled', 'dropped']);
       });
 
       test('reroll then keep highest: 2d6r<2kh1', () => {

--- a/src/evaluator/modifiers/keep-drop.ts
+++ b/src/evaluator/modifiers/keep-drop.ts
@@ -29,6 +29,11 @@ export function markDroppedIndices(
   selector: ModifierSpec['selector'],
   droppedMask: Uint8Array,
 ): void {
+  if (count === 1) {
+    markSingleExtreme(dice, kind, selector, droppedMask);
+    return;
+  }
+
   const eligible: EligibleDie[] = [];
 
   for (let index = 0; index < dice.length; index++) {
@@ -71,6 +76,57 @@ export function markDroppedIndices(
     const item = eligible[i];
     if (item != null) droppedMask[item.index] = 1;
   }
+}
+
+/**
+ * `count === 1` fast path: a single linear scan replaces the wrapper array
+ * and comparator sort — `2d20kh1` (advantage) and `4d6dl1` are the most
+ * common notations. Strict comparison preserves the stable sort's
+ * first-occurrence tie-break, and bits are only ever set, never cleared, so
+ * a shared mask keeps every previous spec's drops.
+ */
+function markSingleExtreme(
+  dice: DieResult[],
+  kind: ModifierSpec['kind'],
+  selector: ModifierSpec['selector'],
+  droppedMask: Uint8Array,
+): void {
+  const isKeep = kind === 'keep';
+  const wantHighest = selector === 'highest';
+
+  let extremeIndex = -1;
+  let extremeResult = 0;
+
+  for (let index = 0; index < dice.length; index++) {
+    const die = dice[index];
+    if (die == null) continue;
+
+    if (die.modifiers.includes('dropped')) {
+      droppedMask[index] = 1;
+      continue;
+    }
+
+    const { result } = die;
+
+    if (extremeIndex === -1) {
+      extremeIndex = index;
+      extremeResult = result;
+      continue;
+    }
+
+    if (wantHighest ? result > extremeResult : result < extremeResult) {
+      // A keep drops the dethroned extreme; a drop keeps everything else.
+      if (isKeep) droppedMask[extremeIndex] = 1;
+      extremeIndex = index;
+      extremeResult = result;
+    } else if (isKeep) {
+      droppedMask[index] = 1;
+    }
+  }
+
+  // Keeping 1 of ≤1 eligible dice drops nothing; dropping 1 of ≥1 drops the
+  // extreme — both match the general path's whole-pool guards.
+  if (!isKeep && extremeIndex !== -1) droppedMask[extremeIndex] = 1;
 }
 
 /**


### PR DESCRIPTION
Adds a `count === 1` fast path to `markDroppedIndices`: a single linear scan (`markSingleExtreme`) finds the one extreme eligible die instead of allocating an `EligibleDie` wrapper per die and comparator-sorting the pool. This covers `2d20kh1` (advantage) and `4d6dl1`, the most common real-world notations.

Strict `>` / `<` comparison preserves the stable sort's first-occurrence tie-break, and the scan only ever sets bits in the shared `droppedMask`, never clears them, so chained specs keep their union semantics. The keep path drops the dethroned extreme as it scans; the drop path marks the final extreme once — both match the general path's whole-pool guards for pools of 0 or 1 eligible dice.

New tests cover ties (first occurrence wins) in all four `keep`/`drop` x `highest`/`lowest` combinations, an all-tied pool, chained specs sharing the mask (`2d20kh1kl1`), and pools containing already-dropped dice: reroll intermediates (`2d6r<2dl1`), meta dice (`2d20kl(1d2)`), and a preceding chain's losers (`2d6dh1r>6kh1`). A `3d6r<2kh2` case keeps the general sorted path's pre-dropped branch covered now that `count === 1` bypasses it. Seeded RNG draw order and rendered strings are unchanged across the full suite (1295 pass, coverage gate green).

End-to-end benchmarks (`bun bench:evaluate` / `bun bench:roll`, same container, single run each):

| Case | evaluate before | evaluate after | roll before | roll after |
| --- | --- | --- | --- | --- |
| `2d20kh1 vs 15` | 3.03 µs | 2.83 µs (-7%) | 4.63 µs | 4.02 µs (-13%) |
| `4d6kh3` (not fast-pathed) | 2.99 µs | 2.92 µs | 4.14 µs | 3.79 µs |
| `1000d6kh(n/2)` | 470.49 µs | 456.66 µs | — | — |

The isolated 4-18x selection-step win dilutes to single-digit percent end-to-end because parse, RNG draws, and die-object creation dominate; run-to-run drift on this machine is roughly ±10% (non-keep cases moved similarly between runs), so treat the deltas as directional. Quickselect for large half-pool selections (`1000d6kh500`) remains out of scope per the issue.

Closes #164

<sub>[Claude Code session](https://claude.ai/code/session_01KTvWFQzAs7vF6y4SUVfhrP)</sub>