### PR TITLE
perf: replace parser guard array scans with direct traversal #163

### DIFF
--- a/src/parser/guards.ts
+++ b/src/parser/guards.ts
@@ -12,47 +12,41 @@
 import type { ASTNode } from './ast.js';
 
 /**
- * Wrapper kinds that `unwrapTransparent` can peel.
- *
- * "Transparent" is relative to the question being asked. `Modifier`/`Sort`/
- * `CritThreshold` are transparent for "what is the underlying operand?" when
- * deciding whether to reject a `Group` target — they preserve `containsDicePool`'s
- * answer for whatever they wrap. They are NOT transparent for "is this a
- * `SuccessCount`?" or "is this a `Versus`?", because the parsers that build
- * those wrappers already reject `SuccessCount`/`Versus` operands upstream.
+ * Peels nested `Grouped` wrappers, returning the first descendant that is not
+ * one. The narrow unwrap for reject helpers whose forbidden node cannot live
+ * inside `Modifier`/`Sort`/`CritThreshold` — those parsers already reject it
+ * upstream, so peeling parentheses is all that is left to see through.
  */
-export type TransparentWrapperKind = 'Grouped' | 'Modifier' | 'Sort' | 'CritThreshold';
+export function unwrapGrouped(node: ASTNode): ASTNode {
+  let current = node;
+  while (current.type === 'Grouped') {
+    current = current.expression;
+  }
+  return current;
+}
 
 /**
- * Walks `node` while its `.type` is in `kinds`, returning the first descendant
- * that is not one of the listed wrappers. Each caller picks the subset that
- * matches its rejection semantics — see `TransparentWrapperKind` for guidance.
+ * Peels every transparent wrapper — `Grouped`, `Modifier`, `Sort`,
+ * `CritThreshold` — returning the first descendant that is none of them.
  *
- * Used by parser reject helpers to look past wrappers when deciding whether
- * an operand violates a rule (e.g., `Group` cannot be the target of `cs`/`cf`,
- * even when wrapped in `Modifier` like `{1d6}kh1cs>5`).
+ * "Transparent" is relative to the question being asked. These wrappers
+ * preserve `containsDicePool`'s answer for whatever they wrap, so they are
+ * transparent for "what is the underlying operand?" when deciding whether to
+ * reject a `Group` target (e.g., `Group` cannot be the target of `cs`/`cf`,
+ * even when wrapped in `Modifier` like `{1d6}kh1cs>5`). They are NOT
+ * transparent for "is this a `SuccessCount`?" or "is this a `Versus`?" —
+ * those questions use `unwrapGrouped`.
  */
