### PR TITLE
test: add guard-heavy and count-one keep/drop bench cases #190

### DIFF
--- a/bench/_cases.ts
+++ b/bench/_cases.ts
@@ -57,6 +57,7 @@ export const BENCH_CASES: BenchCase[] = [
   { id: '4dF', notation: '4dF', tier: 'simple' },
 
   { id: '4d6kh3', notation: '4d6kh3', tier: 'common' },
+  { id: '{1d6+2}kh1', notation: '{1d6+2}kh1', tier: 'common' },
   { id: '2d20kh1 vs 15', notation: '2d20kh1 vs 15', tier: 'common' },
   { id: '10d10>=6f1', notation: '10d10>=6f1', tier: 'common' },
   { id: '4d6r<2', notation: '4d6r<2', tier: 'common', variableWork: true },
@@ -72,6 +73,7 @@ export const BENCH_CASES: BenchCase[] = [
   },
   { id: 'sum-20-terms', notation: FLAT_SUM_NOTATION, tier: 'heavy' },
   { id: '100d6', notation: '100d6', tier: 'heavy' },
+  { id: '100d6kh1', notation: '100d6kh1', tier: 'heavy' },
 
   { id: '1000d6', notation: '1000d6', tier: 'pathological' },
 ];


### PR DESCRIPTION
## Changes

- Added `{ id: '100d6kh1', notation: '100d6kh1', tier: 'heavy' }` to `BENCH_CASES`, after `100d6` so the keep/drop overhead reads as a side-by-side delta. `count === 1` routes unconditionally to `markSingleExtreme` (`src/evaluator/modifiers/keep-drop.ts:32`), and a 100-die pool is large enough that the #164 linear scan is distinguishable from the comparator sort it replaced — unlike `2d20kh1 vs 15`, where the two are indistinguishable on a pool of two
- Added `{ id: '{1d6+2}kh1', notation: '{1d6+2}kh1', tier: 'common' }` to `BENCH_CASES`, after `4d6kh3`. This is the guard-heavy shape named in #163, isolating a parse cost that `{2d20kh1+5, 3d8!}kh1` only measures diluted across subgroups, explode, keep/drop, and arithmetic

Neither case sets `variableWork` — no explode or reroll, so per-iteration work is value-independent and both join `FIXED_WORK_CASES` for the extra `roll (injected RNG)` series. Verified empirically over 200 rolls each: `100d6kh1` always yields 100 dice, `{1d6+2}kh1` always 1. No count plumbing was needed — all four registrars derive their totals from `BENCH_CASES.length` / `FIXED_WORK_CASES.length`, and `scripts/bench-json.ts` compares against those returned totals. Existing ids are untouched and keep their relative order.

`bun run bench:json` reports 95 records with no failures. New series read sensibly against neighbors: `100d6kh1` evaluate lands at 13.7 µs between `100d6` (4.3 µs) and `1000d6` (39.8 µs), and `{1d6+2}kh1` parse at 371 ns sits above `4d6kh3` at 239 ns.

One correction to the issue body: a bare `kh` reaches `someDescendant` twice (via `rejectVersusTarget` and `deepContainsDicePool`) but not `unwrapAllTransparent`, which `parseSort` and the explode/reroll guards own. #163 rewrote `someDescendant` as well, and that recursive walk was its dominant target, so the case still tracks the optimization.

Closes #190

<sub>[Claude Code session](https://claude.ai/code/a4f18b36-0524-4baf-a899-66ee565a7239)</sub>
