### PR TITLE
test: execute the browser smoke bundle in a real browser #160

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,3 +480,80 @@ jobs:
 
       - name: Execute browser bundle
         run: node "$RUNNER_TEMP/browser-smoke/bundle.js"
+
+      # `browser-run` executes these exact bytes in Chromium — the same bundle
+      # the grep above just cleared.
+      - name: Upload browser bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: browser-bundle
+          path: ${{ runner.temp }}/browser-smoke/bundle.js
+          retention-days: 1
+          if-no-files-found: error
+
+  # Executes the browser-smoke bundle where it claims to work: real headless
+  # Chromium, with browser globals present and Node's absent. The cheap proxy
+  # checks (esbuild platform errors + grep + Node execution) stay on every
+  # push in `browser-smoke`; this leg costs a Playwright browser download, so
+  # it runs on default-branch pushes and manual dispatches only — the same
+  # gate as `bench`, and how a feature branch gets a browser run pre-merge.
+  browser-run:
+    name: Browser Execution Test
+    runs-on: ubuntu-latest
+    needs: browser-smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # lts/* keeps `node run.ts` on native type stripping (default since 23.6).
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          # ! No package-lock.json in this repo — setup-node's npm auto-cache
+          # ! (on by default since v5) hard-fails when it cannot find one.
+          package-manager-cache: false
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./scripts/browser-smoke/node_modules/playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Chromium
+        run: ./scripts/browser-smoke/node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Download browser bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: browser-bundle
+          path: ${{ runner.temp }}/browser-run
+
+      - name: Execute bundle in headless Chromium
+        run: node scripts/browser-smoke/run.ts "$RUNNER_TEMP/browser-run/bundle.js"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,32 @@ jobs:
       - name: Execute browser bundle
         run: node "$RUNNER_TEMP/smoke/bundle.js"
 
+      # The Node-22.12 steps above are done proving the engines floor; the
+      # browser leg needs lts/* so `node run.ts` gets native type stripping.
+      - name: Setup Node.js (lts for the browser harness)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          # ! No package-lock.json in this repo — setup-node's npm auto-cache
+          # ! (on by default since v5) hard-fails when it cannot find one.
+          package-manager-cache: false
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./scripts/browser-smoke/node_modules/playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Chromium
+        run: ./scripts/browser-smoke/node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Execute bundle in headless Chromium
+        run: node scripts/browser-smoke/run.ts "$RUNNER_TEMP/smoke/bundle.js"
+
   # Deliberately minimal: no checkout, no dependency install, no cache — the
   # only thing that runs next to the OIDC publishing identity is npm itself,
   # publishing the exact tarball `validate` produced and `smoke` verified.

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,13 @@
         "typescript": "^7.0.2",
       },
     },