-export function unwrapTransparent(
-  node: ASTNode,
-  kinds: readonly TransparentWrapperKind[],
-): ASTNode {
+export function unwrapAllTransparent(node: ASTNode): ASTNode {
   let current = node;
   while (true) {
     switch (current.type) {
       case 'Grouped':
-        if (!kinds.includes('Grouped')) return current;
         current = current.expression;
         break;
       case 'Modifier':
-        if (!kinds.includes('Modifier')) return current;
-        current = current.target;
-        break;
       case 'Sort':
-        if (!kinds.includes('Sort')) return current;
-        current = current.target;
-        break;
       case 'CritThreshold':
-        if (!kinds.includes('CritThreshold')) return current;
         current = current.target;
         break;
       default:
@@ -62,61 +56,63 @@ export function unwrapTransparent(
 }
 
 /**
- * Yields every direct child of `node`, covering the full node vocabulary:
- * arithmetic operands, modifier-chain targets, `Versus` sides, function
- * arguments, and group sub-expressions. Leaves yield nothing.
+ * Returns `true` when `node` or any descendant satisfies `isHit`. Recurses
+ * directly through the entire node vocabulary: arithmetic operands,
+ * modifier-chain targets, `Versus` sides, function arguments, and group
+ * sub-expressions. This is the shared driver behind the four deep walkers
+ * below. The shallow walkers (`containsDicePool`, `containsFatePool`) stay
+ * hand-written because their rejection semantics deliberately stop at
+ * arithmetic boundaries.
  */
-function* childNodes(node: ASTNode): Generator<ASTNode> {
+function someDescendant(node: ASTNode, isHit: (node: ASTNode) => boolean): boolean {
+  if (isHit(node)) return true;
+
   switch (node.type) {
     case 'BinaryOp':
-      yield node.left;
-      yield node.right;
-      return;
+      return someDescendant(node.left, isHit) || someDescendant(node.right, isHit);
     case 'UnaryOp':
-      yield node.operand;
-      return;
+      return someDescendant(node.operand, isHit);
     case 'Modifier':
     case 'Explode':
     case 'Reroll':
     case 'SuccessCount':
     case 'Sort':
     case 'CritThreshold':
-      yield node.target;
-      return;
+      return someDescendant(node.target, isHit);
     case 'Versus':
-      yield node.roll;
-      yield node.dc;
-      return;
-    case 'FunctionCall':
-      yield* node.args;
-      return;
+      return someDescendant(node.roll, isHit) || someDescendant(node.dc, isHit);
+    case 'FunctionCall': {
+      for (const arg of node.args) {
+        if (someDescendant(arg, isHit)) return true;
+      }
+      return false;
+    }
     case 'Grouped':
-      yield node.expression;
-      return;
-    case 'Group':
-      yield* node.expressions;
-      return;
+      return someDescendant(node.expression, isHit);
+    case 'Group': {
+      for (const expression of node.expressions) {
+        if (someDescendant(expression, isHit)) return true;
+      }
+      return false;
+    }
     default:
-      return;
+      return false;
   }
 }
 
-/**
- * Returns `true` when `node` or any descendant satisfies `isHit`. Recurses
- * through the entire node vocabulary via `childNodes` — this is the shared
- * driver behind the four deep walkers below. The shallow walkers
- * (`containsDicePool`, `containsFatePool`) stay hand-written because their
- * rejection semantics deliberately stop at arithmetic boundaries.
- */
-function someDescendant(node: ASTNode, isHit: (node: ASTNode) => boolean): boolean {
-  if (isHit(node)) return true;
+// Hoisted `someDescendant` predicates — the deep walkers run on nearly every
+// LED parse, so rebuilding these closures per call is measurable churn.
+const isDicePoolHit = (current: ASTNode): boolean =>
+  current.type === 'Dice' ||
+  current.type === 'FateDice' ||
+  (current.type === 'Group' && current.expressions.length >= 2);
 
-  for (const child of childNodes(node)) {
-    if (someDescendant(child, isHit)) return true;
-  }
+const isFateDiceHit = (current: ASTNode): boolean => current.type === 'FateDice';
 
-  return false;
-}
+const isMultiSubGroupHit = (current: ASTNode): boolean =>
+  current.type === 'Group' && current.expressions.length >= 2;
+
+const isVersusHit = (current: ASTNode): boolean => current.type === 'Versus';
 
 /**
  * Returns `true` only when `node`'s direct result is a dice pool —
@@ -165,13 +161,7 @@ export function containsDicePool(node: ASTNode): boolean {
  * matching `containsDicePool`'s Group rule.
  */
 export function deepContainsDicePool(node: ASTNode): boolean {
-  return someDescendant(
-    node,
-    (current) =>
-      current.type === 'Dice' ||
-      current.type === 'FateDice' ||
-      (current.type === 'Group' && current.expressions.length >= 2),
-  );
+  return someDescendant(node, isDicePoolHit);
 }
 
 /**
@@ -219,7 +209,7 @@ export function containsFatePool(node: ASTNode): boolean {
  * intentionally stays Group-internal.
  */
 export function deepContainsFatePool(node: ASTNode): boolean {
-  return someDescendant(node, (current) => current.type === 'FateDice');
+  return someDescendant(node, isFateDiceHit);
 }
 
 /**
@@ -234,10 +224,7 @@ export function deepContainsFatePool(node: ASTNode): boolean {
  * in a `BinaryOp`/`UnaryOp`/`FunctionCall` revives issue #97.
  */
 export function containsMultiSubGroup(node: ASTNode): boolean {
-  return someDescendant(
-    node,
-    (current) => current.type === 'Group' && current.expressions.length >= 2,
-  );
+  return someDescendant(node, isMultiSubGroupHit);
 }
 
 /**
@@ -248,5 +235,5 @@ export function containsMultiSubGroup(node: ASTNode): boolean {
  * silently dropping `versusMetadata` at the modifier consumer site.
  */
 export function containsVersus(node: ASTNode): boolean {
-  return someDescendant(node, (current) => current.type === 'Versus');
+  return someDescendant(node, isVersusHit);
 }

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -2350,7 +2350,7 @@ describe('Parser', () => {
       });
 
       // #109 — single-sub-roll passthrough must not smuggle a buried
-      // multi-sub Group through a wrapper `unwrapTransparent` doesn't peel.
+      // multi-sub Group through a wrapper `unwrapAllTransparent` doesn't peel.
       it('should reject cs on nested multi-sub-roll group: {{1d20, 1d20}kh1}cs>18', () => {
         expect(() => parseAst('{{1d20, 1d20}kh1}cs>18')).toThrow(ParseError);
         try {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -36,7 +36,8 @@ import {
   containsMultiSubGroup,
   containsVersus,
   deepContainsDicePool,
-  unwrapTransparent,
+  unwrapAllTransparent,
+  unwrapGrouped,
 } from './guards.js';
 
 /**
@@ -637,7 +638,7 @@ export class Parser {
     // `Modifier`/`Sort`/`CritThreshold` because each of those parsers calls
     // this same reject on their target before constructing the wrapper —
     // so widening the set here would never match.
-    const node = unwrapTransparent(target, ['Grouped']);
+    const node = unwrapGrouped(target);
     if (isSuccessCount(node)) {
       throw new ParseError(
         `Cannot apply modifier after success counting`,
@@ -670,10 +671,10 @@ export class Parser {
     code: RollParserErrorCode,
     singleSubRollPasses = false,
   ): void {
-    const node = unwrapTransparent(target, ['Grouped', 'Modifier', 'Sort', 'CritThreshold']);
+    const node = unwrapAllTransparent(target);
     if (node.type !== 'Group') return;
     if (singleSubRollPasses && node.expressions.length === 1) {
-      // ! Deep-walk the inner sub-expression — `unwrapTransparent` only peels
+      // ! Deep-walk the inner sub-expression — `unwrapAllTransparent` only peels
       //   `Grouped`/`Modifier`/`Sort`/`CritThreshold`, so a multi-sub Group
       //   buried under arithmetic (`{{1d6,2d8}+0}cs>5`), function calls
       //   (`{abs({1d6,2d8})}cs>5`), or unary ops would otherwise revive the
@@ -696,7 +697,7 @@ export class Parser {
     // Narrow unwrap: only `Grouped`. `Modifier`/`Sort`/`CritThreshold`
     // cannot wrap a `Versus` because `containsDicePool` does not recurse
     // into `Versus`, so each of those parsers rejects the wrap upstream.
-    const node = unwrapTransparent(target, ['Grouped']);
+    const node = unwrapGrouped(target);
     if (node.type === 'Versus') {
       throw new ParseError(
         `Versus cannot be used as a meta-expression`,
@@ -905,7 +906,7 @@ export class Parser {
     //   which is the user's flat-pool escape hatch).
     // TODO: Implement hierarchical multi-sub-roll group sort, then drop this
     //   reject.
-    const base = unwrapTransparent(target, ['Grouped', 'Modifier', 'Sort', 'CritThreshold']);
+    const base = unwrapAllTransparent(target);
     if (base.type === 'Group' && base.expressions.length >= 2) {
       throw new ParseError(
         `Sort modifier does not yet support multi-sub-roll groups`,


### PR DESCRIPTION
Removes allocation churn from the parser's guard helpers. All changes are internal to `src/parser/` — no public API impact.

- Split `unwrapTransparent(node, kinds)` into two dedicated helpers: `unwrapGrouped()` for the two call sites that only peel `Grouped` (`rejectSuccessCountTarget`, `rejectVersusTarget`) and `unwrapAllTransparent()` for the two that peel the full `Grouped`/`Modifier`/`Sort`/`CritThreshold` set (`rejectGroupTarget`, `parseSort`). No per-call array literal, no `includes` string scan.
- Rewrote `someDescendant` as a direct recursive switch, removing the `childNodes` generator and its per-step generator plus iterator-result allocations.
- Hoisted the predicate closures in `deepContainsDicePool`, `deepContainsFatePool`, `containsMultiSubGroup`, and `containsVersus` to module level.

#### Verification

Full suite passes (1297 tests) with identical ASTs, error codes, and error positions; `bun check:fix` clean.

Fresh mitata measurements (same methodology as `bench:parse`, two stable runs per side). The 1.33-1.86x claimed by the earlier uncommitted experiment did not reproduce; actual gains:

| Notation | Before | After | Speedup |
|---|---|---|---|
| `{1d6+2}kh1` | ~885 ns | ~685 ns | ~1.29x |
| `(1d6+2d8)s` | ~889 ns | ~672 ns | ~1.32x |
| `{abs({1d6,2d8})}cs>5` | ~3.79 us | ~3.32 us | ~1.14x |
| `{2d20kh1+5, 3d8!}kh1` | ~1.27 us | ~1.13 us | ~1.12x |
| `1d20`, `1d20+5`, `4d6kh3` | 302/415/439 ns | 300/413/414 ns | parity |

Closes #163

<sub>[Claude Code session](https://claude.ai/code/session_01KhNKNbvxbhTvJAwEw9ueu7)</sub>
