### PR TITLE
ci: key PR concurrency group on PR number #158

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ on:
   # how a branch gets bench numbers now.
   workflow_dispatch:
 
+# PR events key on the PR number — `head_ref` is the bare fork branch name,
+# so same-named branches from different forks would cancel each other's runs.
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Keys the CI concurrency group on `github.event.pull_request.number` for PR events instead of `github.head_ref`. The bare fork branch name meant two fork PRs sharing a branch name (e.g. GitHub's web-edit default `patch-1`) resolved to the same group, so one contributor's push cancelled the other's in-flight run. Push events fall through to `github.ref` as before, so superseded pushes to the same branch still cancel.

Closes #158

<sub>[Claude Code session](https://claude.ai/code/session_01CXWURRrQf7ZzkXzW8Tv22T)</sub>