+    "scripts/browser-smoke": {
+      "name": "@roll-parser/browser-smoke",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwright": "^1.62.0",
+      },
+    },
     "scripts/docs": {
       "name": "@roll-parser/docs-builder",
       "version": "0.0.0",
@@ -113,6 +120,8 @@
     "@loaderkit/resolve": ["@loaderkit/resolve@1.0.6", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg=="],
 
     "@publint/pack": ["@publint/pack@0.1.6", "", { "dependencies": { "tinyexec": "^1.2.4" } }, "sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA=="],
+
+    "@roll-parser/browser-smoke": ["@roll-parser/browser-smoke@workspace:scripts/browser-smoke"],
 
     "@roll-parser/docs-builder": ["@roll-parser/docs-builder@workspace:scripts/docs"],
 
@@ -234,6 +243,8 @@
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -283,6 +294,10 @@
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+
+    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
 
     "publint": ["publint@0.3.22", "", { "dependencies": { "@publint/pack": "^0.1.6", "package-manager-detector": "^1.7.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "./src/cli.js" } }, "sha512-6Z/scsr5CA7APdwyF35EY88CqgDj1textWuY788DVTJYPCWVv/Wn9G6KmLnrVRnStgYcahqN4wCDLZGSbQJ69w=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "workspaces": ["scripts/docs"],
+  "workspaces": ["scripts/browser-smoke", "scripts/docs"],
   "scripts": {
     "prepare": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || exit 0",
     "typecheck": "tsc --noEmit && bun run build && tsc --noEmit -p site/tsconfig.json && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p bench/tsconfig.json",

--- a/scripts/browser-smoke/package.json
+++ b/scripts/browser-smoke/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@roll-parser/browser-smoke",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Isolated dependency tree for the real-browser smoke harness. Playwright and its Chromium download are CI-only weight, so they live here rather than in the root dependency tree — same pattern as scripts/docs. The harness (run.ts) executes the browser-smoke bundle in headless Chromium; see .github/workflows/ci.yml and release.yml for the jobs that run it.",
+  "dependencies": {
+    "playwright": "^1.62.0"
+  }
+}

--- a/scripts/browser-smoke/run.ts
+++ b/scripts/browser-smoke/run.ts
@@ -1,0 +1,135 @@
+/**
+ * Executes a browser-smoke bundle in real headless Chromium.
+ *
+ * Serves the bundle as a module script over local HTTP (module scripts
+ * misreport errors on file:// and data: origins), then passes only when the
+ * fixture's success log appears — and fails on any page error, console error,
+ * or unhandled rejection, whichever comes first.
+ *
+ * Usage: node scripts/browser-smoke/run.ts <bundle.js>
+ */
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { chromium } from 'playwright';
+
+const SUCCESS_MARKER = 'browser-smoke OK';
+const TIMEOUT_MS = 30_000;
+// Lets in-flight async failures surface before the run is declared green.
+const SETTLE_MS = 250;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const bundlePath = process.argv[2];
+if (!bundlePath) {
+  console.error('Usage: node scripts/browser-smoke/run.ts <bundle.js>');
+  process.exit(1);
+}
+
+const bundle = await readFile(bundlePath);
+
+// Chromium reports unhandled rejections as pageerror only for Error reasons;
+// this listener surfaces non-Error rejections as console errors.
+const harnessHtml = `<!doctype html>
+<html>
+<head>
+<script>
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('unhandledrejection: ' + event.reason);
+});
+</script>
+<script type="module" src="/bundle.js"></script>
+</head>
+<body></body>
+</html>`;
+
+const server = createServer((req, res) => {
+  if (req.url === '/') {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(harnessHtml);
+  } else if (req.url === '/bundle.js') {
+    res.writeHead(200, { 'content-type': 'text/javascript' });
+    res.end(bundle);
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const port = await new Promise<number>((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', () => {
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      reject(new Error('Server did not report a bound port.'));
+      return;
+    }
+    resolve(address.port);
+  });
+});
+
+const failures: string[] = [];
+let reportSuccess = (): void => {};
+const successSeen = new Promise<void>((resolve) => {
+  reportSuccess = resolve;
+});
+let reportFailure = (): void => {};
+const failureSeen = new Promise<void>((resolve) => {
+  reportFailure = resolve;
+});
+
+function fail(reason: string): void {
+  failures.push(reason);
+  reportFailure();
+}
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext();
+  context.on('weberror', (webError) => fail(`weberror: ${webError.error().message}`));
+
+  const page = await context.newPage();
+  page.on('pageerror', (error) => fail(`pageerror: ${error.message}`));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      fail(`console.error: ${message.text()}`);
+    } else if (message.text().startsWith(SUCCESS_MARKER)) {
+      console.log(`Fixture logged: ${message.text()}`);
+      reportSuccess();
+    }
+  });
+
+  // A wedged page load would otherwise throw Playwright's own navigation
+  // timeout past the reporting below.
+  try {
+    await page.goto(`http://127.0.0.1:${port}/`, { timeout: TIMEOUT_MS });
+  } catch (error) {
+    fail(`navigation: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const result = await Promise.race([
+    successSeen.then(() => 'success' as const),
+    failureSeen.then(() => 'failure' as const),
+    delay(TIMEOUT_MS).then(() => 'timeout' as const),
+  ]);
+  if (result === 'success') {
+    await delay(SETTLE_MS);
+  }
+  if (result === 'timeout') {
+    fail(`timeout: no "${SUCCESS_MARKER}" console log within ${TIMEOUT_MS}ms`);
+  }
+
+  if (failures.length > 0) {
+    console.error('Browser execution failed:');
+    for (const failure of failures) {
+      console.error(`  ${failure}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log('Browser execution OK (headless Chromium).');
+  }
+} finally {
+  await browser.close();
+  server.close();
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,5 +3,6 @@
   "extends": "../tsconfig.json",
   // Non-recursive on purpose: `docs/` is a workspace that exists only to hold a
   // nested TypeDoc dependency tree (see its `package.json`), and has no sources.
-  "include": ["*.ts"]
+  // `browser-smoke/` has sources, so it is listed explicitly.
+  "include": ["*.ts", "browser-smoke/*.ts"]
 }


### PR DESCRIPTION
## Changes

- Added `scripts/browser-smoke` workspace isolating the `playwright` dependency from the root tree (the `scripts/docs` nesting pattern)
- Added `run.ts` harness: serves the bundle as a module script over local HTTP, executes it in headless Chromium, fails on any `pageerror`, console error, unhandled rejection, or navigation hang, and passes only when the fixture's success log appears within a timeout
- Added a `browser-run` CI job gated to default-branch pushes and manual dispatches (same gate as `bench`), consuming the exact bundle the `browser-smoke` grep cleared via a new artifact, with Playwright browsers cached keyed on the resolved version
- Extended the release `smoke` job with the same Chromium execution against the release tarball's bundle; the credentialed `publish` path is untouched

Negative test verified locally with a `process.version` probe: the issue's suggested `process.env` read is neutralized by esbuild's automatic `NODE_ENV` define under `--platform=browser --minify` and never reaches the browser. Async failures arriving after the success log are also caught via a settle window.

Closes #160

<sub>[Claude Code session](https://claude.ai/code/34df95f3-1226-46f8-9626-ec3bfaac71b3)</sub>
