### PR TITLE
fix: validate bench-json records beyond the zero-count gate #157

### DIFF
--- a/bench/evaluate.bench.ts
+++ b/bench/evaluate.bench.ts
@@ -28,7 +28,14 @@ import {
   warmUpPipeline,
 } from './_cases.js';
 
-export function registerEvaluateBenches(): void {
+/**
+ * `.range('n', 1, 1000, 10)` below expands into one run per value — 1, 10, 100,
+ * 1000. Keep in sync with those calls; `bench:json` fails loudly on a mismatch.
+ */
+const POOL_SCALING_RUNS = 2 * 4;
+
+/** Returns the number of runs these groups contribute to a mitata dump. */
+export function registerEvaluateBenches(): number {
   warmUpPipeline();
 
   group('evaluate', () => {
@@ -77,6 +84,8 @@ export function registerEvaluateBenches(): void {
       .range('n', 1, 1000, 10)
       .gc('inner');
   });
+
+  return BENCH_CASES.length + POOL_SCALING_RUNS;
 }
 
 if (import.meta.main) {

--- a/bench/index.bench.ts
+++ b/bench/index.bench.ts
@@ -13,11 +13,19 @@ import { registerLexBenches } from './lex.bench.js';
 import { registerParseBenches } from './parse.bench.js';
 import { registerRollBenches } from './roll.bench.js';
 
-export function registerAllBenches(): void {
-  registerLexBenches();
-  registerParseBenches();
-  registerEvaluateBenches();
-  registerRollBenches();
+/**
+ * Returns the number of runs the suite is expected to produce in a mitata
+ * dump. `bench:json` cross-checks its record count against this so a run that
+ * vanishes from the dump fails the export instead of silently shrinking the CI
+ * trend series (#157).
+ */
+export function registerAllBenches(): number {
+  return (
+    registerLexBenches() +
+    registerParseBenches() +
+    registerEvaluateBenches() +
+    registerRollBenches()
+  );
 }
 
 if (import.meta.main) {

--- a/bench/lex.bench.ts
+++ b/bench/lex.bench.ts
@@ -8,7 +8,8 @@ import { bench, do_not_optimize, group, run, summary } from 'mitata';
 import { lex } from '../src/lexer/lexer.js';
 import { BASELINE_ID, BENCH_CASES, primeBenchFn, warmUpPipeline } from './_cases.js';
 
-export function registerLexBenches(): void {
+/** Returns the number of runs this group contributes to a mitata dump. */
+export function registerLexBenches(): number {
   warmUpPipeline();
 
   group('lex', () => {
@@ -26,6 +27,8 @@ export function registerLexBenches(): void {
       }
     });
   });
+
+  return BENCH_CASES.length;
 }
 
 if (import.meta.main) {

--- a/bench/parse.bench.ts
+++ b/bench/parse.bench.ts
@@ -8,7 +8,8 @@ import { bench, do_not_optimize, group, run, summary } from 'mitata';
 import { parse } from '../src/index.js';
 import { BASELINE_ID, BENCH_CASES, primeBenchFn, warmUpPipeline } from './_cases.js';
 
-export function registerParseBenches(): void {
+/** Returns the number of runs this group contributes to a mitata dump. */
+export function registerParseBenches(): number {
   warmUpPipeline();
 
   group('parse', () => {
@@ -26,6 +27,8 @@ export function registerParseBenches(): void {
       }
     });
   });
+
+  return BENCH_CASES.length;
 }
 
 if (import.meta.main) {

--- a/bench/roll.bench.ts
+++ b/bench/roll.bench.ts
@@ -22,7 +22,8 @@ import {
   warmUpPipeline,
 } from './_cases.js';
 
-export function registerRollBenches(): void {
+/** Returns the number of runs these groups contribute to a mitata dump. */
+export function registerRollBenches(): number {
   warmUpPipeline();
 
   group('roll (seeded)', () => {
@@ -60,6 +61,8 @@ export function registerRollBenches(): void {
       }
     });
   });
+
+  return BENCH_CASES.length + FIXED_WORK_CASES.length;
 }
 
 if (import.meta.main) {

--- a/scripts/bench-json.ts
+++ b/scripts/bench-json.ts
@@ -8,6 +8,8 @@
  * histogram (809 ns avg against 508 ns p50 on the same benchmark), and cross-
  * process avg variance runs ±43% where p50 stays within ±5-10%.
  *
+ * Conversion and per-record validation live in `bench-records.ts`.
+ *
  * Usage: `bun run bench:json [outputPath]`
  */
 
@@ -15,76 +17,14 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { run } from 'mitata';
 import { registerAllBenches } from '../bench/index.bench.js';
-
-type MitataStats = { p50: number; p75: number; ticks: number };
-
-type MitataRun = { name: string; stats?: MitataStats };
-
-type MitataTrial = { group: number; runs: MitataRun[] };
-
-type MitataDump = { layout: { name: string | null }[]; benchmarks: MitataTrial[] };
-
-/** One `customSmallerIsBetter` data point. */
-type BenchmarkRecord = {
-  name: string;
-  unit: 'ns';
-  value: number;
-  range: string;
-  extra: string;
-};
+import { toRecords } from './bench-records.js';
 
 const DEFAULT_OUTPUT_PATH = join(import.meta.dir, '..', '.tmp', 'bench-results.json');
-
-/** mitata's batch size — `ticks` is a multiple of it whenever batching kicked in. */
-const MITATA_BATCH_SAMPLES = 4096;
-
-function round(value: number): number {
-  return Math.round(value * 100) / 100;
-}
-
-/**
- * Which sampling mode mitata settled on. `primeBenchFn` pins every bench to
- * `batch`, so `single` here means that pin broke — the two modes are not
- * comparable (`single` times one post-GC call per sample and reads 10-30x high
- * on sub-10 µs work), and a series that changes mode between runs shows a
- * measurement artefact, not a regression (#143). Recorded in `extra` so the CI
- * trend artefact carries the evidence.
- */
-function getSamplingMode(ticks: number): 'batch' | 'single' {
-  return ticks % MITATA_BATCH_SAMPLES === 0 ? 'batch' : 'single';
-}
-
-function toRecords(dump: MitataDump): BenchmarkRecord[] {
-  const records: BenchmarkRecord[] = [];
-
-  for (const trial of dump.benchmarks) {
-    // ? `trial.group` is an index into `layout`; `summary()` nests a collection
-    //   that inherits its parent group's name, so this stays the group label.
-    const group = dump.layout[trial.group]?.name ?? 'ungrouped';
-
-    for (const trialRun of trial.runs) {
-      if (trialRun.stats == null) continue;
-
-      const { p50, p75, ticks } = trialRun.stats;
-      const mode = getSamplingMode(ticks);
-
-      records.push({
-        name: `${group} / ${trialRun.name}`,
-        unit: 'ns',
-        value: round(p50),
-        range: `± ${round(p75 - p50)} ns`,
-        extra: `group=${group} case=${trialRun.name} p50=${round(p50)}ns p75=${round(p75)}ns mode=${mode}`,
-      });
-    }
-  }
-
-  return records;
-}
 
 async function main(): Promise<void> {
   const outputPath = resolve(process.argv[2] ?? DEFAULT_OUTPUT_PATH);
 
-  registerAllBenches();
+  const expectedCount = registerAllBenches();
 
   let dump = '';
 
@@ -97,10 +37,28 @@ async function main(): Promise<void> {
     },
   });
 
-  const records = toRecords(JSON.parse(dump));
+  const { records, problems } = toRecords(JSON.parse(dump));
+
+  const failures = [...problems];
 
   if (records.length === 0) {
-    console.error('bench-json: mitata produced no usable benchmark stats');
+    failures.push('mitata produced no usable benchmark stats');
+  } else if (records.length !== expectedCount) {
+    failures.push(
+      `expected ${expectedCount} records, got ${records.length} — a bench run is missing from the dump, or a registrar's returned count is stale`,
+    );
+  }
+
+  // ! Never write a partial series: the CI trend compares against whatever
+  //   landed last, so a shrunk or corrupt export reads as a phantom regression
+  //   on every later run (#157).
+  if (failures.length > 0) {
+    console.error('bench-json: refusing to write a partial or corrupt export');
+
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+
     process.exit(1);
   }
 

--- a/scripts/bench-records.test.ts
+++ b/scripts/bench-records.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'bun:test';
+import type { MitataDump, MitataRun, MitataStats } from './bench-records.js';
+import { toRecords } from './bench-records.js';
+
+/** `ticks` is a multiple of mitata's 4096 batch size, so the mode reads `batch`. */
+const GOOD_STATS: MitataStats = { p50: 500, p75: 620.5, ticks: 8192 };
+
+function dumpOf(groupName: string | null, ...runs: MitataRun[]): MitataDump {
+  return { layout: [{ name: groupName }], benchmarks: [{ group: 0, runs }] };
+}
+
+function statsWith(overrides: Partial<MitataStats>): MitataStats {
+  return { ...GOOD_STATS, ...overrides };
+}
+
+describe('toRecords', () => {
+  describe('valid dumps', () => {
+    it('builds one record per run', () => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: GOOD_STATS }, { name: '3d6', stats: GOOD_STATS }),
+      );
+
+      expect(problems).toEqual([]);
+      expect(records).toHaveLength(2);
+      expect(records[0]).toEqual({
+        name: 'lex / 1d20',
+        unit: 'ns',
+        value: 500,
+        range: '± 120.5 ns',
+        extra: 'group=lex case=1d20 p50=500ns p75=620.5ns mode=batch',
+      });
+    });
+
+    it('rounds values to two decimals', () => {
+      const { records } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: statsWith({ p50: 1.23456, p75: 2.34567 }) }),
+      );
+
+      expect(records[0]).toMatchObject({ value: 1.23, range: '± 1.11 ns' });
+    });
+
+    it('reports `single` when ticks is not a multiple of the batch size', () => {
+      const { records } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: statsWith({ ticks: 8193 }) }),
+      );
+
+      expect(records[0]?.extra).toContain('mode=single');
+    });
+
+    it('accepts p75 equal to p50', () => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: statsWith({ p75: 500 }) }),
+      );
+
+      expect(problems).toEqual([]);
+      expect(records[0]).toMatchObject({ range: '± 0 ns' });
+    });
+
+    it('labels a run whose group is absent from the layout as ungrouped', () => {
+      const { records, problems } = toRecords({
+        layout: [],
+        benchmarks: [{ group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] }],
+      });
+
+      expect(problems).toEqual([]);
+      expect(records[0]).toMatchObject({ name: 'ungrouped / 1d20' });
+    });
+
+    it('resolves the group name per trial', () => {
+      const { records } = toRecords({
+        layout: [{ name: 'lex' }, { name: 'parse' }],
+        benchmarks: [
+          { group: 1, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+          { group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+        ],
+      });
+
+      expect(records.map((record) => record.name)).toEqual(['parse / 1d20', 'lex / 1d20']);
+    });
+
+    it('returns nothing for an empty dump', () => {
+      const { records, problems } = toRecords({ layout: [], benchmarks: [] });
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual([]);
+    });
+  });
+
+  describe('malformed dumps (#157)', () => {
+    it('reports a run with missing stats instead of skipping it', () => {
+      const { records, problems } = toRecords(dumpOf('lex', { name: '1d20' }));
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual(['lex / 1d20: missing stats']);
+    });
+
+    it('keeps the valid runs out of the export when a sibling is malformed', () => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: GOOD_STATS }, { name: '3d6' }),
+      );
+
+      expect(records.map((record) => record.name)).toEqual(['lex / 1d20']);
+      expect(problems).toEqual(['lex / 3d6: missing stats']);
+    });
+
+    it('reports an empty group name', () => {
+      const { records, problems } = toRecords(dumpOf('  ', { name: '1d20', stats: GOOD_STATS }));
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual(['   / 1d20: group name is empty']);
+    });
+
+    it('reports an empty case name', () => {
+      const { records, problems } = toRecords(dumpOf('lex', { name: '', stats: GOOD_STATS }));
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual(['lex / #0: case name is empty']);
+    });
+
+    it.each([
+      ['zero', 0],
+      ['negative', -1],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ])('reports a %s p50', (_label, p50) => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: statsWith({ p50 }) }),
+      );
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual([`lex / 1d20: p50 is not a positive finite number (${p50})`]);
+    });
+
+    it.each([
+      ['below p50', 499],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ])('reports a p75 that is %s', (_label, p75) => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: statsWith({ p75 }) }),
+      );
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual([`lex / 1d20: p75 is not a finite number >= p50 (${p75})`]);
+    });
+
+    it.each([
+      ['zero', 0],
+      ['negative', -4096],
+      ['NaN', Number.NaN],
+    ])('reports a %s ticks rather than mislabelling the sampling mode', (_label, ticks) => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: statsWith({ ticks }) }),
+      );
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual([`lex / 1d20: ticks is not a positive finite number (${ticks})`]);
+    });
+  });
+});

