### PR TITLE
test: add explicit timeout to dist-building test hooks #189

### DIFF
--- a/src/cli/package-smoke.test.ts
+++ b/src/cli/package-smoke.test.ts
@@ -31,7 +31,7 @@ async function runCommand(
 // `bun test` runs files sequentially in a single process.
 beforeAll(async () => {
   await ensureFreshDist();
-});
+}, 60_000);
 
 describe('packaged CLI smoke', () => {
   test('package bin points to the built executable', async () => {

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -252,7 +252,7 @@ beforeAll(async () => {
     // Samples narrate through console; keep the test output clean.
     console: { log() {}, error() {}, warn() {}, info() {} },
   };
-});
+}, 60_000);
 
 function lookupCase<K extends DocCase['kind']>(
   file: string,


### PR DESCRIPTION
## Changes

- Passed `60_000` as the per-hook timeout to the `beforeAll` in `src/readme.test.ts` and `src/cli/package-smoke.test.ts`, the only two hooks that rebuild `dist/` through `ensureFreshDist()`

Both hooks ran under Bun's 5s default. The build is ~0.3s normally, but an 11s build was observed under heavy parallel load, and `test:ci` runs with `--bail`, so one slow build failed the whole gate. `ensureFreshDist`, the scripts, and all per-test timeouts are untouched — tests keep the 5s default.

Verified in both directions: with `await Bun.sleep(6000)` injected into the smoke hook, the file fails at 5001ms without the second argument and passes at 6.56s with it. `bun run check` and the full suite (1342 passed) are green.

Closes #189

<sub>[Claude Code session](https://claude.ai/code/34df95f3-1226-46f8-9626-ec3bfaac71b3)</sub>
