### PR TITLE
test: add an automated README example runner #161

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,6 +32,7 @@ classes. v3 has `roll(notation, options)` for the common path, and
 `createMockRng` (exported by `roll-parser/testing`) so their numbers are exact
 rather than whatever the dice happened to do:
 
+<!-- readme-test: skip -->
 ```typescript
 // v2
 const res = parseAndRoll('2d10+1'); // { notation: '2d10+1', value: 9, rolls: [2, 6] }
@@ -49,6 +50,7 @@ res.rolls.map((die) => die.result); // [2, 6] — `rolls` is now DieResult[]
 were easy to miss. v3 throws a typed error with a stable `code` and a source
 span:
 
+<!-- readme-test: skip -->
 ```typescript
 // v2
 if (parseAndRoll(input) == null) {

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -8,6 +8,10 @@ minimumReleaseAge = 259200
 
 [test]
 coverageSkipTestFiles = true
+# `readme.test.ts` imports the built package in-process (the self-reference),
+# which would otherwise pull every `dist/` file into the coverage report and
+# double-count the library against the thresholds below.
+coveragePathIgnorePatterns = ["dist/**"]
 
 # Enforced only when coverage runs (`bun test --coverage`, `test:ci`) — plain
 # `bun test` stays fast. This is the only place the numbers live; CONTRIBUTING.md

--- a/src/cli/package-smoke.test.ts
+++ b/src/cli/package-smoke.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
 import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { ensureFreshDist } from '../test-helpers.js';
 
 type PackageJson = {
   bin?: Record<string, string>;
@@ -25,14 +26,11 @@ async function runCommand(
 
 // The real `build` script, not a reimplementation of it: the assertions below
 // judge the artifact a consumer installs, including the executable bit that
-// `tsc` alone never sets. Its `clean` step is safe here because this is the
-// only test file that touches `dist/`, and `bun test` runs files sequentially
-// in a single process.
+// `tsc` alone never sets. `ensureFreshDist` is shared with `readme.test.ts`
+// and memoized to one build per test run; its `clean` step is safe because
+// `bun test` runs files sequentially in a single process.
 beforeAll(async () => {
-  const { stderr, exitCode } = await runCommand(['bun', 'run', 'build']);
-  if (exitCode !== 0) {
-    throw new Error(`Failed to build packaged CLI smoke target:\n${stderr}`);
-  }
+  await ensureFreshDist();
 });
 
 describe('packaged CLI smoke', () => {

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -1,0 +1,363 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { ensureFreshDist } from './test-helpers.js';
+
+/**
+ * Executes the `typescript` fenced blocks in README.md and MIGRATION.md
+ * against the built package and asserts the outputs their comments claim,
+ * so a doc edit that falsifies an example fails the suite.
+ *
+ * The per-line convention:
+ * - `expr; // <literal>` — evaluate `expr` and compare. Prose after ` — ` or
+ *   a comma is ignored: `// 14, every run` asserts `14`.
+ * - `expr; // throws …` — assert the line throws; when the comment quotes a
+ *   code (`'DICE_LIMIT_EXCEEDED'`), assert `error.code` matches it.
+ * - `expr;` followed by a lone `// <literal>` comment line — same assertion.
+ * - Anything else (`// the kept dice`, `// e.g. 14`, `// 5..15`) — the line
+ *   only executes; a throw still fails the block.
+ *
+ * Blocks are fragments, so they run with an injected scope instead of real
+ * modules: import lines are validated against the actual entry points and
+ * stripped, and every public export plus the free variables some samples
+ * lean on (`userInput`, `notation`, `error`) is provided as a binding.
+ * A `<!-- readme-test: skip -->` HTML comment directly above a fence opts a
+ * block out — used for MIGRATION.md blocks that show the removed v2 API.
+ */
+
+//
+// * Corpus extraction
+//
+
+const DOC_FILES = ['README.md', 'MIGRATION.md'];
+const SKIP_MARKER = '<!-- readme-test: skip -->';
+
+type DocBlock = {
+  file: string;
+  /** 1-based line of the opening fence. */
+  fenceLine: number;
+  lines: string[];
+  skip: boolean;
+};
+
+function extractBlocks(file: string, text: string): DocBlock[] {
+  const lines = text.split('\n');
+  const blocks: DocBlock[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^```(?:typescript|ts)\s*$/.test(lines[i] ?? '')) {
+      continue;
+    }
+
+    let end = i + 1;
+    while (end < lines.length && !/^```\s*$/.test(lines[end] ?? '')) {
+      end++;
+    }
+
+    let above = i - 1;
+    while (above >= 0 && (lines[above] ?? '').trim() === '') {
+      above--;
+    }
+
+    blocks.push({
+      file,
+      fenceLine: i + 1,
+      lines: lines.slice(i + 1, end),
+      skip: (lines[above] ?? '').trim() === SKIP_MARKER,
+    });
+    i = end;
+  }
+
+  return blocks;
+}
+
+//
+// * Expected-output convention
+//
+
+function parseLiteral(text: string): { value: unknown } | null {
+  const raw = text.trim();
+
+  const singleQuoted = raw.match(/^'((?:[^'\\]|\\.)*)'$/);
+  if (singleQuoted) {
+    return { value: (singleQuoted[1] ?? '').replace(/\\(.)/g, '$1') };
+  }
+
+  try {
+    return { value: JSON.parse(raw) as unknown };
+  } catch {
+    return null;
+  }
+}
+
+function parseExpected(comment: string): { value: unknown } | null {
+  const text = comment.trim();
+  // A claimed output often carries prose: `14, every run`, `9 — was `value``.
+  for (const candidate of [text, text.split(' — ')[0] ?? '', text.split(',')[0] ?? '']) {
+    const parsed = parseLiteral(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+//
+// * Block compilation
+//
+
+type DocImport = { specifier: string; names: string[] };
+
+type CompiledBlock = {
+  block: DocBlock;
+  imports: DocImport[];
+  code: string;
+  assertions: number;
+};
+
+const IMPORT_RE = /^import\s+(type\s+)?\{([^}]+)\}\s+from\s+'([^']+)';\s*$/;
+const TRAILING_RE = /^(\s*)(.*?\S)\s*;\s*\/\/\s*(.*)$/;
+const BARE_STATEMENT_RE = /^(\s*)(.*?\S)\s*;\s*$/;
+const COMMENT_LINE_RE = /^\s*\/\/\s*(.*)$/;
+const THROWS_RE = /^throws\b/;
+const THROWS_CODE_RE = /'([A-Z0-9_]+)'/;
+// Only bare expression statements can be wrapped in an assertion callback.
+const NON_EXPRESSION_RE =
+  /^(?:const|let|var|import|export|type|function|class|return|throw)\b|^[})\]]/;
+
+function assertCall(
+  indent: string,
+  line: number,
+  source: string,
+  expr: string,
+  tail: string,
+): string {
+  return `${indent}__assert(${line}, ${JSON.stringify(source)}, () => (${expr}), ${tail});`;
+}
+
+// One output line per input line, so failure messages keep the documented line numbers.
+function compileBlock(block: DocBlock): CompiledBlock {
+  const imports: DocImport[] = [];
+  const out: string[] = [];
+  let assertions = 0;
+
+  for (let i = 0; i < block.lines.length; i++) {
+    const line = block.lines[i] ?? '';
+    const lineNo = block.fenceLine + 1 + i;
+
+    if (/^\s*import\b/.test(line)) {
+      const match = line.match(IMPORT_RE);
+      if (!match) {
+        throw new Error(`${block.file}:${lineNo} — unsupported import form in a doc block`);
+      }
+      const names = match[1]
+        ? []
+        : (match[2] ?? '')
+            .split(',')
+            .map((name) => name.trim())
+            .filter((name) => name !== '' && !name.startsWith('type '));
+      imports.push({ specifier: match[3] ?? '', names });
+      out.push('');
+      continue;
+    }
+
+    const trailing = line.match(TRAILING_RE);
+    if (trailing) {
+      const [, indent = '', expr = '', comment = ''] = trailing;
+      if (!NON_EXPRESSION_RE.test(expr)) {
+        if (THROWS_RE.test(comment.trim())) {
+          const code = comment.match(THROWS_CODE_RE)?.[1] ?? null;
+          out.push(
+            `${indent}__throws(${lineNo}, ${JSON.stringify(line.trim())}, () => (${expr}), ${JSON.stringify(code)});`,
+          );
+          assertions++;
+          continue;
+        }
+        const expected = parseExpected(comment);
+        if (expected) {
+          out.push(assertCall(indent, lineNo, line.trim(), expr, JSON.stringify(expected.value)));
+          assertions++;
+          continue;
+        }
+      }
+      out.push(line);
+      continue;
+    }
+
+    const bare = line.match(BARE_STATEMENT_RE);
+    const nextComment = (block.lines[i + 1] ?? '').match(COMMENT_LINE_RE);
+    if (bare && nextComment) {
+      const [, indent = '', expr = ''] = bare;
+      const expected = NON_EXPRESSION_RE.test(expr) ? null : parseExpected(nextComment[1] ?? '');
+      if (expected) {
+        const source = `${line.trim()} ${(block.lines[i + 1] ?? '').trim()}`;
+        out.push(assertCall(indent, lineNo, source, expr, JSON.stringify(expected.value)));
+        assertions++;
+        continue;
+      }
+    }
+
+    out.push(line);
+  }
+
+  return { block, imports, code: out.join('\n'), assertions };
+}
+
+//
+// * Execution
+//
+
+type AssertFn = (line: number, source: string, actual: () => unknown, expected: unknown) => void;
+type ThrowsFn = (line: number, source: string, run: () => unknown, code: string | null) => void;
+
+const transpiler = new Bun.Transpiler({ loader: 'ts' });
+
+let namespaces: Record<string, Record<string, unknown>> = {};
+let scope: Record<string, unknown> = {};
+
+beforeAll(async () => {
+  await ensureFreshDist();
+
+  // ! Keep the specifier computed — a literal 'roll-parser' fails `tsc --noEmit`
+  // on a fresh clone, where `dist/` (the self-reference target) does not exist yet.
+  const packageName = 'roll-parser';
+  const api = (await import(packageName)) as Record<string, unknown>;
+  const testing = (await import(`${packageName}/testing`)) as Record<string, unknown>;
+  namespaces = { [packageName]: api, [`${packageName}/testing`]: testing };
+
+  const roll = api.roll as (notation: string) => unknown;
+  const notation = '2d6+1d0+3';
+  let error: unknown;
+  try {
+    roll(notation);
+  } catch (caught) {
+    error = caught;
+  }
+
+  scope = {
+    ...api,
+    ...testing,
+    // Free variables the samples use without declaring.
+    userInput: '2d20kh1+5',
+    notation,
+    error,
+    // Samples narrate through console; keep the test output clean.
+    console: { log() {}, error() {}, warn() {}, info() {} },
+  };
+});
+
+function makeAssert(file: string): AssertFn {
+  return (line, source, actual, expected) => {
+    const value = actual();
+    if (!Bun.deepEquals(value, expected, true)) {
+      throw new Error(
+        `${file}:${line} documents an output the code does not produce\n` +
+          `  ${source}\n` +
+          `  expected: ${JSON.stringify(expected)}\n` +
+          `  actual:   ${JSON.stringify(value)}`,
+      );
+    }
+  };
+}
+
+function makeThrows(file: string): ThrowsFn {
+  return (line, source, run, code) => {
+    try {
+      run();
+    } catch (caught) {
+      const actualCode = (caught as { code?: unknown }).code;
+      if (code != null && actualCode !== code) {
+        throw new Error(
+          `${file}:${line} documents a throw with code '${code}', got '${String(actualCode)}'\n  ${source}`,
+        );
+      }
+      return;
+    }
+    throw new Error(`${file}:${line} documents a throw that did not happen\n  ${source}`);
+  };
+}
+
+async function runBlock(compiled: CompiledBlock): Promise<void> {
+  const { block, imports, code } = compiled;
+
+  for (const imp of imports) {
+    const ns = namespaces[imp.specifier];
+    if (!ns) {
+      throw new Error(
+        `${block.file}:${block.fenceLine} imports from '${imp.specifier}', which is not a public entry point`,
+      );
+    }
+    for (const name of imp.names) {
+      if (!(name in ns)) {
+        throw new Error(
+          `${block.file}:${block.fenceLine} imports '${name}', which '${imp.specifier}' does not export`,
+        );
+      }
+    }
+  }
+
+  const js = transpiler.transformSync(code);
+  const bindings = Object.keys(scope).join(', ');
+  const factory = new Function(
+    '__scope',
+    '__assert',
+    '__throws',
+    `'use strict';\nconst { ${bindings} } = __scope;\nreturn (async () => {\n${js}\n})();`,
+  ) as (
+    scopeArg: Record<string, unknown>,
+    assertArg: AssertFn,
+    throwsArg: ThrowsFn,
+  ) => Promise<unknown>;
+
+  await factory(scope, makeAssert(block.file), makeThrows(block.file));
+}
+
+//
+// * Test registration
+//
+
+const corpus: { file: string; compiled: CompiledBlock[]; skipped: DocBlock[] }[] = [];
+for (const file of DOC_FILES) {
+  const text = await Bun.file(new URL(`../${file}`, import.meta.url)).text();
+  const blocks = extractBlocks(file, text);
+  corpus.push({
+    file,
+    compiled: blocks.filter((block) => !block.skip).map(compileBlock),
+    skipped: blocks.filter((block) => block.skip),
+  });
+}
+
+for (const { file, compiled, skipped } of corpus) {
+  describe(`${file} examples`, () => {
+    for (const entry of compiled) {
+      test(`block at line ${entry.block.fenceLine}`, async () => {
+        await runBlock(entry);
+      });
+    }
+    for (const block of skipped) {
+      test.skip(`block at line ${block.fenceLine} (opted out)`, () => {});
+    }
+  });
+}
+
+describe('doc example corpus', () => {
+  test('extraction still finds the fenced blocks', () => {
+    const blocks = corpus.flatMap((entry) => entry.compiled);
+    const assertions = blocks.reduce((sum, entry) => sum + entry.assertions, 0);
+    // Floors, not exact counts — they catch a fence-language or convention
+    // change that silently stops extraction, without rotting on every edit.
+    expect(blocks.length).toBeGreaterThanOrEqual(12);
+    expect(assertions).toBeGreaterThanOrEqual(15);
+  });
+
+  test('the trailing-comment convention parses the shapes the docs use', () => {
+    expect(parseExpected("'binaryOp'")).toEqual({ value: 'binaryOp' });
+    expect(parseExpected('14, every run')).toEqual({ value: 14 });
+    expect(parseExpected('9          — was `value`')).toEqual({ value: 9 });
+    expect(parseExpected('[4, 0]')).toEqual({ value: [4, 0] });
+    expect(parseExpected("'2d6[2, 6] + 3 = 11'")).toEqual({ value: '2d6[2, 6] + 3 = 11' });
+    expect(parseExpected('true, at every level of the tree')).toEqual({ value: true });
+    expect(parseExpected('e.g. 14')).toBeNull();
+    expect(parseExpected('5..15')).toBeNull();
+    expect(parseExpected('the kept dice')).toBeNull();
+    expect(parseExpected('DegreeOfSuccess.Success (2)')).toBeNull();
+  });
+});