--- a/scripts/bench-records.ts
+++ b/scripts/bench-records.ts
@@ -1,0 +1,123 @@
+/**
+ * Turns a mitata JSON dump into `customSmallerIsBetter` records for the CI
+ * trend job, rejecting anything that would poison the series (#157).
+ *
+ * Split out of `bench-json.ts` so the conversion is testable without running
+ * the bench suite.
+ */
+
+export type MitataStats = { p50: number; p75: number; ticks: number };
+
+export type MitataRun = { name: string; stats?: MitataStats };
+
+export type MitataTrial = { group: number; runs: MitataRun[] };
+
+export type MitataDump = { layout: { name: string | null }[]; benchmarks: MitataTrial[] };
+
+/** One `customSmallerIsBetter` data point. */
+export type BenchmarkRecord = {
+  name: string;
+  unit: 'ns';
+  value: number;
+  range: string;
+  extra: string;
+};
+
+/**
+ * Records that passed validation, plus one message per run that did not. A
+ * rejected run is absent from `records` — callers must treat a non-empty
+ * `problems` as fatal rather than exporting the remainder.
+ */
+export type RecordsResult = { records: BenchmarkRecord[]; problems: string[] };
+
+/** mitata's batch size — `ticks` is a multiple of it whenever batching kicked in. */
+const MITATA_BATCH_SAMPLES = 4096;
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Which sampling mode mitata settled on. `primeBenchFn` pins every bench to
+ * `batch`, so `single` here means that pin broke — the two modes are not
+ * comparable (`single` times one post-GC call per sample and reads 10-30x high
+ * on sub-10 µs work), and a series that changes mode between runs shows a
+ * measurement artefact, not a regression (#143). Recorded in `extra` so the CI
+ * trend artefact carries the evidence.
+ */
+function getSamplingMode(ticks: number): 'batch' | 'single' {
+  return ticks % MITATA_BATCH_SAMPLES === 0 ? 'batch' : 'single';
+}
+
+function isNonEmptyName(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * Why these stats cannot become a record, or `null` when they are usable.
+ * Checked before the numbers are rounded, so a dump-format change surfaces as
+ * a named offender instead of a `NaN` data point.
+ */
+function findStatsProblem({ p50, p75, ticks }: MitataStats): string | null {
+  if (!Number.isFinite(p50) || p50 <= 0) return `p50 is not a positive finite number (${p50})`;
+  if (!Number.isFinite(p75) || p75 < p50) return `p75 is not a finite number >= p50 (${p75})`;
+  // A non-finite `ticks` makes the modulo `NaN`, which silently reports every
+  // bench as `single` and defeats the mode tripwire.
+  if (!Number.isFinite(ticks) || ticks <= 0) {
+    return `ticks is not a positive finite number (${ticks})`;
+  }
+
+  return null;
+}
+
+export function toRecords(dump: MitataDump): RecordsResult {
+  const records: BenchmarkRecord[] = [];
+  const problems: string[] = [];
+
+  for (const trial of dump.benchmarks) {
+    // ? `trial.group` is an index into `layout`; `summary()` nests a collection
+    //   that inherits its parent group's name, so this stays the group label.
+    const group = dump.layout[trial.group]?.name ?? 'ungrouped';
+
+    for (const [index, trialRun] of trial.runs.entries()) {
+      const label = `${group} / ${isNonEmptyName(trialRun.name) ? trialRun.name : `#${index}`}`;
+
+      if (!isNonEmptyName(group)) {
+        problems.push(`${label}: group name is empty`);
+        continue;
+      }
+
+      if (!isNonEmptyName(trialRun.name)) {
+        problems.push(`${label}: case name is empty`);
+        continue;
+      }
+
+      const stats = trialRun.stats;
+
+      if (stats == null) {
+        problems.push(`${label}: missing stats`);
+        continue;
+      }
+
+      const problem = findStatsProblem(stats);
+
+      if (problem != null) {
+        problems.push(`${label}: ${problem}`);
+        continue;
+      }
+
+      const { p50, p75, ticks } = stats;
+      const mode = getSamplingMode(ticks);
+
+      records.push({
+        name: label,
+        unit: 'ns',
+        value: round(p50),
+        range: `± ${round(p75 - p50)} ns`,
+        extra: `group=${group} case=${trialRun.name} p50=${round(p50)}ns p75=${round(p75)}ns mode=${mode}`,
+      });
+    }
+  }
+
+  return { records, problems };
+}


### PR DESCRIPTION
`bench:json` no longer writes a partial or corrupt trend export.

Extracted the mitata dump conversion into `scripts/bench-records.ts` so it is testable without running the bench suite.

Added per-run validation in `toRecords`: non-empty group and case names, present `stats`, finite `p50 > 0`, finite `p75 >= p50`, finite `ticks > 0` — a non-finite `ticks` would otherwise mislabel every bench as `single` and defeat the `mode=` tripwire from #143.

Replaced the silent `continue` on a stats-less run with a reported problem; `bench:json` lists every offender and exits 1 instead of exporting the remainder.

Made the bench registrars return their expected run count and cross-checked it against the record count, so a run vanishing from the dump fails the export instead of silently shrinking the series.

Added `scripts/bench-records.test.ts` with malformed-dump fixtures. A full `bun run bench:json` still writes 85 records with byte-identical names, so the gh-pages trend history is unaffected.

Closes #157
