### PR TITLE
fix: reject missing group mappings and duplicate bench record names #191

### DIFF
--- a/scripts/bench-records.test.ts
+++ b/scripts/bench-records.test.ts
@@ -56,16 +56,6 @@ describe('toRecords', () => {
       expect(records[0]).toMatchObject({ range: '± 0 ns' });
     });
 
-    it('labels a run whose group is absent from the layout as ungrouped', () => {
-      const { records, problems } = toRecords({
-        layout: [],
-        benchmarks: [{ group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] }],
-      });
-
-      expect(problems).toEqual([]);
-      expect(records[0]).toMatchObject({ name: 'ungrouped / 1d20' });
-    });
-
     it('resolves the group name per trial', () => {
       const { records } = toRecords({
         layout: [{ name: 'lex' }, { name: 'parse' }],
@@ -76,6 +66,19 @@ describe('toRecords', () => {
       });
 
       expect(records.map((record) => record.name)).toEqual(['parse / 1d20', 'lex / 1d20']);
+    });
+
+    it('keeps the same case name under different groups', () => {
+      const { records, problems } = toRecords({
+        layout: [{ name: 'lex' }, { name: 'parse' }],
+        benchmarks: [
+          { group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+          { group: 1, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+        ],
+      });
+
+      expect(problems).toEqual([]);
+      expect(records.map((record) => record.name)).toEqual(['lex / 1d20', 'parse / 1d20']);
     });
 
     it('returns nothing for an empty dump', () => {
@@ -107,7 +110,71 @@ describe('toRecords', () => {
       const { records, problems } = toRecords(dumpOf('  ', { name: '1d20', stats: GOOD_STATS }));
 
       expect(records).toEqual([]);
-      expect(problems).toEqual(['   / 1d20: group name is empty']);
+      expect(problems).toEqual(['#0 / 1d20: group 0 has no name in the layout']);
+    });
+
+    it('rejects a run whose group is absent from the layout (#191)', () => {
+      const { records, problems } = toRecords({
+        layout: [],
+        benchmarks: [{ group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] }],
+      });
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual(['#0 / 1d20: group 0 has no name in the layout']);
+    });
+
+    it('rejects a run whose group name is null (#191)', () => {
+      const { records, problems } = toRecords(dumpOf(null, { name: '1d20', stats: GOOD_STATS }));
+
+      expect(records).toEqual([]);
+      expect(problems).toEqual(['#0 / 1d20: group 0 has no name in the layout']);
+    });
+
+    it('reports every run of a trial whose group is unresolvable (#191)', () => {
+      const { records, problems } = toRecords({
+        layout: [{ name: 'lex' }],
+        benchmarks: [
+          { group: 1, runs: [{ name: '1d20', stats: GOOD_STATS }, { name: '3d6' }] },
+          { group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+        ],
+      });
+
+      expect(records.map((record) => record.name)).toEqual(['lex / 1d20']);
+      expect(problems).toEqual([
+        '#1 / 1d20: group 1 has no name in the layout',
+        '#1 / 3d6: group 1 has no name in the layout',
+      ]);
+    });
+
+    it('rejects a record name duplicated within a trial (#191)', () => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20', stats: GOOD_STATS }, { name: '1d20', stats: GOOD_STATS }),
+      );
+
+      expect(records.map((record) => record.name)).toEqual(['lex / 1d20']);
+      expect(problems).toEqual(['lex / 1d20: duplicate record name']);
+    });
+
+    it('rejects a record name duplicated across trials (#191)', () => {
+      const { records, problems } = toRecords({
+        layout: [{ name: 'lex' }],
+        benchmarks: [
+          { group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+          { group: 0, runs: [{ name: '1d20', stats: GOOD_STATS }] },
+        ],
+      });
+
+      expect(records.map((record) => record.name)).toEqual(['lex / 1d20']);
+      expect(problems).toEqual(['lex / 1d20: duplicate record name']);
+    });
+
+    it('claims a name only once a record is emitted (#191)', () => {
+      const { records, problems } = toRecords(
+        dumpOf('lex', { name: '1d20' }, { name: '1d20', stats: GOOD_STATS }),
+      );
+
+      expect(records.map((record) => record.name)).toEqual(['lex / 1d20']);
+      expect(problems).toEqual(['lex / 1d20: missing stats']);
     });
 
     it('reports an empty case name', () => {

--- a/scripts/bench-records.ts
+++ b/scripts/bench-records.ts
@@ -73,17 +73,21 @@ function findStatsProblem({ p50, p75, ticks }: MitataStats): string | null {
 export function toRecords(dump: MitataDump): RecordsResult {
   const records: BenchmarkRecord[] = [];
   const problems: string[] = [];
+  const seen = new Set<string>();
 
   for (const trial of dump.benchmarks) {
     // ? `trial.group` is an index into `layout`; `summary()` nests a collection
     //   that inherits its parent group's name, so this stays the group label.
-    const group = dump.layout[trial.group]?.name ?? 'ungrouped';
+    const group = dump.layout[trial.group]?.name;
+    const groupLabel = isNonEmptyName(group) ? group : `#${trial.group}`;
 
     for (const [index, trialRun] of trial.runs.entries()) {
-      const label = `${group} / ${isNonEmptyName(trialRun.name) ? trialRun.name : `#${index}`}`;
+      const label = `${groupLabel} / ${isNonEmptyName(trialRun.name) ? trialRun.name : `#${index}`}`;
 
+      // Every bench registers inside a `group()`, so an index the layout cannot
+      // resolve means a corrupt dump, never a legitimately ungrouped bench.
       if (!isNonEmptyName(group)) {
-        problems.push(`${label}: group name is empty`);
+        problems.push(`${label}: group ${trial.group} has no name in the layout`);
         continue;
       }
 
@@ -105,6 +109,15 @@ export function toRecords(dump: MitataDump): RecordsResult {
         problems.push(`${label}: ${problem}`);
         continue;
       }
+
+      // The count check cannot catch this: a duplicate plus a dropped run leaves
+      // the total intact while one series carries another's numbers.
+      if (seen.has(label)) {
+        problems.push(`${label}: duplicate record name`);
+        continue;
+      }
+
+      seen.add(label);
 
       const { p50, p75, ticks } = stats;
       const mode = getSamplingMode(ticks);


### PR DESCRIPTION
`toRecords` now rejects a dump whose `trial.group` resolves to no `layout` entry or to a blank name, instead of renaming it to `ungrouped` — the fallback kept the record count intact while the real series stalled and a phantom `ungrouped / <case>` series appeared. One problem is pushed per affected run, naming the group index, and the previous empty-group check is absorbed by it. Duplicate record labels are tracked in a dump-scoped `Set` and rejected within and across trials.

Verified with `bun validate` and a real `bun run bench:json` run (95 records, no false rejections).

Closes #191