--- a/src/test-helpers.test.ts
+++ b/src/test-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ParseError } from './parser/parser.js';
-import { expectRollError } from './test-helpers.js';
+import { buildDist, expectRollError } from './test-helpers.js';
 
 describe('expectRollError', () => {
   const throwParseError = () => {
@@ -29,5 +29,13 @@ describe('expectRollError', () => {
         'UNEXPECTED_TOKEN',
       ),
     ).toThrow('Expected ParseError');
+  });
+});
+
+describe('buildDist', () => {
+  it('fails when the build command exits non-zero', async () => {
+    await expect(buildDist(['bun', '-e', 'process.exit(1)'])).rejects.toThrow(
+      'Failed to rebuild dist/ for tests',
+    );
   });
 });

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,6 +1,35 @@
 import { expect } from 'bun:test';
 import type { RollParserError, RollParserErrorCode } from './errors.js';
 
+let distBuild: Promise<void> | undefined;
+
+/**
+ * Runs the real `build` script once per test process, so suites that exercise
+ * `dist/` (the package self-reference, the packed CLI) see the current source
+ * rather than a stale emit. Memoized because `bun test` runs every file
+ * sequentially in one process — the first caller pays for the build, and the
+ * `clean` step inside `build` cannot race another test file.
+ */
+export function ensureFreshDist(): Promise<void> {
+  distBuild ??= buildDist(['bun', 'run', 'build']);
+  return distBuild;
+}
+
+/** Exported for its own failure-path test; use {@link ensureFreshDist}. */
+export async function buildDist(command: string[]): Promise<void> {
+  const proc = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
+  // Drain both pipes — an unread pipe can block the child, and `tsc` reports
+  // its diagnostics on stdout.
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`Failed to rebuild dist/ for tests:\n${stdout}${stderr}`);
+  }
+}
+
 /**
  * Asserts that `fn` throws `ErrorClass` carrying `code`, and returns the error
  * so call sites can go on to assert spans, tokens, or message text.


### PR DESCRIPTION
## Changes

- Added `src/readme.test.ts`: extracts the `typescript` fenced blocks from README.md and MIGRATION.md, executes them against the built package (self-reference into `dist/`), and asserts the outputs claimed by `expr; // <literal>` trailing comments; supports `throws` comments, next-line expected-output comments, and treats prose comments as execute-only
- Validated doc-block imports against the real entry points; unseeded examples execute without output assertions
- Added a `<!-- readme-test: skip -->` opt-out marker, applied to the two MIGRATION.md blocks that show the removed v2 API
- Extracted a memoized `ensureFreshDist()` into `src/test-helpers.ts`, shared by `package-smoke.test.ts` and the runner, so one `bun run build` serves the whole test run; both spawn pipes are drained and `tsc` diagnostics from stdout are included in failures
- Covered the `buildDist()` failure path in `src/test-helpers.test.ts`
- Ignored `dist/**` in Bun coverage — the in-process import of the built package otherwise double-counts the library against the thresholds

Closes #161

<sub>[Claude Code session](https://claude.ai/code/d9016176-2d5c-4261-94da-cb9e51bea5a2)</sub>
