### PR TITLE
chore: audit and tighten inline comments repo-wide #195

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -11,6 +11,29 @@ a plain comment. Never combine two prefixes.
 | `// ?` | blue | **Not settled**: a hack, a temporary fix, a guess, something still in doubt. |
 | `// TODO:` | — | Actionable follow-up. Imperative verb, `[#123]` when an issue exists. |
 
+## Continuation lines
+
+The highlighter colors **per line**, so a prefix on the first line only leaves the rest
+of the block uncolored. Repeat the prefix on every line the block covers. Never continue
+with a bare indented `//` — that line loses the color and stops looking like part of the
+warning.
+
+```ts
+// ! Fate dice use `sides === 0` as a sentinel.
+// ! A renderer that reads it as a real side count emits `d0`.
+
+// Unrelated note: no prefix, no indent, blank line between the two blocks.
+const sides = die.sides;
+```
+
+Wrong — line two loses the color, and line three reads as part of the warning:
+
+```ts
+// ! Fate dice use `sides === 0` as a sentinel.
+//   A renderer that reads it as a real side count emits `d0`.
+// Unrelated note.
+```
+
 ## `// ?` is for doubt, not for rationale
 
 This is the one that gets misused. A finished decision with a non-obvious reason is
@@ -30,7 +53,8 @@ If removing the uncertainty would not change the comment, it should not be `// ?
 ## `// *` sections
 
 Wrap in blank `//` lines. Header ≤ 4 words. Never `// ----`, `// ====`, or numbered
-headers.
+headers. The `*` stays on the header line alone — the blank `//` lines carry no text, so
+the continuation rule above does not apply to them.
 
 ```ts
 //

--- a/bench/evaluate.bench.ts
+++ b/bench/evaluate.bench.ts
@@ -44,10 +44,8 @@ export function registerEvaluateBenches(): number {
         const ast = parse(benchCase.notation);
         const options = getEvaluateOptions(benchCase);
 
-        // Each sample charges `SeededRNG` construction alongside evaluation.
-        // Deliberate: `roll()` builds one RNG per call, so this is the shipped
-        // hot path — and renaming or splitting the series now would orphan the
-        // gh-pages trend history.
+        // Charging `SeededRNG` construction per sample matches `roll()`, the shipped
+        // hot path; renaming or splitting the series would orphan the trend history.
         bench(benchCase.id, function* () {
           yield primeBenchFn(() => {
             do_not_optimize(evaluate(ast, new SeededRNG(BENCH_SEED), options));
@@ -59,8 +57,8 @@ export function registerEvaluateBenches(): number {
     });
   });
 
-  // ? Tripwire for accidental O(n²) work in pool handling — keep/drop sorts the
-  //   pool, so `kh(n/2)` is the shape most likely to regress super-linearly.
+  // Tripwire for accidental O(n²) work in pool handling — keep/drop sorts the pool,
+  // so `kh(n/2)` is the shape most likely to regress super-linearly.
   group('evaluate — pool scaling', () => {
     bench('$nd6', function* (state: { get(name: string): number }) {
       const size = state.get('n');

--- a/bench/lex.bench.ts
+++ b/bench/lex.bench.ts
@@ -15,8 +15,7 @@ export function registerLexBenches(): number {
   group('lex', () => {
     summary(() => {
       for (const { id, notation } of BENCH_CASES) {
-        // ? Generator form so `primeBenchFn` runs right before mitata's
-        //   warm-up — see its doc comment for why that is load-bearing.
+        // Generator form so `primeBenchFn` runs right before mitata's warm-up.
         bench(id, function* () {
           yield primeBenchFn(() => {
             do_not_optimize(lex(notation));

--- a/bench/parse.bench.ts
+++ b/bench/parse.bench.ts
@@ -15,8 +15,7 @@ export function registerParseBenches(): number {
   group('parse', () => {
     summary(() => {
       for (const { id, notation } of BENCH_CASES) {
-        // ? Generator form so `primeBenchFn` runs right before mitata's
-        //   warm-up — see its doc comment for why that is load-bearing.
+        // Generator form so `primeBenchFn` runs right before mitata's warm-up.
         bench(id, function* () {
           yield primeBenchFn(() => {
             do_not_optimize(parse(notation));

--- a/bench/roll.bench.ts
+++ b/bench/roll.bench.ts
@@ -31,8 +31,7 @@ export function registerRollBenches(): number {
       for (const benchCase of BENCH_CASES) {
         const options = { ...getRollOptions(benchCase), seed: BENCH_SEED };
 
-        // ? Generator form so `primeBenchFn` runs right before mitata's
-        //   warm-up — see its doc comment for why that is load-bearing.
+        // Generator form so `primeBenchFn` runs right before mitata's warm-up.
         bench(benchCase.id, function* () {
           yield primeBenchFn(() => {
             do_not_optimize(roll(benchCase.notation, options));

--- a/scripts/bench-json.ts
+++ b/scripts/bench-json.ts
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
   let dump = '';
 
   // ! `debug` and `samples` must stay disabled — mitata's default JSON dump
-  //   embeds every raw sample and is ~23 MB for this suite.
+  // ! embeds every raw sample and is ~23 MB for this suite.
   await run({
     format: { json: { debug: false, samples: false } },
     print: (chunk: string) => {
@@ -50,8 +50,9 @@ async function main(): Promise<void> {
   }
 
   // ! Never write a partial series: the CI trend compares against whatever
-  //   landed last, so a shrunk or corrupt export reads as a phantom regression
-  //   on every later run (#157).
+  // ! landed last, so a shrunk export reads as a phantom regression on every
+  // ! later run, and a renamed or duplicated record keeps the count valid while
+  // ! the real series stalls.
   if (failures.length > 0) {
     console.error('bench-json: refusing to write a partial or corrupt export');
 

--- a/scripts/bench-records.ts
+++ b/scripts/bench-records.ts
@@ -76,8 +76,8 @@ export function toRecords(dump: MitataDump): RecordsResult {
   const seen = new Set<string>();
 
   for (const trial of dump.benchmarks) {
-    // ? `trial.group` is an index into `layout`; `summary()` nests a collection
-    //   that inherits its parent group's name, so this stays the group label.
+    // `trial.group` indexes `layout`; `summary()` nests a collection that inherits
+    // its parent group's name, so this stays the group label.
     const group = dump.layout[trial.group]?.name;
     const groupLabel = isNonEmptyName(group) ? group : `#${trial.group}`;
 

--- a/scripts/browser-smoke/run.ts
+++ b/scripts/browser-smoke/run.ts
@@ -100,8 +100,8 @@ try {
     }
   });
 
-  // A wedged page load would otherwise throw Playwright's own navigation
-  // timeout past the reporting below.
+  // A wedged load would otherwise throw Playwright's navigation timeout past the
+  // reporting below.
   try {
     await page.goto(`http://127.0.0.1:${port}/`, { timeout: TIMEOUT_MS });
   } catch (error) {

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -96,12 +96,12 @@ function extractReferences(html: string): string[] {
 
 function isLocalAsset(reference: string): boolean {
   if (reference === '') return false;
-  // ? Protocol-relative URLs start with `//`, so test them before the leading-slash case.
+  // Protocol-relative URLs start with `//`, so test them before the leading-slash case.
   if (reference.startsWith('//')) return false;
   if (/^[a-z]+:/i.test(reference)) return false;
   if (reference.startsWith('#')) return false;
-  // Root-absolute references belong to `404.html`, which is served at arbitrary
-  // depths and so links to routes rather than to files.
+  // Root-absolute references belong to `404.html`, served at arbitrary depths, so
+  // they name routes rather than files.
   if (reference.startsWith('/')) return false;
 
   const [path] = reference.split(/[?#]/);

--- a/scripts/check-version.ts
+++ b/scripts/check-version.ts
@@ -3,8 +3,8 @@ import pkg from '../package.json' with { type: 'json' };
 const input = process.argv[2];
 const pkgVersion = pkg.version;
 
-// The generated src/version.ts must always match package.json — it is what
-// the published library actually exports as VERSION.
+// src/version.ts is what the published library exports as VERSION, so it must
+// never drift from package.json.
 const versionFile = Bun.file(new URL('../src/version.ts', import.meta.url));
 const versionSource = (await versionFile.exists()) ? await versionFile.text() : '';
 const srcVersion = versionSource.match(/^export const version = '(.+)';\r?$/m)?.[1];

--- a/site/src/dice.ts
+++ b/site/src/dice.ts
@@ -200,9 +200,8 @@ export function renderDie(die: DieResult, index: number, folded = false): string
   const facets = facetsFor(die.sides);
   const facetGroup = facets !== '' ? `<g class="die-facets">${facets}</g>` : '';
   const classes = ['die', ...dieStates(die), ...(folded ? ['is-folded'] : [])].join(' ');
-  // Folded dice also carry their index within the folded run, so unfolding can
-  // re-base the stagger on `--j`. Keying off `--i` there would delay the first
-  // revealed die by the whole visible row before it even starts.
+  // `--j` is the index within the folded run, so unfolding re-bases the stagger on
+  // it — `--i` would delay the first revealed die by the whole visible row.
   const foldIndex = folded ? `;--j:${index - MAX_TRAY_DICE}` : '';
 
   return [

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -205,7 +205,7 @@ async function copyLink(): Promise<void> {
   try {
     await navigator.clipboard.writeText(url);
   } catch {
-    // ? Clipboard API can reject on insecure/denied contexts — fall back to select.
+    // Clipboard API rejects on insecure or permission-denied contexts.
     input.focus();
   }
 

--- a/site/src/reference.ts
+++ b/site/src/reference.ts
@@ -245,9 +245,8 @@ function mount(): void {
 
   guide.addEventListener('click', (event) => {
     const target = event.target as HTMLElement;
-    // Let the playground link navigate, and the overflow chip unfold its tray,
-    // instead of rolling. Neither stops propagation — the delegated tray
-    // toggle on `document` still sees the chip click.
+    // Let the playground link navigate and the overflow chip unfold its tray instead
+    // of rolling — neither stops propagation, so the delegated tray toggle still fires.
     if (target.closest('.widget-open') != null) return;
     if (target.closest('button.die-overflow') != null) return;
 

--- a/site/src/render.ts
+++ b/site/src/render.ts
@@ -269,7 +269,7 @@ function expressionNote(result: RollResult): string {
 
 /** Renders the full result panel content for a successful roll. */
 export function renderResultPanel(result: RollResult): string {
-  // ? Success counting reframes the roll — lead with the counts, not the sum.
+  // Success counting reframes the roll — lead with the counts, not the sum.
   const emphasizeCounts = result.successes != null;
   const totalBlock = emphasizeCounts
     ? successSummary(result)

--- a/site/src/theme.ts
+++ b/site/src/theme.ts
@@ -52,9 +52,8 @@ export function initTheme(): void {
     if (event.key === THEME_KEY) applyTheme(getStoredTheme());
   });
 
-  // Re-apply when restored from the back/forward cache: bfcache restores a
-  // frozen page without re-running scripts, so a theme changed on another page
-  // (e.g. the docs) would otherwise stay stale until a manual reload.
+  // bfcache restores a frozen page without re-running scripts, so a theme changed
+  // on another page (e.g. the docs) would otherwise stay stale until a reload.
   window.addEventListener('pageshow', (event) => {
     if (event.persisted) applyTheme(getStoredTheme());
   });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -326,7 +326,7 @@ describe('parseArgs', () => {
       expect(result).toEqual({ ok: false, error: 'Unknown option: --unknown' });
     });
 
-    // The `-x` short-flag case lives in `notation parsing`, where it sits next
-    // to the negative-notation cases it draws the boundary against.
+    // The `-x` short-flag case sits in `notation parsing`, next to the
+    // negative-notation cases it draws the boundary against.
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -98,9 +98,8 @@ export function parseArgs(argv: string[]): ParseArgsResult {
     } else if (arg === '--json') {
       json = true;
     } else if (arg === '--seed') {
-      // Any non-empty next argument counts, matching `--seed=<value>` — a
-      // seed is an opaque string, so `--seed -abc` is a valid seed, not a
-      // missing value. Genuinely ambiguous cases are what `--` is for.
+      // A seed is an opaque string, so any non-empty next argument counts:
+      // `--seed -abc` is a valid seed, not a missing value.
       const next = argv[i + 1];
       if (next == null || next === '') {
         return { ok: false, error: 'Missing value for --seed' };
@@ -122,9 +121,8 @@ export function parseArgs(argv: string[]): ParseArgsResult {
     }
   }
 
-  // Positional arguments are joined, not treated as separate rolls — a shell
-  // splits `roll-parser 2d6 + 3` into three words and the user means one
-  // expression. Changing this would break every unquoted spaced notation.
+  // Joined, not separate rolls — a shell splits `roll-parser 2d6 + 3` into three
+  // words and the user means one expression.
   const notation = positional.length > 0 ? positional.join(' ') : undefined;
 
   return { ok: true, args: { ...BASE_ARGS, notation, verbose, json, seed } };

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -76,8 +76,7 @@ describe('formatResult', () => {
     });
 
     test('converts compound dropped sub-roll spans from group keep', () => {
-      // {1d8, 1d10}kh1 — the whole dropped sub-roll (`~~1d8[2]~~`) is one
-      // strikethrough span wrapping notation, not just a number.
+      // The dropped sub-roll strikethrough wraps notation (`~~1d8[2]~~`), not just a number.
       const result = roll('{1d8, 1d10}kh1', { rng: createMockRng([2, 7]) });
       const output = formatResult(result, { verbose: true });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,10 +11,8 @@
 
 import { main } from './main.js';
 
-// Minimal host-process surface this entry needs. The library build compiles
-// with no Node/Bun type packages (`types: []` in tsconfig.build.json) so that
-// runtime globals in library code are type errors; this module-scoped declare
-// keeps the one legitimate use local without leaking `process` program-wide.
+// Declared locally because the library build sets `types: []` — runtime globals
+// are type errors everywhere, and this is the one place `process` is legitimate.
 declare const process: {
   argv: string[];
   exitCode: number | undefined;
@@ -32,6 +30,6 @@ const exitCode = main({
   },
 });
 
-// Left unset on success — assigning 0 would override an exit code a
-// surrounding runtime hook may already have set.
+// Left unset on success — assigning 0 would clobber an exit code a surrounding
+// runtime hook may already have set.
 if (exitCode !== 0) process.exitCode = exitCode;

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -266,8 +266,8 @@ describe('cli main', () => {
 
   describe('non-library failures', () => {
     test('a plain Error from the output sink propagates instead of exiting 1', () => {
-      // `stdout` is written inside `main`'s try/catch, so a throwing sink is
-      // the one seam that reaches the non-RollParserError re-raise branch.
+      // `stdout` is written inside `main`'s try/catch, so a throwing sink is the
+      // one seam that reaches the non-RollParserError re-raise branch.
       expect(() =>
         main({
           argv: ['2d6', '--seed', 'test'],
@@ -282,8 +282,7 @@ describe('cli main', () => {
 
   describe('writeErrorContext', () => {
     test('counts columns in code points, not UTF-16 units', () => {
-      // `&` sits at UTF-16 offset 6 but visual column 5 — the astral `🎲`
-      // occupies two units and one column.
+      // `&` sits at UTF-16 offset 6 but column 5 — the astral `🎲` is two units, one column.
       expect(run(['@{🎲}+&']).stderr).toContain('  @{🎲}+&\n       ^\n');
     });
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -66,8 +66,8 @@ export function writeErrorContext(notation: string, error: unknown, write: Write
   if (span == null) return;
   if (notation.includes('\n') || span.start > notation.length) return;
 
-  // Indent by code points, not UTF-16 units — astral characters (e.g. '🎲')
-  // occupy two units but print as one column, which shifts the caret right.
+  // Code points, not UTF-16 units — an astral character ('🎲') is two units but
+  // one column, and counting units shifts the caret right.
   const column = [...notation.slice(0, span.start)].length;
 
   write(`  ${notation}\n`);

--- a/src/cli/package-smoke.test.ts
+++ b/src/cli/package-smoke.test.ts
@@ -24,11 +24,9 @@ async function runCommand(
   return { stdout, stderr, exitCode };
 }
 
-// The real `build` script, not a reimplementation of it: the assertions below
-// judge the artifact a consumer installs, including the executable bit that
-// `tsc` alone never sets. `ensureFreshDist` is shared with `readme.test.ts`
-// and memoized to one build per test run; its `clean` step is safe because
-// `bun test` runs files sequentially in a single process.
+// Runs the real `build` script so the assertions judge the artifact a consumer
+// installs — including the executable bit `tsc` never sets. `ensureFreshDist`
+// memoizes one build per run; its `clean` is safe because `bun test` is sequential.
 beforeAll(async () => {
   await ensureFreshDist();
 }, 60_000);

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -65,8 +65,8 @@ describe('RollParserError', () => {
 });
 
 describe('error messages', () => {
-  // Positions are structured data — duplicating them in prose forced UI
-  // consumers to strip the suffix before rendering their own markers.
+  // Positions belong to the structured fields; in prose they force UI consumers
+  // to strip a suffix before rendering their own markers.
   test('lexer messages omit the position', () => {
     const error = captureError(() => lex('2d6+&')) as LexerError;
 
@@ -171,12 +171,11 @@ describe('getErrorSpan', () => {
  */
 type CodeCase = { notation: string; options?: RollOptions } | { ast: ASTNode; why: string };
 
-// ? Deliberately outside the `ASTNode` union. Reaching `evalNode`'s
-//   exhaustiveness default is the whole point, and the parser cannot emit it.
+// Forged node type — the parser cannot emit one, so this is the only path to
+// `evalNode`'s exhaustiveness default.
 const UNKNOWN_NODE = { type: 'Nonesuch' } as unknown as ASTNode;
 
-// ? Same idea one level down: `evalBinary`'s operator switch is exhaustive
-//   over `BinaryOpNode['operator']`, so only a forged operator reaches it.
+// Forged operator — same idea one level down, for `evalBinary`'s switch default.
 const UNKNOWN_OPERATOR_NODE = {
   type: 'BinaryOp',
   operator: '^^',

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -351,7 +351,7 @@ describe('evaluate', () => {
       const rng = createMockRng([4]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(10); // 4 + (2 * 3) = 10
+      expect(result.total).toBe(10);
     });
 
     test('parenthesized expression', () => {
@@ -359,7 +359,7 @@ describe('evaluate', () => {
       const rng = createMockRng([3]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(8); // (3 + 1) * 2 = 8
+      expect(result.total).toBe(8);
     });
   });
 
@@ -403,7 +403,7 @@ describe('evaluate', () => {
       const ast = parse('floor((1d20+5)/2)');
       const result = evaluate(ast, createMockRng([10]));
 
-      expect(result.total).toBe(7); // floor((10+5)/2) = floor(7.5)
+      expect(result.total).toBe(7); // (10 + 5) / 2 = 7.5
       expect(result.expression).toBe('floor((1d20 + 5) / 2)');
     });
 
@@ -442,7 +442,7 @@ describe('evaluate', () => {
       const rng = createMockRng([1]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(-4); // 1 - 5 = -4, NOT 0!
+      expect(result.total).toBe(-4); // no clamping: 1 - 5 = -4
     });
 
     test('unary minus on dice', () => {
@@ -489,7 +489,7 @@ describe('evaluate', () => {
       const rng = createMockRng([3, 5, 2, 6]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(14); // 5 + 3 + 6 = 14
+      expect(result.total).toBe(14);
       expect(result.rolls.filter((r) => r.modifiers.includes('dropped'))).toHaveLength(1);
     });
   });
@@ -512,7 +512,7 @@ describe('evaluate', () => {
       const rng = createMockRng([4, 2, 5, 3]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(12); // 4 + 5 + 3 = 12
+      expect(result.total).toBe(12);
       expect(getDie(result.rolls, 1).modifiers).toContain('dropped');
     });
   });
@@ -523,7 +523,7 @@ describe('evaluate', () => {
       const rng = createMockRng([4, 2, 6, 3]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(9); // 4 + 2 + 3 = 9
+      expect(result.total).toBe(9);
       expect(getDie(result.rolls, 2).modifiers).toContain('dropped');
     });
   });
@@ -601,12 +601,11 @@ describe('evaluate', () => {
     });
 
     test('same modifier twice does not stack (dl1dl1 ≠ dl2)', () => {
-      // Each dl1 independently drops the same lowest die
+      // [3,1,4,2]: each dl1 independently drops idx1 → union {1} → total 9
       const ast = parse('4d6dl1dl1');
       const rng = createMockRng([3, 1, 4, 2]);
       const result = evaluate(ast, rng);
 
-      // Both dl1s drop idx1 (value 1), union = {1}, total = 9
       expect(result.total).toBe(9);
       expect(result.rolls.filter((r) => r.modifiers.includes('dropped'))).toHaveLength(1);
     });
@@ -660,7 +659,7 @@ describe('evaluate', () => {
       const rng = createMockRng([5, 5, 2]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(7); // 5 + 2
+      expect(result.total).toBe(7);
       expect(getDie(result.rolls, 0).modifiers).toContain('dropped');
       expect(getDie(result.rolls, 1).modifiers).toContain('kept');
       expect(getDie(result.rolls, 2).modifiers).toContain('kept');
@@ -671,7 +670,7 @@ describe('evaluate', () => {
       const rng = createMockRng([4, 2, 2]);
       const result = evaluate(ast, rng);
 
-      expect(result.total).toBe(6); // 4 + 2
+      expect(result.total).toBe(6);
       expect(getDie(result.rolls, 0).modifiers).toContain('kept');
       expect(getDie(result.rolls, 1).modifiers).toContain('dropped');
       expect(getDie(result.rolls, 2).modifiers).toContain('kept');
@@ -700,8 +699,8 @@ describe('evaluate', () => {
     });
 
     test('dl1 skips rerolled intermediates', () => {
-      // Die 0: 1 (r<2 matches) → 4. Die 1: 3. Final pool [4, 3] — the
-      // intermediate 1 stays dropped and must not absorb the dl1.
+      // Die 0: 1 (r<2) → 4. Die 1: 3. The dropped intermediate 1 must not
+      // absorb the dl1.
       const ast = parse('2d6r<2dl1');
       const rng = createMockRng([1, 3, 4]);
       const result = evaluate(ast, rng);
@@ -713,8 +712,7 @@ describe('evaluate', () => {
     });
 
     test('computed kl count skips the meta die', () => {
-      // Meta d2 → 1, pool [15, 7]. kl1 keeps 7 — the meta die's 1 is not
-      // eligible to win lowest.
+      // Meta d2 → 1, pool [15, 7]. kl1 keeps 7 — the meta die's 1 cannot win lowest.
       const ast = parse('2d20kl(1d2)');
       const rng = createMockRng([1, 15, 7]);
       const result = evaluate(ast, rng);
@@ -728,9 +726,8 @@ describe('evaluate', () => {
     });
 
     test("kh1 skips a preceding chain's losers", () => {
-      // Parse: Modifier(kh1, Reroll(r>6, Modifier(dh1, Dice))). dh1 drops
-      // the 5; the no-op reroll splits the chains, so kh1 sees it already
-      // dropped and must keep the 2 instead.
+      // Parse: Modifier(kh1, Reroll(r>6, Modifier(dh1, Dice))). The no-op reroll
+      // splits the chains, so kh1 sees dh1's 5 already dropped and keeps the 2.
       const ast = parse('2d6dh1r>6kh1');
       const rng = createMockRng([5, 2]);
       const result = evaluate(ast, rng);
@@ -761,8 +758,8 @@ describe('evaluate', () => {
     });
 
     test('evaluator errors carry the span of the failing sub-expression', () => {
-      // `1d0` sits at offsets 4..7 inside `2d6+1d0+3` — the innermost node
-      // that failed, not the whole expression.
+      // `1d0` sits at offsets 4..7 — the span is the innermost failing node,
+      // not the whole expression.
       const error = expectRollError(
         () => evaluate(parse('2d6+1d0+3'), createMockRng([1, 1])),
         EvaluatorError,
@@ -997,10 +994,8 @@ describe('evaluate', () => {
     });
 
     test('invalid maxDice falls back to DEFAULT_MAX_DICE', () => {
-      // Roll DEFAULT_MAX_DICE+1 dice with invalid maxDice values and assert the
-      // resulting error message references DEFAULT_MAX_DICE — proves the
-      // fallback used the documented default and not Infinity (would not throw)
-      // or some other value (different limit in the message).
+      // The thrown limit pins the fallback: Infinity would not throw at all,
+      // any other value would report a different limit.
       const overCount = DEFAULT_MAX_DICE + 1;
       const ast = parse(`${overCount}d6`);
       const expectedMsg = `Total dice count ${overCount} exceeds limit of ${DEFAULT_MAX_DICE}`;
@@ -1014,7 +1009,6 @@ describe('evaluate', () => {
       const ast = parse('3d6');
       const rng = createMockRng([1, 2, 3]);
 
-      // maxDice: 2.9 → floor → 2, so 3d6 should throw
       expect(() => evaluate(ast, rng, { maxDice: 2.9 })).toThrow(EvaluatorError);
     });
 
@@ -1067,8 +1061,7 @@ describe('evaluate', () => {
 
       test('multi-die pool explodes independently (explosion interleaved with originals)', () => {
         // RNG [6, 3, 2]: initial pool [6, 3]. Die 0 (=6) explodes → 2.
-        // Final pool order: [6, 2, 3] — explosions appended right after their
-        // triggering die.
+        // Final pool [6, 2, 3] — explosions are appended right after their trigger.
         const ast = parse('2d6!');
         const rng = createMockRng([6, 3, 2]);
         const result = evaluate(ast, rng);
@@ -1213,9 +1206,8 @@ describe('evaluate', () => {
 
     describe('modifier chain interaction', () => {
       test('4d6!kh3 explodes first, then keeps highest 3', () => {
-        // RNG: 4 dice then one explosion. [6, 3, 1, 4, 2]:
-        //   initial pool [6, 3, 1, 4]; 6 triggers explosion → [6, 3, 1, 4, 2]
-        //   kh3 keeps top 3 by result: 6, 4, 3 → total 13
+        // [6, 3, 1, 4, 2]: pool [6, 3, 1, 4], the 6 explodes → 2.
+        // kh3 then keeps 6, 4, 3 → total 13.
         const ast = parse('4d6!kh3');
         const rng = createMockRng([6, 3, 1, 4, 2]);
         const result = evaluate(ast, rng);
@@ -1225,24 +1217,19 @@ describe('evaluate', () => {
       });
 
       test('4d6kh3! keeps highest 3 first, then explodes only kept dice', () => {
-        // RNG: 4 dice. Initial [6, 3, 1, 4]. kh3 keeps 6,4,3 and drops 1.
-        // Explode only kept dice with max = 6 → kept die rolling 6 explodes.
-        // Next RNG value consumed is the explosion roll.
+        // [6, 3, 1, 4, 2]: kh3 keeps 6, 4, 3 and drops the 1. Only kept dice
+        // explode, so the 6 draws the 2 → 6+2+4+3 = 15 over 5 pool entries.
         const ast = parse('4d6kh3!');
         const rng = createMockRng([6, 3, 1, 4, 2]);
         const result = evaluate(ast, rng);
 
-        // Kept dice: 6 (then +2 exploded), 4, 3 = 6 + 2 + 4 + 3 = 15
-        // Dropped: 1
         expect(result.total).toBe(15);
-        // Pool: 4 original + 1 explosion = 5, but 1 is marked dropped.
         expect(result.rolls).toHaveLength(5);
       });
 
       test('explosion counts against global maxDice', () => {
-        // 2d6! with all sixes would grow unboundedly. maxDice=4 lets the
-        // initial 2 rolls plus 2 explosions occur before the next explosion
-        // would exceed the cap.
+        // maxDice=4 covers the 2 initial rolls plus 2 explosions; the next
+        // explosion trips the cap.
         const ast = parse('2d6!');
         const rng = createMockRng([6, 6, 6, 6, 6, 6]);
 
@@ -1306,8 +1293,8 @@ describe('evaluate', () => {
     describe('recursive reroll (r)', () => {
       test('single match re-rolls until condition fails', () => {
         const ast = parse('2d6r<2');
-        // RNG: die 0 rolls 1, die 1 rolls 5, die 0 re-rolls 3.
-        // Pool ordering: intermediate + final for die 0 first, then die 1.
+        // Draws: die 0 rolls 1, die 1 rolls 5, then die 0 re-rolls 3. Pool order
+        // is die 0's intermediate + final first, then die 1.
         const rng = createMockRng([1, 5, 3]);
         const result = evaluate(ast, rng);
 
@@ -1373,9 +1360,8 @@ describe('evaluate', () => {
         const rng = createMockRng([-1, 0, 1, -1, 0, 0]);
         const result = evaluate(ast, rng);
 
-        expect(result.total).toBe(1); // 0 + 0 + 1 + 0
+        expect(result.total).toBe(1);
 
-        // Two intermediate rerolled -1s should appear in rolls.
         const rerolled = result.rolls.filter((d) => d.modifiers.includes('rerolled'));
         expect(rerolled).toHaveLength(2);
         expect(rerolled.every((d) => d.result === -1)).toBe(true);
@@ -1408,7 +1394,7 @@ describe('evaluate', () => {
         const rng = createMockRng([2, 5, 1]);
         const result = evaluate(ast, rng);
 
-        expect(result.total).toBe(6); // 1 + 5
+        expect(result.total).toBe(6);
         expect(result.rolls).toHaveLength(3);
         expect(getDie(result.rolls, 0).result).toBe(2);
         expect(getDie(result.rolls, 0).modifiers).toEqual(['rerolled', 'dropped']);
@@ -1440,8 +1426,8 @@ describe('evaluate', () => {
 
     describe('modifier chain interactions', () => {
       test('reroll then keep highest: intermediate high roll does not win kh', () => {
-        // `2d6r>4kh1` — die 0 rolls 6 (>4, rerolled → 2), die 1 rolls 3.
-        // Final pool is [2, 3]. kh1 should pick 3, not the rerolled 6.
+        // [6, 3, 2]: die 0's 6 rerolls → 2, die 1 rolls 3. Final pool [2, 3] —
+        // kh1 picks 3, not the rerolled 6.
         const ast = parse('2d6r>4kh1');
         const rng = createMockRng([6, 3, 2]);
         const result = evaluate(ast, rng);
@@ -1450,8 +1436,8 @@ describe('evaluate', () => {
       });
 
       test('reroll then keep-2 skips the intermediate in the sorted path', () => {
-        // Die 0: 1 (r<2 matches) → 4. Dice 1-2: 5, 3. kh2 sorts [4, 5, 3]
-        // and keeps 5 + 4 — the dropped intermediate 1 is never eligible.
+        // Die 0: 1 (r<2) → 4. Dice 1-2: 5, 3. kh2 keeps 5 + 4 — the dropped
+        // intermediate 1 is never eligible.
         const ast = parse('3d6r<2kh2');
         const rng = createMockRng([1, 5, 3, 4]);
         const result = evaluate(ast, rng);
@@ -1470,10 +1456,9 @@ describe('evaluate', () => {
       });
 
       test('keep highest then reroll only runs on the survivor', () => {
-        // Parse: Reroll(r<2, Modifier(kh1, Dice)). kh1 keeps higher, reroll
-        // only touches the kept die.
+        // Parse: Reroll(r<2, Modifier(kh1, Dice)) — the reroll only touches kh1's
+        // survivor. [5, 1]: kh1 keeps the 5, which does not match r<2.
         const ast = parse('2d6kh1r<2');
-        // Rolls: 5, 1. kh1 keeps 5 (index 0); 1 is dropped. Reroll on 5 — no match.
         const rng = createMockRng([5, 1]);
         const result = evaluate(ast, rng);
 
@@ -1481,20 +1466,18 @@ describe('evaluate', () => {
       });
 
       test('chained reroll-once then recursive: 2d6ro<2r<3', () => {
-        // Parse: Reroll(r<3, Reroll(ro<2, Dice)).
-        // Die 0: 1 (ro<2 matches) → 2. Then outer r<3: 2 matches → 5 (stop).
-        // Die 1: 4. ro<2 no match (kept → 4). Outer r<3: 4 no match.
+        // Parse: Reroll(r<3, Reroll(ro<2, Dice)). [1, 4, 2, 5]: die 0 goes
+        // 1 →(ro<2) 2 →(r<3) 5; die 1 stays 4.
         const ast = parse('2d6ro<2r<3');
         const rng = createMockRng([1, 4, 2, 5]);
         const result = evaluate(ast, rng);
 
-        expect(result.total).toBe(9); // 5 + 4
+        expect(result.total).toBe(9);
       });
 
       test('dropped target: pre-dropped die is not rerolled', () => {
-        // `2d6dl1r<5` — dl1 drops the lowest; reroll leaves it alone.
-        // Rolls: 3, 5. dl1 drops 3. Reroll(r<5) on [3(dropped), 5(kept)] —
-        // only 5 is eligible, 5 is not <5 → no reroll.
+        // [3, 5]: dl1 drops the 3, so only the kept 5 is reroll-eligible and
+        // 5 is not <5 → no reroll.
         const ast = parse('2d6dl1r<5');
         const rng = createMockRng([3, 5]);
         const result = evaluate(ast, rng);
@@ -1503,13 +1486,12 @@ describe('evaluate', () => {
       });
 
       test('reroll then explode preserves modifier semantics', () => {
-        // `2d6r<2!` — reroll first, then explode.
         const ast = parse('2d6r<2!');
-        // Die 0: 1 → 3. Die 1: 6 (triggers explode) → 2.
+        // [1, 6, 3, 2]: die 0's 1 rerolls → 3, die 1's 6 explodes → 2.
         const rng = createMockRng([1, 6, 3, 2]);
         const result = evaluate(ast, rng);
 
-        expect(result.total).toBe(11); // 3 + 6 + 2
+        expect(result.total).toBe(11);
       });
     });
 
@@ -1538,7 +1520,7 @@ describe('evaluate', () => {
         const rng = createMockRng([1, 4, 3]);
         const result = evaluate(ast, rng);
 
-        expect(result.total).toBe(12); // 3 + 4 + 5
+        expect(result.total).toBe(12); // 3 (reroll of the 1, drawn last) + 4 + 5
       });
 
       test('reroll Fate dice without negative: 4dFr=1', () => {
@@ -1547,7 +1529,7 @@ describe('evaluate', () => {
         const rng = createMockRng([1, -1, 0, 1, 0, -1]);
         const result = evaluate(ast, rng);
 
-        expect(result.total).toBe(-2); // 0 + -1 + 0 + -1
+        expect(result.total).toBe(-2);
       });
     });
   });
@@ -1602,7 +1584,7 @@ describe('evaluate', () => {
       const result = evaluate(ast, rng);
 
       // The 3 matches both >=3 and =3, but success wins.
-      expect(result.successes).toBe(2); // 3, 5
+      expect(result.successes).toBe(2);
       expect(result.failures).toBe(0);
       expect(result.total).toBe(2);
       expect(getDie(result.rolls, 0).modifiers).toContain('success');
@@ -1624,7 +1606,7 @@ describe('evaluate', () => {
       const rng = createMockRng([1, 5, 6, 6, 3]);
       const result = evaluate(ast, rng);
 
-      expect(result.successes).toBe(2); // two 6s
+      expect(result.successes).toBe(2);
       expect(result.total).toBe(2);
     });
 
@@ -1641,10 +1623,10 @@ describe('evaluate', () => {
       const rng = createMockRng([1, 5, 6, 3]);
       const result = evaluate(ast, rng);
 
-      expect(result.successes).toBe(2); // 5 and 6 among kept {5,6,3}
+      expect(result.successes).toBe(2); // kept {5, 6, 3} → 5 and 6 pass >=5
       expect(result.total).toBe(2);
       expect(result.rolls).toHaveLength(4);
-      // The dropped die must not be tagged with success/failure.
+
       const dropped = result.rolls.find((d) => d.modifiers.includes('dropped'));
       expect(dropped).toBeDefined();
       expect(dropped?.modifiers.includes('success')).toBe(false);
@@ -1661,7 +1643,6 @@ describe('evaluate', () => {
       expect(result.successes).toBe(2);
       expect(result.total).toBe(2);
 
-      // Intermediate rerolls are 'dropped' and must not carry success/failure.
       const intermediates = result.rolls.filter((d) => d.modifiers.includes('rerolled'));
       expect(intermediates.length).toBe(2);
       for (const d of intermediates) {
@@ -1682,12 +1663,11 @@ describe('evaluate', () => {
 
     test('Fate dice + success count with negative fail — 4dF>=1f-1', () => {
       const ast = parse('4dF>=1f-1');
-      // Rolls: [1, 0, -1, 1]
       const rng = createMockRng([1, 0, -1, 1]);
       const result = evaluate(ast, rng);
 
-      expect(result.successes).toBe(2); // two +1s
-      expect(result.failures).toBe(1); // one -1
+      expect(result.successes).toBe(2);
+      expect(result.failures).toBe(1);
       expect(result.total).toBe(1);
     });
 
@@ -1696,7 +1676,7 @@ describe('evaluate', () => {
       const rng = createMockRng([4, 5, 6]);
       const result = evaluate(ast, rng);
 
-      expect(result.successes).toBe(2); // 5, 6
+      expect(result.successes).toBe(2);
     });
 
     test('success/failure fields absent when no success count used', () => {
@@ -1873,7 +1853,6 @@ describe('evaluate', () => {
     });
 
     test('Failure boundary: 1d20 vs 15 roll=5 (total=5 > dc-10=5 is false)', () => {
-      // total > dc-10 → 5 > 5 is false → CriticalFailure
       const ast = parse('1d20 vs 15');
       const rng = createMockRng([5]);
       const result = evaluate(ast, rng);
@@ -1976,7 +1955,7 @@ describe('evaluate', () => {
       const rng = createMockRng([6, 10]);
       const result = evaluate(ast, rng);
 
-      // total=16, dc=25: 16 < 25 and 16 > 15 → Failure
+      // 16 < 25 but 16 > dc-10 → Failure
       expect(result.total).toBe(16);
       expect(result.natural).toBeUndefined();
       expect(result.degree).toBe(DegreeOfSuccess.Failure);
@@ -1989,7 +1968,7 @@ describe('evaluate', () => {
 
       expect(result.total).toBe(30);
       expect(result.natural).toBeUndefined();
-      // Base: 30 ≥ 25+10=35? no; 30 ≥ 25? yes → Success (no upgrade, natural undefined)
+      // 30 < dc+10 but ≥ dc → Success; an undefined natural blocks any upgrade.
       expect(result.degree).toBe(DegreeOfSuccess.Success);
     });
 
@@ -1998,22 +1977,21 @@ describe('evaluate', () => {
       const rng = createMockRng([15, 10]);
       const result = evaluate(ast, rng);
 
-      // roll total = 15, dc total = 10 + 10 = 20 → 15 < 20 → Failure
+      // dc side draws second: 10 + 10 = 20 → 15 < 20 → Failure
       expect(result.total).toBe(15);
       expect(result.natural).toBe(15);
       expect(result.degree).toBe(DegreeOfSuccess.Failure);
     });
 
     test('Contested check: DC dice do not count as natural d20 source', () => {
-      // Roll-side has no d20; DC-side has a d20 that rolls 20 — must not
-      // influence natural extraction.
+      // The DC-side d20 rolls 20 and must not become the natural.
       const ast = parse('1d6+10 vs 1d20');
       const rng = createMockRng([3, 20]);
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(13);
       expect(result.natural).toBeUndefined();
-      // total=13, dc=20 → 13 < 20 but 13 > 10 → Failure
+      // 13 < 20 but 13 > dc-10 → Failure
       expect(result.degree).toBe(DegreeOfSuccess.Failure);
     });
 
@@ -2060,17 +2038,17 @@ describe('evaluate', () => {
     });
 
     test('Paren-nested versus throws NESTED_VERSUS at eval time', () => {
-      // Parser allows this (left of `vs` is a literal, not Versus); evaluator
-      // rejects during dc-side evaluation.
+      // The parser allows this — the left of the inner `vs` is a literal, not a
+      // Versus node — so the rejection lands during dc-side evaluation.
       const ast = parse('1d20 vs (5 vs 3)');
 
       expectRollError(() => evaluate(ast, createMockRng([15])), EvaluatorError, 'NESTED_VERSUS');
     });
 
     test('Sibling versus in arithmetic throw NESTED_VERSUS at merge', () => {
-      // `(a vs b) + (c vs d)` — two independent checks collide on one
-      // `RollResult`. There is no semantics for combining two degrees, so the
-      // merge rejects the ambiguity rather than silently dropping one side.
+      // Two independent checks collide on one `RollResult`. There is no semantics
+      // for combining degrees, so the merge rejects rather than silently dropping
+      // one side.
       const ast = parse('(1d20 vs 15) + (1d20 vs 20)');
       const rng = createMockRng([12, 18]);
 
@@ -2102,7 +2080,7 @@ describe('evaluate', () => {
       const rng = createMockRng([12]);
       const result = evaluate(ast, rng);
 
-      // 1d20+5=17 vs DC=20 → 17 < 20 and 17 > dc-10=10 → Failure.
+      // 17 < 20 but 17 > dc-10 → Failure.
       expect(result.degree).toBe(DegreeOfSuccess.Failure);
       expect(result.natural).toBe(12);
     });
@@ -2181,9 +2159,8 @@ describe('evaluate', () => {
     });
 
     test('Meta-d20 on count side: (1d20)d20!! vs 30 — meta d20 filtered from natural', () => {
-      // Draw order: meta count `(1d20)` → 1 (stamped 'dropped'), then outer
-      // `1d20!!` rolls [20, 20, 5] and compound-explodes to 45.
-      // `extractNatural` must skip the meta d20 and use the outer pool's 20.
+      // Draw order: meta count `(1d20)` → 1 ('dropped'), then the outer pool
+      // [20, 20, 5] compounds to 45. `extractNatural` must skip the meta d20.
       const ast = parse('(1d20)d20!! vs 30');
       const rng = createMockRng([1, 20, 20, 5]);
       const result = evaluate(ast, rng);
@@ -2194,10 +2171,9 @@ describe('evaluate', () => {
     });
 
     test('Meta-d20 on sides: 1d(1d20) vs 15 — meta d20 filtered from natural', () => {
-      // Draw order: meta sides `(1d20)` → 20 (stamped 'dropped'), then outer
-      // `1d20` rolls 3. If `extractNatural` leaked the meta d20, two kept
-      // d20s would render natural undefined (ambiguous); correct behavior
-      // returns the outer result (3).
+      // Draw order: meta sides `(1d20)` → 20 ('dropped'), then the outer d20
+      // rolls 3. A leaked meta d20 would make natural ambiguous (undefined)
+      // instead of 3.
       const ast = parse('1d(1d20) vs 15');
       const rng = createMockRng([20, 3]);
       const result = evaluate(ast, rng);
@@ -2208,8 +2184,8 @@ describe('evaluate', () => {
     });
 
     test('Standard explode nat-20: 1d20! vs 35 rolls=[20,5] → natural=20, upgrade CriticalFailure→Failure', () => {
-      // The explosion continuation die is not a primary d20 — the natural
-      // comes from the original die, matching the compound (`!!`) behavior.
+      // A continuation die is not a primary d20 — the natural comes from the
+      // original die, matching `!!`.
       const ast = parse('1d20! vs 35');
       const rng = createMockRng([20, 5]);
       const result = evaluate(ast, rng);
@@ -2372,7 +2348,8 @@ describe('evaluate', () => {
     });
 
     test('evaluator throws UNKNOWN_FUNCTION for unregistered name (defensive)', () => {
-      // Build an AST directly — bypass the parser so we can test the defensive branch.
+      // Hand-built AST — the parser rejects unknown names, so this branch is
+      // otherwise unreachable.
       const ast = {
         type: 'FunctionCall' as const,
         name: 'sqrt',
@@ -2436,14 +2413,10 @@ describe('evaluate', () => {
     });
 
     test('computed modifier count (kh) preserves meta die', () => {
-      // d2 rolls 2 → kh2 → keep the two highest of [1, 3, 5, 6] = [5, 6].
-      //
-      // The keep count draws FIRST, before the 4d6 pool — keep/drop is the
-      // asymmetric case in README, Randomness: `flattenModifierChain`
-      // resolves every modifier argument up front because `evalModifier`
-      // needs the counts to drive selection on the pool it is about to roll.
-      // Threshold-style modifiers (`cs`, `!`, `r`, `>`) post-process an
-      // existing pool, so their metas draw last.
+      // d2 → 2, so kh2 keeps the two highest of [1, 3, 5, 6].
+      // The keep count draws BEFORE the pool: `flattenModifierChain` resolves
+      // modifier arguments up front because selection needs the counts. Threshold
+      // modifiers post-process an existing pool and draw last (README → Randomness).
       const ast = parse('4d6kh(1d2)');
       const rng = createMockRng([2, 1, 3, 5, 6]);
       const result = evaluate(ast, rng);
@@ -2551,8 +2524,8 @@ describe('evaluate', () => {
     });
 
     test('meta dice count against maxDice (budget enforced)', () => {
-      // The meta d4 plus the 2d6 it sizes cost three dice against the budget:
-      // exactly 3 fits, and 2 must throw — otherwise the meta die would be free.
+      // The meta d4 counts against the budget with the 2d6 it sizes: 3 fits,
+      // 2 must throw — otherwise the meta die would be free.
       const result = evaluate(parse('(1d4)d6'), createMockRng([2, 3, 5]), { maxDice: 3 });
 
       expect(result.rolls).toHaveLength(3);
@@ -2566,10 +2539,8 @@ describe('evaluate', () => {
     });
 
     test('mergeMetaRolls strips success/failure modifiers (#69)', () => {
-      // Defense-in-depth: parser rejects SuccessCount in meta positions, but
-      // if a die ever arrives with `'success'`/`'failure'` tags inside a meta
-      // sub-context, mergeMetaRolls must drop those tags so they cannot reach
-      // the top-level successes/failures scan.
+      // Defense-in-depth: the parser rejects SuccessCount in meta positions, but a
+      // stray `'success'`/`'failure'` tag must not reach the top-level scan.
       const source: EvalContext = {
         rolls: [
           { result: 6, sides: 10, modifiers: ['kept', 'success'], critical: false, fumble: false },
@@ -2828,8 +2799,8 @@ describe('evaluate', () => {
     describe('flat-pool mode (single sub-roll with keep/drop)', () => {
       test('{4d10+5d6}kh2 keeps 2 highest across combined 9-die pool', () => {
         const ast = parse('{4d10+5d6}kh2');
-        // 4 d10 draws: [10, 9, 8, 7], 5 d6 draws: [6, 5, 4, 3, 2]
-        // Combined sorted: 10, 9, 8, 7, 6, 5, 4, 3, 2 — kh2 keeps [10, 9]
+        // 4d10 draws [10, 9, 8, 7], 5d6 draws [6, 5, 4, 3, 2] — kh2 across the
+        // flat pool keeps [10, 9].
         const rng = createMockRng([10, 9, 8, 7, 6, 5, 4, 3, 2]);
         const result = evaluate(ast, rng);
 
@@ -2853,10 +2824,8 @@ describe('evaluate', () => {
     describe('sub-roll mode (multi sub-roll with keep/drop)', () => {
       test('{4d6+2d8, 3d20+3, 5d10+1}kh1 keeps highest subtotal', () => {
         const ast = parse('{4d6+2d8, 3d20+3, 5d10+1}kh1');
-        // Sub 1: 4d6 = [1,1,1,1]=4, 2d8 = [1,1]=2 → 6
-        // Sub 2: 3d20 = [5,5,5]=15 → 15+3=18
-        // Sub 3: 5d10 = [1,1,1,1,1]=5 → 5+1=6
-        // Subtotals: [6, 18, 6] — kh1 picks 18
+        // Subtotals: 4d6[1,1,1,1] + 2d8[1,1] = 6; 3d20[5,5,5] + 3 = 18;
+        // 5d10[1,1,1,1,1] + 1 = 6 — kh1 picks 18.
         const rng = createMockRng([1, 1, 1, 1, 1, 1, 5, 5, 5, 1, 1, 1, 1, 1]);
         const result = evaluate(ast, rng);
 
@@ -2880,9 +2849,8 @@ describe('evaluate', () => {
 
       test('dropped sub-roll success tags are stripped from successes count', () => {
         const ast = parse('{2d6>=4, 2d6>=4}kh1');
-        // Sub 1: [5, 5] → 2 successes, subtotal 2. Sub 2: [4, 1] → 1 success,
-        // subtotal 1. kh1 keeps sub 1 — the dropped sub-roll's success must
-        // not leak into RollResult.successes.
+        // Subtotals: sub 1 [5, 5] → 2 successes; sub 2 [4, 1] → 1. kh1 keeps sub 1 —
+        // the dropped sub-roll's success must not leak into `successes`.
         const rng = createMockRng([5, 5, 4, 1]);
         const result = evaluate(ast, rng);
 
@@ -2956,8 +2924,7 @@ describe('evaluate', () => {
 
       test('RNG draw order is left-to-right across sub-expressions', () => {
         const ast = parse('{1d6, 2d8}kh1');
-        // Expected draws: 1d6 first, then 2d8 left-to-right.
-        // Subtotals: [3, 5+6]=[3, 11] — kh1 picks sub 2
+        // Draws left-to-right: 1d6, then 2d8. Subtotals [3, 11] — kh1 picks sub 2.
         const rng = createMockRng([3, 5, 6]);
         const result = evaluate(ast, rng);
 
@@ -2989,9 +2956,8 @@ describe('evaluate', () => {
       });
 
       test('two kept versus sub-rolls still throw NESTED_VERSUS', () => {
-        // kh2 on a 3-sub group keeps subs 0 and 1 (subtotals 18, 6 — sub 2 d4=4
-        // dropped). Both kept subs carry versus metadata, so propagation must
-        // collide via the NESTED_VERSUS guard.
+        // Subtotals [18, 6, 4] — kh2 keeps subs 0 and 1, and both carry versus
+        // metadata, so propagation collides on the NESTED_VERSUS guard.
         const ast = parse('{1d20 vs 15, 1d6 vs 10, 1d4}kh2');
         const rng = createMockRng([18, 6, 4]);
 
@@ -3005,7 +2971,7 @@ describe('evaluate', () => {
         const rng = createMockRng([4, 3]);
         const result = evaluate(ast, rng);
 
-        // Subtotals: [4, 3] — kh1 picks 4. 2 * 4 = 8.
+        // Subtotals: [4, 3] — kh1 picks 4, doubled to 8.
         expect(result.total).toBe(8);
       });
 
@@ -3022,7 +2988,7 @@ describe('evaluate', () => {
         const rng = createMockRng([3, 4, 5]);
         const result = evaluate(ast, rng);
 
-        // Subtotals: [3, 9]. kh1 picks 9. Negate: -9.
+        // Subtotals: [3, 9] — kh1 picks 9, negated to -9.
         expect(result.total).toBe(-9);
       });
     });
@@ -3072,8 +3038,8 @@ describe('evaluate', () => {
     });
 
     test('sort preserves dropped-die flag after keep/drop', () => {
-      // 4d6dl1: drop lowest (2). Kept: [5, 6, 3]. Total: 14.
-      // Sort ascending: [2 dropped, 3, 5, 6]. Total unchanged.
+      // dl1 drops the 2; sorting reorders to [2, 3, 5, 6] without moving the flag
+      // or changing the total.
       const ast = parse('4d6dl1s');
       const rng = createMockRng([5, 2, 6, 3]);
       const result = evaluate(ast, rng);
@@ -3086,8 +3052,7 @@ describe('evaluate', () => {
     });
 
     test('sort after explode reorders the expanded pool', () => {
-      // 4d6!: rolls [6, 2, 3, 5], explode the 6 → rolls 4. Pool: [6, 2, 3, 5, 4]. Total 20.
-      // Sort ascending: [2, 3, 4, 5, 6].
+      // [6, 2, 3, 5]: the 6 explodes → 4, so the sorted pool spans 5 dice.
       const ast = parse('4d6!s');
       const rng = createMockRng([6, 2, 3, 5, 4]);
       const result = evaluate(ast, rng);
@@ -3125,7 +3090,6 @@ describe('evaluate', () => {
     });
 
     test('sort with Fate dice pool', () => {
-      // 4dF → [1, -1, 0, 1]. Sort descending: [1, 1, 0, -1]. Total: 1+(-1)+0+1 = 1.
       const ast = parse('4dFsd');
       const rng = createMockRng([1, -1, 0, 1]);
       const result = evaluate(ast, rng);
@@ -3135,8 +3099,7 @@ describe('evaluate', () => {
     });
 
     test('sort on arithmetic-wrapped pool mixes all dice flat', () => {
-      // (1d6+2d8)s: 1d6=4, 2d8=[5, 2]. Flat pool [4, 5, 2]. Sort asc: [2, 4, 5].
-      // Total is preserved: 4 + (5+2) = 11.
+      // 1d6=4 and 2d8=[5, 2] sort as one flat pool; the total still sums per operand.
       const ast = parse('(1d6+2d8)s');
       const rng = createMockRng([4, 5, 2]);
       const result = evaluate(ast, rng);
@@ -3205,7 +3168,7 @@ describe('evaluate', () => {
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(38);
-      // Independent overrides — cs side untouched, so the natural 20 keeps
+      // Independent overrides — the cs side is untouched, so the natural 20 keeps
       // its default critical.
       expect(result.rolls.map((d) => d.critical)).toEqual([true, false, false, false]);
       expect(result.rolls.map((d) => d.fumble)).toEqual([false, true, true, false]);
@@ -3274,33 +3237,28 @@ describe('evaluate', () => {
       const rng = createMockRng([20, 18, 5, 19]);
       const result = evaluate(ast, rng);
 
-      // Drop lowest (5). Kept: [20, 18, 19]. Total: 57.
       expect(result.total).toBe(57);
       const dropped = result.rolls.find((d) => d.modifiers.includes('dropped'));
       expect(dropped?.result).toBe(5);
       expect(dropped?.critical).toBe(false);
-      // All kept dice satisfy cs>17, so they're flagged.
+
       const kept = result.rolls.filter((d) => !d.modifiers.includes('dropped'));
       expect(kept.map((d) => d.critical)).toEqual([true, true, true]);
     });
 
     test('cs flags entire expanded explode pool; explosion trigger uses raw face', () => {
-      // 1d6!: rolls [6, 4], explode 6 → rolls another [4]. Pool [6, 4]? Let
-      // me trace: standard-explode re-rolls 6, gets 4, appends. Pool: [6, 4].
-      // Actually mock [6, 4] → rng.nextInt: first draw 6 (pool die), second
-      // draw 4 (explosion). Pool: [6, 4]. Total 10.
+      // [6, 4]: the first draw is the pool die, the second its explosion → pool
+      // [6, 4]. `cs` flags the appended die too, not just the original.
       const ast = parse('1d6!cs>3');
       const rng = createMockRng([6, 4]);
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(10);
-      // Both dice have result > 3, so both flagged critical.
       expect(result.rolls.every((d) => d.critical === true)).toBe(true);
     });
 
     test('cs with custom threshold does not suppress explode on natural max', () => {
-      // 1d6!cs<1 — no explosion trigger change; the 6 still explodes even
-      // though cs<1 never matches (all critical cleared).
+      // cs<1 never matches, yet the 6 still explodes — cs does not move the trigger.
       const ast = parse('1d6!cs<1');
       const rng = createMockRng([6, 4]);
       const result = evaluate(ast, rng);
@@ -3315,7 +3273,6 @@ describe('evaluate', () => {
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(16);
-      // Sorted: [2, 3, 5, 6]. cs>4 flags 5 and 6.
       expect(result.rolls.map((d) => d.result)).toEqual([2, 3, 5, 6]);
       expect(result.rolls.map((d) => d.critical)).toEqual([false, false, true, true]);
     });
@@ -3331,8 +3288,8 @@ describe('evaluate', () => {
     });
 
     test('renders expression with default-sentinel codes', () => {
-      // `cscf` lexed as one unknown identifier; whitespace separates the
-      // two bare modifiers.
+      // `cscf` would lex as one unknown identifier — whitespace is what separates
+      // the two bare modifiers.
       const ast = parse('1d20cs cf');
       const rng = createMockRng([10]);
       const result = evaluate(ast, rng);
@@ -3342,8 +3299,8 @@ describe('evaluate', () => {
     });
 
     test('renders expression with mixed defaults and compare points', () => {
-      // Bare `cs` + `cf<3` + `cs=10`. Rendered order: all success thresholds
-      // first, then all fail thresholds — so "cscs=10cf<3".
+      // Rendered order is all success thresholds first, then all fail thresholds —
+      // input `cs` + `cf<3` + `cs=10` comes back as `cscs=10cf<3`.
       const ast = parse('1d20cs cf<3cs=10');
       const rng = createMockRng([10]);
       const result = evaluate(ast, rng);
@@ -3357,22 +3314,20 @@ describe('evaluate', () => {
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(62);
-      // >= 19 flags 20 and 19.
       expect(result.rolls.map((d) => d.critical)).toEqual([true, true, false, false]);
     });
 
     test('RNG-consuming cs threshold draws pool first, then meta — 4d20cs>=(1d2+17)', () => {
-      // Pins the documented draw order: `evalCritThreshold` evaluates the
-      // 4d20 pool before resolving the threshold meta-expression. RNG order:
-      // pool dice [20, 19, 18, 5] → 1d2 threshold die [2]. Threshold = 19.
+      // Pins the documented draw order: `evalCritThreshold` rolls the 4d20 pool
+      // [20, 19, 18, 5] before resolving the 1d2 threshold meta [2] → 19.
       const ast = parse('4d20cs>=(1d2+17)');
       const rng = createMockRng([20, 19, 18, 5, 2]);
       const result = evaluate(ast, rng);
 
       expect(result.total).toBe(62);
 
-      // Meta die pushed before pool in result.rolls — same shape as the
-      // SuccessCount meta-threshold test above.
+      // The meta die is pushed before the pool in `result.rolls` even though it
+      // drew last.
       const meta = getDie(result.rolls, 0);
       expect(meta.sides).toBe(2);
       expect(meta.result).toBe(2);
@@ -3387,8 +3342,8 @@ describe('evaluate', () => {
     });
 
     test('RNG-consuming cs threshold sanity variant — 4d20cs>=(1d4)', () => {
-      // Distinct sequence to avoid coincidence with the test above.
-      // RNG order: pool [15, 12, 10, 4] → 1d4 threshold [3]. Threshold = 3.
+      // Distinct sequence, so a coincidence cannot carry the test above.
+      // Draws: pool [15, 12, 10, 4] → 1d4 threshold [3] → threshold 3.
       const ast = parse('4d20cs>=(1d4)');
       const rng = createMockRng([15, 12, 10, 4, 3]);
       const result = evaluate(ast, rng);
@@ -3403,13 +3358,12 @@ describe('evaluate', () => {
 
       const pool = result.rolls.slice(1);
       expect(pool.map((d) => d.result)).toEqual([15, 12, 10, 4]);
-      // >= 3 flags all four.
       expect(pool.map((d) => d.critical)).toEqual([true, true, true, true]);
     });
 
     test('RNG-consuming cf threshold draws pool first, then meta — 4d20cf<=(1d3)', () => {
-      // Mirrors the cs draw-order pin for cf. RNG order: pool [20, 2, 1, 15]
-      // → 1d3 threshold [2]. Threshold = 2.
+      // Mirrors the cs draw-order pin for cf: pool [20, 2, 1, 15] → 1d3
+      // threshold [2] → threshold 2.
       const ast = parse('4d20cf<=(1d3)');
       const rng = createMockRng([20, 2, 1, 15, 2]);
       const result = evaluate(ast, rng);
@@ -3424,12 +3378,10 @@ describe('evaluate', () => {
 
       const pool = result.rolls.slice(1);
       expect(pool.map((d) => d.result)).toEqual([20, 2, 1, 15]);
-      // <= 2 flags 2 and 1 as fumble.
       expect(pool.map((d) => d.fumble)).toEqual([false, true, true, false]);
     });
 
     test('cs on Fate dice overrides the always-false defaults', () => {
-      // 4dF: [1, -1, 0, 1]. cs>0 flags both 1s as critical.
       const ast = parse('4dFcs>0');
       const rng = createMockRng([1, -1, 0, 1]);
       const result = evaluate(ast, rng);
@@ -3440,16 +3392,13 @@ describe('evaluate', () => {
     });
 
     test('SuccessCount wrapping CritThreshold leaves success tags independent of crit flags', () => {
-      // 10d10cs>8>=6 — crit flagged for result > 8; success for >= 6.
       const ast = parse('10d10cs>8>=6');
       const rng = createMockRng([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
       const result = evaluate(ast, rng);
 
-      // Successes (>= 6): 10, 9, 8, 7, 6 → 5 successes.
       expect(result.successes).toBe(5);
-      // Critical (> 8): 10, 9 → 2 critical dice.
       expect(result.rolls.filter((d) => d.critical).length).toBe(2);
-      // Total is the success count (5) since SuccessCount transforms the pool.
+      // The total is the success count, not the sum — SuccessCount transforms the pool.
       expect(result.total).toBe(5);
     });
 
@@ -3458,23 +3407,21 @@ describe('evaluate', () => {
       const rng = createMockRng([1]);
       const result = evaluate(ast, rng);
 
-      // Both thresholds apply: >19 false for 1, =1 true for 1 → critical.
+      // Both thresholds survive the collapse: >19 misses the 1, =1 matches it.
       expect(getDie(result.rolls, 0).critical).toBe(true);
       expect(result.expression).toBe('1d20cs>19cs=1');
     });
 
     test('single-sub-roll group passthrough — {1d20}kh1cs>18 matches 1d20kh1cs>18', () => {
-      // Stage 3 single-sub-roll passthrough: `{1d20}` is the documented
-      // flat-pool escape hatch and must produce the same total and per-die
-      // critical/fumble flags as the unwrapped form under the same RNG.
+      // `{1d20}` is the documented flat-pool escape hatch — under the same RNG it
+      // must match the unwrapped form die-for-die.
       const grouped = evaluate(parse('{1d20}kh1cs>18'), createMockRng([20]));
       const flat = evaluate(parse('1d20kh1cs>18'), createMockRng([20]));
 
       expect(grouped.total).toBe(flat.total);
       expect(grouped.rolls).toEqual(flat.rolls);
-      // ! The notation MUST round-trip — braces survive in `expression`,
-      //   so the user's input is preserved verbatim. A future renderer
-      //   refactor that strips braces would silently regress this.
+      // ! Braces must survive in `expression` — a renderer that strips them would
+      // ! silently rewrite the user's notation.
       expect(grouped.expression).toBe('{1d20}kh1cs>18');
       expect(flat.expression).toBe('1d20kh1cs>18');
     });
@@ -3509,10 +3456,9 @@ describe('evaluate', () => {
   });
 
   describe('cross-family modifier combinations (#134)', () => {
-    // Draw order per README, Randomness: keep/drop counts resolve before
-    // the base pool (all literal here, so no meta draws), threshold-style
-    // modifiers post-process a pool that already exists. Every sequence below
-    // is therefore `pool dice left-to-right, then explosion/reroll follow-ups`.
+    // Draw order per README → Randomness: keep/drop counts resolve before the pool
+    // (all literal here), threshold modifiers post-process it. Every sequence below
+    // is therefore pool left-to-right, then explosion/reroll follow-ups.
 
     test('4d6!!kh3 compounds first, then keeps the highest three', () => {
       // Draws: 4d6 pool [6, 3, 2, 5], then die 1 compounds on its 6 → 4.
@@ -3529,9 +3475,8 @@ describe('evaluate', () => {
     });
 
     test('4d6!pkh3 keeps the highest three of the penetrated pool', () => {
-      // Draws: 4d6 pool [6, 3, 2, 5], then die 1 penetrates on its 6 → raw 4,
-      // stored as 3. The appended die sits directly after its originator, so
-      // the pool becomes [6, 3, 3, 2, 5] before kh3 selects.
+      // Draws: 4d6 pool [6, 3, 2, 5], then die 1 penetrates on its 6 → raw 4 stored
+      // as 3, appended right after its originator → [6, 3, 3, 2, 5] before kh3.
       const result = evaluate(parse('4d6!pkh3'), createMockRng([6, 3, 2, 5, 4]));
 
       expect(result.rolls).toHaveLength(5);
@@ -3558,25 +3503,23 @@ describe('evaluate', () => {
     });
 
     test('4d6cf<2r<3 flags fumbles before the reroll replaces the die', () => {
-      // Draws: 4d6 pool [1, 5, 2, 4], then one replacement per matching die —
-      // 6 for the 1, 3 for the 2. `cf<2` is the inner modifier, so the flag
-      // lands on the original die even though the reroll then drops it.
+      // Draws: 4d6 pool [1, 5, 2, 4], then one replacement per match — 6 for the 1,
+      // 3 for the 2. `cf<2` is the inner modifier, so the flag lands on the original
+      // die even though the reroll then drops it.
       const result = evaluate(parse('4d6cf<2r<3'), createMockRng([1, 5, 2, 4, 6, 3]));
 
       expect(result.rolls).toHaveLength(6);
       expect(getDie(result.rolls, 0).fumble).toBe(true);
       expect(getDie(result.rolls, 0).modifiers).toEqual(['rerolled', 'dropped']);
-      // The replacement dice were rolled after `cf` ran, so they keep the
-      // default fumble rule (`result === 1`).
+      // Replacements roll after `cf` ran, so they keep the default rule (result === 1).
       expect(getDie(result.rolls, 1).fumble).toBe(false);
       expect(result.total).toBe(6 + 5 + 3 + 4);
       expect(result.rendered).toBe('4d6cf<2r<3[~~1~~, 6, 5, ~~2~~, 3, 4] = 18');
     });
 
     test('6d6!!>=8 binds the comparison to the explode, not to success counting', () => {
-      // `>=8` is unreachable on a d6, so nothing compounds and the result is a
-      // plain sum — `successes` stays undefined, proving this is not a
-      // SuccessCount node.
+      // `>=8` is unreachable on a d6: nothing compounds and `successes` stays
+      // undefined, proving the comparison bound to the explode, not SuccessCount.
       const result = evaluate(parse('6d6!!>=8'), createMockRng([6, 3, 2, 5, 4, 6]));
 
       expect(result.rolls).toHaveLength(6);
@@ -3625,8 +3568,7 @@ describe('evaluate', () => {
     });
 
     test('a penetrating chain just under the cap completes', () => {
-      // Three explosions then a non-matching roll: raw 6,6,6,2 → stored
-      // 6 + 5 + 5 + 1.
+      // Three explosions then a non-matching roll: raw 6,6,6,2 → stored 6+5+5+1.
       const result = evaluate(parse('1d6!p'), createMockRng([6, 6, 6, 2]), {
         maxExplodeIterations: 3,
       });
@@ -3636,9 +3578,8 @@ describe('evaluate', () => {
     });
 
     test('a Fate pool reaching the explode evaluator never rolls a zero-sided die', () => {
-      // ? Hand-built AST — `parseExplode` rejects `2dF!` with
-      //   INVALID_EXPLODE_TARGET, so `canExplode`'s `sides < 1` guard is only
-      //   reachable from a tree the parser cannot produce.
+      // Hand-built AST — `parseExplode` rejects `2dF!` with INVALID_EXPLODE_TARGET,
+      // so `canExplode`'s `sides < 1` guard is unreachable from parser output.
       const ast: ASTNode = {
         type: 'Explode',
         variant: 'standard',
@@ -3653,9 +3594,9 @@ describe('evaluate', () => {
   });
 
   describe('error contract escapes (#128)', () => {
-    // ? Above the engine's argument-list ceiling (~640k in Bun 1.3 on Linux),
-    //   which is where `push(...array)` and `Math.max(...array)` used to blow
-    //   the stack with a bare `RangeError`.
+    // ? Above Bun 1.3's ~640k argument-list ceiling on Linux — where
+    // ? `push(...array)` and `Math.max(...array)` used to blow the stack with a
+    // ? bare `RangeError`.
     const OVER_SPREAD_LIMIT = 700_000;
 
     test('sides beyond the safe-integer ceiling raise a typed error', () => {
@@ -3702,8 +3643,8 @@ describe('evaluate', () => {
     });
 
     test('max/min past the spread limit fold instead of overflowing the stack', () => {
-      // ? Hand-built AST — the equivalent notation is a multi-megabyte string
-      //   whose lexing dominates the runtime without testing anything extra.
+      // Hand-built AST — the equivalent notation is a multi-megabyte string whose
+      // lexing would dominate the runtime.
       const args: ASTNode[] = Array.from({ length: OVER_SPREAD_LIMIT }, (_, i) => ({
         type: 'Literal',
         value: i % 97,
@@ -3718,8 +3659,8 @@ describe('evaluate', () => {
     });
 
     test('max propagates NaN the way Math.max does', () => {
-      // `10**400` overflows to Infinity, so `Infinity - Infinity` is NaN — the
-      // fold must keep poisoning the total so NON_FINITE_RESULT still fires.
+      // `10**400` overflows to Infinity, so `Infinity - Infinity` is NaN — the fold
+      // must keep propagating it so NON_FINITE_RESULT still fires.
       const error = captureError(() =>
         evaluate(parse('max(10**400-10**400, 1)'), createMockRng([])),
       );

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -60,9 +60,8 @@ import {
 import { sortDice } from './modifiers/sort.js';
 import { countSuccesses } from './modifiers/success-count.js';
 
-// Re-exported for existing importers — the class moved to `errors.ts` so
-// `modifiers/explode.ts` and `modifiers/reroll.ts` can throw it without an
-// ESM value cycle back into this module.
+// Defined in `errors.ts` so the modifier modules can throw it without an ESM
+// value cycle back through here; re-exported for importers that expect it here.
 export { EvaluatorError };
 
 //
@@ -205,9 +204,8 @@ function toPublicSpecs(specs: ModifierChainEntry[]): ModifierSpec[] {
  * `RollResult.rolls` for audit, not for display.
  */
 function renderDice(dice: DieResult[]): string {
-  // Single pass building one string. The filter + map + join form allocated
-  // two intermediate arrays plus a string per die on the hottest path in
-  // the evaluator.
+  // Hot path: one pass into a single string — filter + map + join allocated two
+  // intermediate arrays plus a string per die.
   let rendered = '[';
   let isFirst = true;
 
@@ -246,12 +244,9 @@ function renderDie(result: number, modifiers: readonly DieModifier[]): string {
  * wrappings; this strip ensures a future parse regression cannot leak tags
  * into the top-level `successes`/`failures` scan).
  */
-// ? Exported, not `@internal`. The strip above is unreachable through any
-//   parseable notation — every wrapping that could smuggle a tagged die into a
-//   meta position is rejected at parse time — so the only honest way to pin it
-//   is to call this directly with a hand-built context. Marking it `@internal`
-//   claimed a test-only export that TypeDoc then hid, leaving the guarantee
-//   undocumented; the export is real and narrow, so it is stated plainly.
+// Exported rather than `@internal`: the tag strip above is unreachable through
+// any parseable notation, so pinning it needs a direct call with a hand-built
+// context — and `@internal` would hide that guarantee from the docs.
 export function mergeMetaRolls(parent: EvalContext, source: EvalContext): void {
   for (const die of source.rolls) {
     parent.rolls.push({
@@ -759,9 +754,8 @@ function applyFunction(name: string, values: number[]): number {
     case 'ceil':
       return Math.ceil(requireUnaryArg(name, values));
     case 'round':
-      // Delegates to `Math.round`, which rounds half-values toward +∞
-      // (IEEE-754 half-up). So `round(2.5) === 3` but `round(-2.5) === -2`,
-      // not `-3`. Users needing symmetric rounding must compose via `floor`.
+      // `Math.round` breaks halves toward +∞: `round(2.5) === 3` but
+      // `round(-2.5) === -2`. Symmetric rounding must be composed via `floor`.
       return Math.round(requireUnaryArg(name, values));
     case 'abs':
       return Math.abs(requireUnaryArg(name, values));
@@ -796,8 +790,8 @@ function extremumOf(values: number[], kind: 'max' | 'min'): number {
 function requireUnaryArg(name: string, values: number[]): number {
   const [x] = values;
   if (x == null) {
-    // ? Unreachable: parser validates arity before evaluation. Defensive for
-    // `noNonNullAssertion`.
+    // Unreachable: the parser validates arity before evaluation. Present to
+    // satisfy `noNonNullAssertion`.
     throw new EvaluatorError(
       `Function '${name}' requires an argument`,
       'UNKNOWN_FUNCTION',
@@ -961,9 +955,8 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
 
   appendAll(ctx.rolls, expanded);
   ctx.expressionParts.push(`${targetExpr}${code}`);
-  // Include the explode code in rendered output so readers can attribute
-  // the extra dice. Modifier rendering (kh/dl) skips its code because
-  // dropped dice are visible; explosion-origin is otherwise invisible.
+  // Rendered form carries the explode code — unlike kh/dl, whose dropped dice
+  // are self-evident, explosion origin is otherwise invisible.
   ctx.renderedParts.push(`${targetExpr}${code}${renderDice(expanded)}`);
 
   const total = sumKeptDice(expanded);
@@ -1094,8 +1087,8 @@ function evalCritThreshold(
   const successResolved = node.successThresholds.map((t) => resolveCritThreshold(t, rng, ctx, env));
   const failResolved = node.failThresholds.map((t) => resolveCritThreshold(t, rng, ctx, env));
 
-  // Independent overrides: a side with no explicit threshold falls back to
-  // the default rule instead of being wiped by the other side's override.
+  // A side with no explicit threshold falls back to the default rule rather
+  // than being wiped by the other side's override.
   const successApplied: ResolvedCritThreshold[] =
     successResolved.length > 0 ? successResolved : ['default'];
   const failApplied: ResolvedCritThreshold[] = failResolved.length > 0 ? failResolved : ['default'];
@@ -1146,13 +1139,16 @@ function resolveCritThreshold(
   return { operator: threshold.operator, value: resolved };
 }
 
+//
+// * Keep/drop evaluation
+//
+
 function evalModifier(node: ModifierNode, rng: RNG, ctx: EvalContext, env: EvalEnv): EvalResult {
   const { specs, baseTarget } = flattenModifierChain(node, rng, ctx, env);
 
-  // Multi-sub-roll group: keep/drop operates on sub-roll subtotals as if
-  // each subtotal were a compound die. Single-sub-roll groups fall through
-  // to the flat-pool path below — `evalGroup` evaluates the inner expression
-  // into `targetCtx.rolls`, and `mergeDropSets` selects individual dice.
+  // Multi-sub-roll group: keep/drop treats each sub-roll subtotal as a compound
+  // die. Single-sub groups fall through to the flat-pool path, where
+  // `mergeDropSets` selects individual dice.
   if (baseTarget.type === 'Group' && baseTarget.expressions.length >= 2) {
     return evalGroupModifier(node, baseTarget, specs, rng, ctx, env);
   }
@@ -1237,9 +1233,8 @@ function evalGroupModifier(
     };
   });
 
-  // Synthetic dice carry `sides = 0` as a sentinel — they're never
-  // surfaced in `ctx.rolls`, only used as input to `mergeDropSets`. Any
-  // `critical`/`fumble` flags would be meaningless for a subtotal.
+  // `sides = 0` sentinel: synthetic dice only feed `mergeDropSets`, never reach
+  // `ctx.rolls`, and crit/fumble is meaningless for a subtotal.
   const syntheticDice: DieResult[] = subRolls.map((sub) => ({
     sides: 0,
     result: sub.subtotal,
@@ -1260,12 +1255,10 @@ function evalGroupModifier(
     const isDropped = synth.modifiers.includes('dropped');
 
     if (isDropped) {
-      // Flag every inner die dropped so propagated rolls match the total.
-      // Keep existing `'kept'` stripped — the sub-roll didn't contribute,
-      // so its die-level kept annotation no longer applies. `'success'` /
-      // `'failure'` are stripped too: the top-level successes/failures scan
-      // must not count dice from a sub-roll that was dropped. Mutated in
-      // place — the same objects live in the sub-roll's RollPart.
+      // Flag every inner die dropped so propagated rolls still sum to the
+      // total, stripping `'success'`/`'failure'` too so the top-level tally
+      // cannot count a dropped sub-roll. Mutated in place — the same objects
+      // live in the sub-roll's `RollPart`.
       for (const die of sub.rolls) {
         die.modifiers = rewriteFlags(die.modifiers, SELECTION_AND_TALLY_FLAGS, 'dropped');
       }
@@ -1278,10 +1271,9 @@ function evalGroupModifier(
       total += sub.subtotal;
     }
 
-    // Propagate Versus metadata only from kept sub-rolls — `RollResult.degree`
-    // must reflect dice that contributed to `RollResult.total`. Two kept
-    // versus sub-rolls still collide here via the `NESTED_VERSUS` guard
-    // inside `propagateMetadata`.
+    // Only kept sub-rolls propagate versus metadata — `degree` must reflect
+    // dice that contributed to the total. Two kept versus sub-rolls still
+    // collide via `propagateMetadata`'s `NESTED_VERSUS` guard.
     if (!isDropped) {
       propagateMetadata(ctx, sub.versusMetadata);
     }
@@ -1291,15 +1283,13 @@ function evalGroupModifier(
   const modifierCodes = specs.map((s) => `${s.code}${s.count}`).join('');
 
   ctx.expressionParts.push(`{${subExprStrs.join(', ')}}${modifierCodes}`);
-  // Mirror `evalModifier`'s flat-pool rendering: modifier codes live in
-  // `expressionParts` only — the per-sub strikethrough already signals
-  // which sub-rolls were kept vs dropped.
+  // Modifier codes live in `expressionParts` only — the per-sub strikethrough
+  // already shows which sub-rolls were kept.
   ctx.renderedParts.push(`{${outerRendered.join(', ')}}`);
 
-  // ? `keptIndices` lives on the inner `group` part (it describes sub-roll
-  //   selection), even though the outer modifier evaluation computed it —
-  //   the accepted model leak from STAGE3.md §5. Dropped sub-rolls keep
-  //   their complete parts; consumers filter by `keptIndices`.
+  // `keptIndices` sits on the inner `group` part even though the outer modifier
+  // computed it — it describes sub-roll selection. Dropped sub-rolls keep their
+  // complete parts; consumers filter by `keptIndices`.
   const groupPart: RollPart = {
     type: 'group',
     parts: subRolls.map((s) => s.part),
@@ -1396,10 +1386,9 @@ function evalSuccessCount(
     return part;
   };
 
-  // No-op when the target produced no dice in its pool (`0d6>=4`).
-  // `containsDicePool` should already reject dice-less targets at parse
-  // time, but guard defensively. `targetValue` is 0 for an empty pool, so
-  // the `total === successes - failures` invariant holds.
+  // No-op when the target produced no dice (`0d6>=4`); `containsDicePool`
+  // should already reject dice-less targets at parse time. `target.total` is 0
+  // for an empty pool, so `total === successes - failures` still holds.
   if (targetCtx.rolls.length === 0) {
     ctx.expressionParts.push(`${targetExpr}${code}`);
     ctx.renderedParts.push(`${targetExpr}${code}`);
@@ -1495,8 +1484,6 @@ function evalVersus(node: VersusNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
   try {
     const rollCtx = createContext();
     const rollResult = evalNode(node.roll, rng, rollCtx, env);
-    // Extract natural from rollCtx directly — the roll-side pool is isolated
-    // here, so no index slicing on the merged parent pool is needed.
     const natural = extractNatural(rollCtx.rolls);
 
     const dcCtx = createContext();
@@ -1615,8 +1602,7 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
   const trailing = ctx.versusMetadata ? degreeLabel(ctx.versusMetadata.degree) : String(total);
   const rendered = `${ctx.renderedParts.join('')} = ${trailing}`;
 
-  // `RollResult` is `Readonly`, so the optional fields are folded in via
-  // conditional spreads instead of post-construction assignment.
+  // `RollResult` is `Readonly` — optional fields fold in via conditional spreads.
   const versus = ctx.versusMetadata;
 
   return {

--- a/src/evaluator/modifiers/keep-drop.ts
+++ b/src/evaluator/modifiers/keep-drop.ts
@@ -61,8 +61,7 @@ export function markDroppedIndices(
     return;
   }
 
-  // Stable sort — ties resolve by original pool order, matching the
-  // `slice(0, count)` selection this replaced.
+  // Stable sort — ties resolve by original pool order.
   eligible.sort(
     selector === 'highest' ? (a, b) => b.result - a.result : (a, b) => a.result - b.result,
   );

--- a/src/evaluator/parts.test.ts
+++ b/src/evaluator/parts.test.ts
@@ -3,7 +3,7 @@
  *
  * Deep-equal "snapshot" tests pin exact part trees for representative
  * notations under deterministic mock RNGs; the rest assert the contractual
- * invariants from STAGE3.md §5.
+ * invariants directly.
  *
  * The snapshots compare span-stripped trees. Spans are a separate contract
  * with a separate failure mode — a one-character shift in the lexer would
@@ -96,9 +96,9 @@ describe('RollResult.parts', () => {
           type: 'dice',
           count: 4,
           sides: 6,
-          // Dice part total (16) is the pre-modifier pool sum; the flags
-          // reflect post-modifier state via shared references. Recursive
-          // total consistency is deliberately not contractual.
+          // The dice part total is the pre-modifier pool sum while the flags are
+          // post-modifier via shared refs — recursive total consistency is
+          // deliberately not contractual.
           rolls: [
             { sides: 6, result: 3, modifiers: ['kept'], critical: false, fumble: false },
             { sides: 6, result: 6, modifiers: ['kept'], critical: true, fumble: false },
@@ -213,10 +213,8 @@ describe('RollResult.parts', () => {
   });
 
   describe('source spans', () => {
-    // One home for the span contract: every part's `[start, end)` must slice
-    // the notation back to exactly the source text that produced it. The
-    // structural snapshots above are span-stripped, so a lexer offset shift
-    // fails here and nowhere else.
+    // The span contract: every part's `[start, end)` must slice the notation back
+    // to exactly the source text that produced it.
     const SPAN_CASES: [notation: string, draws: number[], expected: string[]][] = [
       [
         '4d6kh3 + floor(1d10/2)',
@@ -401,8 +399,6 @@ describe('RollResult.parts', () => {
       '10d10>=6f1',
     ];
 
-    // The fixed-seed loop this used to run is subsumed: the fast-check
-    // property draws from the same `NOTATIONS` list over 300 runs.
     test('parts.total === result.total holds under fast-check', () => {
       fc.assert(
         fc.property(
@@ -457,7 +453,7 @@ describe('RollResult.parts', () => {
       if (result.parts.type !== 'reroll' || result.parts.target.type !== 'dice') {
         throw new Error('unexpected parts shape');
       }
-      // The original die 1 was rerolled — its shared object carries the flags.
+      // Die 0 rolled a 1 and was rerolled; its shared object carries both flags.
       expect(result.parts.target.rolls[0]?.modifiers).toEqual(['rerolled', 'dropped']);
       expect(result.rolls[0]).toBe(
         result.parts.target.rolls[0] as NonNullable<(typeof result.rolls)[number]>,
@@ -467,8 +463,7 @@ describe('RollResult.parts', () => {
 
   describe('group keptIndices', () => {
     test('accurate for kh/kl/dh/dl', () => {
-      const cases: [string, number[], number[]][] = [
-        // notation, mock draws, expected keptIndices
+      const cases: [notation: string, draws: number[], expected: number[]][] = [
         ['{1d6, 1d8, 1d10}kh1', [2, 7, 5], [1]],
         ['{1d6, 1d8, 1d10}kl1', [2, 7, 5], [0]],
         ['{1d6, 1d8, 1d10}dh1', [2, 7, 5], [0, 2]],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,9 +51,8 @@ const VALUE_EXPORTS = [
   'roll',
 ] as const;
 
-// Re-bound through a plain record so the loop below reads properties off an
-// ordinary object — indexing a namespace import directly defeats tree shaking
-// and trips `noDynamicNamespaceImportAccess`.
+// Indexing a namespace import directly defeats tree shaking and trips
+// `noDynamicNamespaceImportAccess`, hence the re-bind.
 const surface: Record<string, unknown> = api;
 
 describe('public API surface', () => {
@@ -67,8 +66,8 @@ describe('public API surface', () => {
     expect(Object.keys(api).sort()).toEqual([...VALUE_EXPORTS].sort());
   });
 
-  // Drift guard for the generated `src/version.ts` — a package.json bump
-  // without `bun run generate:version` must fail here, in CI, not at release.
+  // Fails in CI, not at release, when a package.json bump skipped
+  // `bun run generate:version` for the generated `src/version.ts`.
   test('VERSION matches the package manifest', () => {
     expect(api.VERSION).toBe(pkg.version);
     expect(api.VERSION).toMatch(/^\d+\.\d+\.\d+/);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -34,13 +34,12 @@ describe('roll() integration', () => {
     });
 
     test('complex expression', () => {
-      // (1d6+1)*2 with roll of 4 → (4+1)*2 = 10
       const result = roll('(1d6+1)*2', { rng: createMockRng([4]) });
       expect(result.total).toBe(10);
     });
 
     test('multiple dice groups', () => {
-      // 2d6+1d4 with rolls [3, 5] and [2] → 8 + 2 = 10
+      // [3, 5] fills the 2d6, [2] the 1d4 → 8 + 2 = 10.
       const result = roll('2d6+1d4', { rng: createMockRng([3, 5, 2]) });
       expect(result.total).toBe(10);
       expect(result.rolls).toHaveLength(3);
@@ -48,9 +47,8 @@ describe('roll() integration', () => {
   });
 
   describe('modifiers', () => {
-    // Per-modifier selection semantics are pinned once in
-    // `evaluator/evaluator.test.ts`. All this file owes is proof that `roll()`
-    // forwards the notation to the same evaluator and surfaces its flags.
+    // Selection semantics are pinned in `evaluator/evaluator.test.ts`; this file
+    // only owes proof that `roll()` reaches that evaluator and surfaces its flags.
     test('roll() wires keep/drop through to the evaluator', () => {
       // Rolls: [3, 1, 4, 2] → keep [3, 4, 2] = 9, drop the 1.
       const result = roll('4d6kh3', { rng: createMockRng([3, 1, 4, 2]) });
@@ -145,8 +143,8 @@ describe('roll() integration', () => {
     });
 
     test('ten fixed seeds decorrelate into at least five distinct d100 totals', () => {
-      // Deterministic, not statistical: the seeds are fixed, so this is a
-      // pinned property of `SeededRNG`'s seed hashing, not a sampling claim.
+      // Deterministic, not statistical: the seeds are fixed, so this pins
+      // `SeededRNG`'s seed hashing rather than making a sampling claim.
       const results = new Set<number>();
       for (let i = 0; i < 10; i++) {
         results.add(roll('1d100', { seed: `seed-${i}` }).total);
@@ -158,7 +156,6 @@ describe('roll() integration', () => {
     test('string and numeric seeds work', () => {
       const r1 = roll('3d6', { seed: 'hello' });
       const r2 = roll('3d6', { seed: 42 });
-      // Both should produce valid results
       expect(r1.total).toBeGreaterThanOrEqual(3);
       expect(r1.total).toBeLessThanOrEqual(18);
       expect(r2.total).toBeGreaterThanOrEqual(3);
@@ -168,13 +165,11 @@ describe('roll() integration', () => {
 
   describe('PRD 3.7 regression: negative numbers', () => {
     test('negative result is NOT clamped to zero', () => {
-      // Roll 1 on d4, subtract 5 → -4 (NOT 0)
       const result = roll('1d4-5', { rng: createMockRng([1]) });
       expect(result.total).toBe(-4);
     });
 
     test('unary minus on dice', () => {
-      // -1d4 with roll of 3 → -3
       const result = roll('-1d4', { rng: createMockRng([3]) });
       expect(result.total).toBe(-3);
     });
@@ -206,32 +201,29 @@ describe('roll() integration', () => {
     });
 
     test('computed dice count', () => {
-      // (1+1)d6 → 2d6
       const result = roll('(1+1)d6', { rng: createMockRng([3, 4]) });
       expect(result.total).toBe(7);
       expect(result.rolls).toHaveLength(2);
     });
 
     test('computed sides', () => {
-      // 2d(3*2) → 2d6
       const result = roll('2d(3*2)', { rng: createMockRng([3, 4]) });
       expect(result.total).toBe(7);
     });
 
     test('deeply nested expression', () => {
-      // ((1+1)d(2*3))kh2 → 2d6kh2
       const result = roll('((1+1)d(2*3))kh2', { rng: createMockRng([3, 5]) });
       expect(result.total).toBe(8);
     });
 
     test('power operator right-associativity', () => {
-      // 2**3**2 = 2^(3^2) = 2^9 = 512
+      // 2^(3^2) = 512, not (2^3)^2 = 64.
       const result = roll('2**3**2', {});
       expect(result.total).toBe(512);
     });
 
     test('operator precedence', () => {
-      // 1+2*3 = 1 + 6 = 7 (not 9)
+      // 1 + (2*3) = 7, not (1+2)*3 = 9.
       const result = roll('1+2*3', {});
       expect(result.total).toBe(7);
     });
@@ -373,8 +365,8 @@ describe('roll() integration', () => {
     });
 
     test('chained modifiers apply independently to full pool', () => {
-      // Each modifier sees the full original pool; drop sets are merged via union
-      // dl1 drops {idx1}, kh3 drops {idx1} → union {1} → total 9
+      // Each modifier sees the full pool and the drop sets are unioned:
+      // [3,1,4,2] → dl1 drops {1}, kh3 drops {1} → union {1} → total 9.
       const result = roll('4d6dl1kh3', { rng: createMockRng([3, 1, 4, 2]) });
       expect(result.total).toBe(9);
     });
@@ -709,7 +701,7 @@ describe('roll() integration', () => {
     });
 
     test('flat-pool: {4d6+2d8}kh3 keeps 3 highest across combined pool', () => {
-      // 4d6: [6, 6, 6, 1], 2d8: [8, 1]. Combined [6, 6, 6, 1, 8, 1]. kh3 → 8+6+6 = 20
+      // 4d6 [6,6,6,1] and 2d8 [8,1] merge into one pool; kh3 → 8+6+6 = 20.
       const result = roll('{4d6+2d8}kh3', { rng: createMockRng([6, 6, 6, 1, 8, 1]) });
 
       expect(result.total).toBe(20);

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -65,7 +65,6 @@ describe('Lexer', () => {
     });
 
     it('should throw for trailing dot not followed by digit', () => {
-      // '1.' followed by something that is not a digit should error
       expect(() => lex('1.+2')).toThrow(LexerError);
     });
 
@@ -532,11 +531,8 @@ describe('Lexer', () => {
     });
 
     it('should not confuse function names with dice/modifiers', () => {
-      // 'd' alone is still DICE
       expect(lex('d')[0]?.type).toBe(TokenType.DICE);
-      // 'k' alone is still KEEP_HIGH
       expect(lex('k')[0]?.type).toBe(TokenType.KEEP_HIGH);
-      // 'kh' is still KEEP_HIGH
       expect(lex('kh')[0]?.type).toBe(TokenType.KEEP_HIGH);
     });
   });
@@ -680,8 +676,7 @@ describe('Lexer', () => {
           type: TokenType.AT,
           value: 'Strength Modifier-1',
           position: 0,
-          // Braced form consumes `@{...}` — end covers the braces, not just
-          // the captured name.
+          // `end` covers the whole `@{...}` span, not just the captured name.
           end: 22,
         });
       });
@@ -768,8 +763,8 @@ describe('Lexer', () => {
     });
 
     it('covers consumed input where value differs from source', () => {
-      // dF normalizes to 'df'; @{..} strips braces from value — end must
-      // still cover the consumed source characters.
+      // `dF` normalizes to 'df' and `@{..}` drops the braces from `value` — `end`
+      // still spans every consumed character.
       expect(lex('4DF')[1]).toEqual({
         type: TokenType.DICE_FATE,
         value: 'df',
@@ -847,9 +842,9 @@ describe('Lexer', () => {
   });
 
   describe('unicode and whitespace boundaries', () => {
-    // These pin the lexer's *current* behavior. Only ASCII space, tab, CR and
-    // LF are whitespace; everything else that looks blank or numeric to a
-    // human is an unexpected character with a code-point-accurate position.
+    // Characterization tests: only ASCII space, tab, CR and LF are whitespace —
+    // anything else that looks blank or numeric to a human is an unexpected
+    // character, reported at a code-point-accurate position.
 
     it('should reject a no-break space as an unexpected character', () => {
       const error = expectRollError(() => lex('2d6 +3'), LexerError, 'UNEXPECTED_CHARACTER');
@@ -907,8 +902,8 @@ describe('Lexer', () => {
     });
 
     it('should reject a bare @ followed by a non-ASCII name', () => {
-      // The bare form is `[A-Za-z_][A-Za-z0-9_]*` only — `@力` reads as an
-      // empty variable name rather than a unicode identifier.
+      // The bare form is `[A-Za-z_][A-Za-z0-9_]*`, so `@力` reads as an empty name
+      // rather than a unicode identifier.
       const error = expectRollError(() => lex('@力'), LexerError, 'UNEXPECTED_CHARACTER');
 
       expect(error.message).toContain('Empty @ variable name');

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -62,8 +62,8 @@ export class LexerError extends RollParserError {
 // * Character codes
 //
 
-// Range tests compare code units rather than strings: `char.toLowerCase()`
-// per character allocated a string on the hottest loop in the lexer.
+// Range tests compare code units: `char.toLowerCase()` per character allocated
+// a string on the lexer's hottest loop.
 const CHAR_DIGIT_0 = 48;
 const CHAR_DIGIT_9 = 57;
 const CHAR_UPPER_A = 65;
@@ -154,22 +154,18 @@ export class Lexer {
     const startPos = this.pos;
     const char = this.peek();
 
-    // * Numbers
     if (this.isDigit(char)) {
       return this.scanNumber();
     }
 
-    // * Identifiers
     if (this.isAlpha(char)) {
       return this.scanIdentifier();
     }
 
-    // * Variable reference
     if (char === '@') {
       return this.scanAt();
     }
 
-    // * Operators and punctuation
     this.advance();
 
     switch (char) {
@@ -228,7 +224,9 @@ export class Lexer {
     }
   }
 
+  //
   // * Private helpers
+  //
 
   private skipWhitespace(): void {
     while (!this.isAtEnd() && this.isWhitespace(this.peek())) {
@@ -236,20 +234,17 @@ export class Lexer {
     }
   }
 
-  // Scanners record a start offset and slice once at the end rather than
-  // accumulating `value += this.advance()` — one string per token instead
-  // of one per character. `scanAt` already used this idiom.
+  // Scanners slice once from a recorded start offset rather than accumulating
+  // `value += this.advance()` — one string per token instead of one per character.
   private scanNumber(): Token {
     const startPos = this.pos;
 
-    // Integer part
     while (!this.isAtEnd() && this.isDigit(this.peek())) {
       this.pos++;
     }
 
-    // Decimal part
     if (!this.isAtEnd() && this.peek() === '.' && this.isDigit(this.peekNext())) {
-      this.pos++; // consume '.'
+      this.pos++;
       while (!this.isAtEnd() && this.isDigit(this.peek())) {
         this.pos++;
       }
@@ -318,11 +313,11 @@ export class Lexer {
    */
   private scanAt(): Token {
     const startPos = this.pos;
-    this.advance(); // consume '@'
+    this.advance();
 
     let name: string;
     if (!this.isAtEnd() && this.peek() === '{') {
-      this.advance(); // consume '{'
+      this.advance();
       const nameStart = this.pos;
       while (!this.isAtEnd() && this.peek() !== '}' && this.peek() !== '\n') {
         this.advance();
@@ -331,7 +326,7 @@ export class Lexer {
         throw new LexerError('Unterminated @{...} variable', 'UNEXPECTED_CHARACTER', startPos, '@');
       }
       name = this.input.slice(nameStart, this.pos);
-      this.advance(); // consume '}'
+      this.advance();
     } else {
       const nameStart = this.pos;
       if (this.isAtEnd() || !this.isIdentifierStart(this.peek())) {

--- a/src/parser/ast.test.ts
+++ b/src/parser/ast.test.ts
@@ -22,8 +22,6 @@ import {
 import { parse } from './parser.js';
 
 describe('AST type guards', () => {
-  // One representative notation per node type — each guard must accept its
-  // own node and reject every other node in the table.
   const nodes: [string, (node: ASTNode) => boolean, ASTNode][] = [
     ['Literal', isLiteral, parse('42')],
     ['Dice', isDice, parse('2d6')],
@@ -62,8 +60,8 @@ describe('AST walkers via parse-level guards', () => {
   });
 
   test('bare cf rejects Fate pools cloaked by wrappers inside a group', () => {
-    // Each notation routes deepContainsFatePool through a different branch:
-    // UnaryOp, Modifier target, Grouped, nested Group.
+    // One notation per `deepContainsFatePool` branch: UnaryOp, Modifier target,
+    // Grouped, nested Group.
     for (const notation of ['{-4dF}cf', '{4dFkh2}cf', '{(4dF)}cf', '{{4dF}}cf']) {
       expect(() => parse(notation)).toThrow('Bare cs/cf cannot apply to Fate dice');
     }

--- a/src/parser/guards.ts
+++ b/src/parser/guards.ts
@@ -138,12 +138,12 @@ export function containsDicePool(node: ASTNode): boolean {
     case 'Grouped':
       return containsDicePool(node.expression);
     case 'Group':
-      // Multi-sub-roll groups (`{a, b, c}kh1`) always accept: keep/drop
-      // operates on subtotals, which are "compound dice" by definition —
-      // even a literal-only `{3, 5, 7}kh1` is valid. Single-sub-roll
-      // groups are the user's explicit opt-in to flat-pool semantics, so
-      // we deep-walk through arithmetic that a raw `(1d6+5)kh1` would
-      // reject. This is the `{}` escape hatch per Stage 3 spec.
+      // Multi-sub-roll groups (`{a, b, c}kh1`) always accept: keep/drop operates
+      // on subtotals, which are compound dice by definition — even a
+      // literal-only `{3, 5, 7}kh1` is valid. A single-sub-roll group is the
+      // user's explicit opt-in to flat-pool semantics, so it deep-walks
+      // arithmetic that a raw `(1d6+5)kh1` rejects — the Stage 3 `{}` escape
+      // hatch.
       return node.expressions.length >= 2 || node.expressions.some(deepContainsDicePool);
     default:
       return false;
@@ -221,7 +221,8 @@ export function deepContainsFatePool(node: ASTNode): boolean {
  *
  * Without this walk, the unwrap inside `rejectGroupTarget` only peels
  * `Grouped`/`Modifier`/`Sort`/`CritThreshold` — a multi-sub Group cloaked
- * in a `BinaryOp`/`UnaryOp`/`FunctionCall` revives issue #97.
+ * in a `BinaryOp`/`UnaryOp`/`FunctionCall` reaches the evaluator, where it
+ * flags crits on dice belonging to dropped sub-rolls.
  */
 export function containsMultiSubGroup(node: ASTNode): boolean {
   return someDescendant(node, isMultiSubGroupHit);

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -24,7 +24,9 @@ import type {
 } from './ast.js';
 import { ParseError, Parser, parse } from './parser.js';
 
-// * Helper functions for readable assertions
+//
+// * Assertion helpers
+//
 
 /**
  * Recursively removes `start`/`end` spans so structural assertions stay
@@ -174,10 +176,7 @@ describe('Parser', () => {
   });
 
   describe('signed literal operands', () => {
-    // #135 — replaces four fast-check "properties" that re-derived IEEE-754
-    // commutativity and identity over random literals. What they actually
-    // exercised was a signed literal reaching either operand position of every
-    // binary operator; that is a parser concern, so it is pinned here exactly.
+    // Pins a signed literal in either operand position of every binary operator.
     const CASES: [notation: string, expected: ASTNode][] = [
       ['-7+3', binary('+', unary(literal(7)), literal(3))],
       ['3+-7', binary('+', literal(3), unary(literal(7)))],
@@ -365,14 +364,12 @@ describe('Parser', () => {
     });
 
     it('should be right-associative: 2**3**2 = 2**(3**2)', () => {
-      // This evaluates to 2^9 = 512, not (2^3)^2 = 64
       expect(parseAst('2**3**2')).toEqual(
         binary('**', literal(2), binary('**', literal(3), literal(2))),
       );
     });
 
     it('should have higher precedence than multiplication', () => {
-      // 2*3**2 = 2*(3^2) = 2*9 = 18
       expect(parseAst('2*3**2')).toEqual(
         binary('*', literal(2), binary('**', literal(3), literal(2))),
       );
@@ -505,7 +502,6 @@ describe('Parser', () => {
 
   describe('modifier + arithmetic', () => {
     it('should parse 4d6kh3+5', () => {
-      // Modifier applies only to dice, then addition
       expect(parseAst('4d6kh3+5')).toEqual(
         binary(
           '+',
@@ -656,7 +652,6 @@ describe('Parser', () => {
     });
 
     it('should handle prefix d with arithmetic', () => {
-      // d6+d8 = (d6)+(d8)
       expect(parseAst('d6+d8')).toEqual(
         binary('+', dice(literal(1), literal(6)), dice(literal(1), literal(8))),
       );
@@ -665,7 +660,6 @@ describe('Parser', () => {
 
   describe('modifier chaining', () => {
     it('should parse 4d6dl1kh3 as (4d6dl1)kh3', () => {
-      // Chained modifiers: drop lowest 1, then keep highest 3
       expect(parseAst('4d6dl1kh3')).toEqual(
         modifier(
           'keep',
@@ -677,7 +671,6 @@ describe('Parser', () => {
     });
 
     it('should parse 4d6kh3dl1 (reverse order)', () => {
-      // Reverse order: keep highest 3, then drop lowest 1
       expect(parseAst('4d6kh3dl1')).toEqual(
         modifier(
           'drop',
@@ -689,7 +682,7 @@ describe('Parser', () => {
     });
 
     it('should parse multiple same modifiers: 4d6dl1dl1', () => {
-      // Chaining same modifier type (semantically odd but should parse)
+      // A redundant chain is semantically odd, but must still parse.
       expect(parseAst('4d6dl1dl1')).toEqual(
         modifier(
           'drop',
@@ -701,7 +694,6 @@ describe('Parser', () => {
     });
 
     it('should allow computed count in chain: 4d6kh(1+2)', () => {
-      // Computed counts should still work with the fix
       expect(parseAst('4d6kh(1+2)')).toEqual(
         modifier(
           'keep',
@@ -713,7 +705,6 @@ describe('Parser', () => {
     });
 
     it('should parse triple chain: 4d6dl1kh3dh1', () => {
-      // Three modifiers in sequence
       expect(parseAst('4d6dl1kh3dh1')).toEqual(
         modifier(
           'drop',
@@ -894,9 +885,8 @@ describe('Parser', () => {
     });
 
     it('should reject d6!d20 as an ambiguous bare dice chain', () => {
-      // EXPLODE (BP.MODIFIER=35) binds to `d6` first, then the second DICE
-      // token would bind the exploded pool as an infix count — the `4d6d1`
-      // trap in another costume. Parenthesized nesting stays legal.
+      // EXPLODE (BP.MODIFIER=35) binds `d6` first, so the second DICE token
+      // would take the exploded pool as an infix count — the `4d6d1` trap again.
       expect(() => parseAst('d6!d20')).toThrow('Ambiguous dice chain');
       expect(parseAst('(d6!)d20')).toEqual(
         dice(grouped(explode('standard', dice(literal(1), literal(6)))), literal(20)),
@@ -1089,9 +1079,8 @@ describe('Parser', () => {
     });
 
     it('should bind compare to explode threshold, not success count: 10d10!>=6', () => {
-      // Explode greedily consumes a trailing ComparePoint as its own
-      // threshold, so `10d10!>=6` means "explode on >=6", not "explode
-      // then count successes". Disambiguate with parentheses.
+      // Explode greedily takes a trailing ComparePoint as its own threshold, so
+      // this is "explode on >=6", not explode-then-count. Parens disambiguate.
       expect(parseAst('10d10!>=6')).toEqual(
         explode('standard', dice(literal(10), literal(10)), cp('>=', literal(6))),
       );
@@ -1217,8 +1206,8 @@ describe('Parser', () => {
   describe('success count rejected in meta-expression positions', () => {
     // SuccessCount is terminal at every meta-expression parse site: modifier
     // count, dice sides/count (infix + prefix), Fate/percent dice count,
-    // SuccessCount threshold value, bare `fN` value, and compare-point values
-    // (Explode / Reroll). Wrapping in parens used to bypass the #51 guards.
+    // threshold value, bare `fN` value, and Explode/Reroll compare points.
+    // Parenthesizing it slips past any check that only looks one level down.
 
     it('should reject SuccessCount as keep-modifier count: 4d6kh(3d6>=3)', () => {
       expectRollError(() => parseAst('4d6kh(3d6>=3)'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
@@ -1267,9 +1256,8 @@ describe('Parser', () => {
 
   describe('versus rejected in meta-expression positions', () => {
     // Versus produces a PF2e degree — a terminal scalar, not a valid
-    // meta-expression input. Symmetric with the SuccessCount rejections
-    // above; prevents `versusMetadata` from being silently dropped in
-    // `mergeMetaRolls` sites.
+    // meta-expression input. Rejecting it here keeps `versusMetadata` from
+    // being silently dropped at the `mergeMetaRolls` sites.
 
     it('should reject Versus as keep-modifier count: 4d6kh(1d20 vs 10)', () => {
       expectRollError(() => parseAst('4d6kh(1d20 vs 10)'), ParseError, 'NESTED_VERSUS');
@@ -1311,13 +1299,12 @@ describe('Parser', () => {
       expectRollError(() => parseAst('1d6r<=(1d20 vs 10)'), ParseError, 'NESTED_VERSUS');
     });
 
-    // #109 — single-sub-roll Group passthrough makes Versus reachable past
-    // the shallow rejectVersusTarget check. Each meta-expression site needs
-    // a `{...}`-form rejection to mirror the existing parens-form coverage.
+    // A single-sub-roll `{...}` Group passes its expression through, so a Versus
+    // inside one reaches sites the shallow `rejectVersusTarget` never looked at —
+    // every parens-form case above needs a `{...}`-form twin.
     it('should reject Versus inside parens-wrapped single-sub group as keep-modifier count: 4d6kh({1d20 vs 10})', () => {
-      // `kh{...}` is not valid syntax — `kh` requires parens, not braces.
-      // `kh({...})` is the actual bypass route: parens around a single-sub
-      // Group around Versus. The new deep-walk catches it.
+      // `kh{...}` is not valid syntax — `kh` requires parens. `kh({...})` is the
+      // real bypass route: parens around a single-sub Group around a Versus.
       expectRollError(() => parseAst('4d6kh({1d20 vs 10})'), ParseError, 'NESTED_VERSUS');
     });
 
@@ -1326,11 +1313,9 @@ describe('Parser', () => {
     });
 
     it('should reject Versus inside single-sub group as kh target: {1d20 vs 15}kh1', () => {
-      // ! Pre-existing inconsistency closed: parseModifier did not call
-      //   rejectVersusTarget. The Group passthrough made it reachable past
-      //   `containsDicePool` (deep walk recurses into Versus.roll/dc), so the
-      //   reject was the only thing standing between user input and a
-      //   silently-dropped `degree`/`natural`.
+      // `containsDicePool`'s deep walk recurses into `Versus.roll`/`dc`, so a
+      // single-sub Group target reaches parseModifier; `rejectVersusTarget` is
+      // the only thing stopping a silently-dropped `degree`/`natural`.
       expectRollError(() => parseAst('{1d20 vs 15}kh1'), ParseError, 'NESTED_VERSUS');
     });
 
@@ -1343,9 +1328,8 @@ describe('Parser', () => {
     });
 
     it('should accept Versus inside single-sub group as arithmetic operand: {1d20 vs 15}+5', () => {
-      // BinaryOp uses `mergeContext`, which propagates `versusMetadata`.
-      // Not a meta-expression site — explicitly distinguished from the
-      // modifier/sort/cs cases above.
+      // BinaryOp propagates `versusMetadata` through `mergeContext`, so
+      // arithmetic is not a meta-expression site.
       expect(() => parseAst('{1d20 vs 15}+5')).not.toThrow();
     });
   });
@@ -1558,8 +1542,7 @@ describe('Parser', () => {
     });
 
     it('should reject paren-wrapped chained versus at parse: (1d20 vs 15) vs 10', () => {
-      // Chain guard unwraps `Grouped`, so parens do not bypass the parse-time
-      // check. Previously parsed and threw at eval via `mergeContext`.
+      // The chain guard unwraps `Grouped`, so parens cannot defer this to eval.
       expectRollError(() => parseAst('(1d20 vs 15) vs 10'), ParseError, 'NESTED_VERSUS');
     });
   });
@@ -1955,8 +1938,7 @@ describe('Parser', () => {
       });
 
       it('should chain keep/drop over sort (modifier outer)', () => {
-        // `sdl` as one identifier maxes-munches to an unknown keyword in
-        // the lexer; whitespace separates the two modifiers cleanly.
+        // `sdl` maximal-munches into one unknown keyword — the space splits it.
         expect(parseAst('4d6s dl1')).toEqual(
           modifier('drop', 'lowest', literal(1), sort('ascending', dice(literal(4), literal(6)))),
         );
@@ -1969,8 +1951,7 @@ describe('Parser', () => {
       });
 
       it('should allow double sort (idempotent chain)', () => {
-        // Maximal-munch lexing treats `ss` / `ssd` as a single identifier,
-        // so chained sorts need whitespace between the keywords.
+        // `ss` / `ssd` lex as one identifier, so chained sorts need whitespace.
         expect(parseAst('4d6s s')).toEqual(
           sort('ascending', sort('ascending', dice(literal(4), literal(6)))),
         );
@@ -2138,25 +2119,22 @@ describe('Parser', () => {
       });
 
       it('should chain cs over sort', () => {
-        // `4d6scs` maxes-munches to an unknown `scs` identifier in the
-        // lexer — whitespace separates the two keywords cleanly, same
-        // as the `4d6s dl1` pattern used by sort tests.
+        // `scs` maximal-munches into one unknown identifier — the space splits it.
         expect(parseAst('4d6s cs>4')).toEqual(
           critThreshold([cp('>', literal(4))], [], sort('ascending', dice(literal(4), literal(6)))),
         );
       });
 
       it('should chain sort over cs (sort outer)', () => {
-        // `cs` and `s` cannot be lexed together as one identifier — the
-        // intervening `>value` breaks maximal munch. No whitespace needed.
+        // The intervening `>value` breaks maximal munch, so `cs` and `s` cannot
+        // fuse into one identifier — no whitespace needed here.
         expect(parseAst('4d6cs>4 s')).toEqual(
           sort('ascending', critThreshold([cp('>', literal(4))], [], dice(literal(4), literal(6)))),
         );
       });
 
       it('should collapse chain through parens', () => {
-        // `(1d20cs>19)cs=1` must collapse into one CritThresholdNode, not
-        // double-wrap through the Grouped node.
+        // Must collapse into one CritThresholdNode, not double-wrap the Grouped.
         expect(parseAst('(1d20cs>19)cs=1')).toEqual(
           critThreshold(
             [cp('>', literal(19)), cp('=', literal(1))],
@@ -2188,9 +2166,8 @@ describe('Parser', () => {
         );
       });
 
-      // Single-sub-roll groups are the documented flat-pool escape hatch
-      // (STAGE3.md "Group Semantics: Single vs Multi Sub-Roll") and pass
-      // through to cs/cf as if they were the unwrapped form.
+      // Single-sub-roll groups are the flat-pool escape hatch — cs/cf sees them
+      // as the unwrapped form.
       it('should accept cs on a single-sub-roll group: {1d6}cs>5', () => {
         expect(parseAst('{1d6}cs>5')).toEqual(
           critThreshold([cp('>', literal(5))], [], group([dice(literal(1), literal(6))])),
@@ -2246,8 +2223,8 @@ describe('Parser', () => {
       });
 
       it('should reject cs on arithmetic-wrapped pool', () => {
-        // Mirrors explode/reroll — cs/cf is "bare dice only". `(1d6+2d8)` is
-        // an arithmetic wrapper, not a dice pool in the shallow sense.
+        // cs/cf is "bare dice only", like explode/reroll: `(1d6+2d8)` is an
+        // arithmetic wrapper, not a dice pool in the shallow sense.
         expectRollError(
           () => parseAst('(1d6+2d8)cs>5'),
           ParseError,
@@ -2298,9 +2275,8 @@ describe('Parser', () => {
       });
 
       it('should reject cs on a parens-wrapped modifier-wrapped multi-sub-roll group', () => {
-        // Acceptance criterion 5 from #97 — Grouped wrapper around the
-        // Modifier(Group([...])) chain still resolves to a Group via the
-        // shared unwrap.
+        // The shared unwrap peels both wrappers, so a `Grouped` around a
+        // `Modifier(Group([...]))` chain still resolves to a Group.
         expectRollError(
           () => parseAst('({1d20, 1d20}kh1)cs>18'),
           ParseError,
@@ -2308,8 +2284,9 @@ describe('Parser', () => {
         );
       });
 
-      // #109 — single-sub-roll passthrough must not smuggle a buried
-      // multi-sub Group through a wrapper `unwrapAllTransparent` doesn't peel.
+      // The single-sub-roll passthrough must not smuggle a buried multi-sub Group
+      // through a wrapper `unwrapAllTransparent` does not peel — otherwise the
+      // evaluator flags crits on dropped sub-roll dice again.
       it('should reject cs on nested multi-sub-roll group: {{1d20, 1d20}kh1}cs>18', () => {
         const error = expectRollError(
           () => parseAst('{{1d20, 1d20}kh1}cs>18'),
@@ -2377,9 +2354,8 @@ describe('Parser', () => {
       });
 
       it('should reject bare cf chained after custom cs on Fate pool', () => {
-        // `containsFatePool` recurses through `CritThreshold`, so the bare
-        // `cf` is caught even when the target is already a wrapping crit
-        // threshold node from a custom success threshold.
+        // `containsFatePool` recurses through `CritThreshold`, so the bare `cf`
+        // is caught even when its target is already a crit-threshold node.
         const error = expectRollError(
           () => parseAst('4dFcs>0cf'),
           ParseError,
@@ -2389,9 +2365,9 @@ describe('Parser', () => {
         expect(error.message).toContain('Fate');
       });
 
-      // #109 — single-sub-roll Group passthrough makes Fate reachable past
-      // the shallow `containsFatePool` check; `deepContainsFatePool` recurses
-      // through arithmetic, so the bare-Fate guard still fires.
+      // The single-sub-roll Group passthrough puts Fate behind arithmetic, where
+      // the shallow `containsFatePool` stops; its Group case delegates to
+      // `deepContainsFatePool` so the bare-Fate guard still fires.
       it('should reject bare cf on Fate inside arithmetic group: {4dF+1d6}cf', () => {
         const error = expectRollError(
           () => parseAst('{4dF+1d6}cf'),
@@ -2410,14 +2386,15 @@ describe('Parser', () => {
         expect(() => parseAst('{abs(4dF)}cf')).toThrow(ParseError);
       });
 
-      // #134 — both guards match `{1d20 vs 4dF}cf`; `rejectVersusTarget` runs
-      // first, so `deepContainsFatePool` never walks the Versus children here.
+      // Both guards match this notation; `rejectVersusTarget` runs first, so
+      // `deepContainsFatePool` never walks the Versus children — guard order,
+      // not Fate detection, decides the code.
       it('should report NESTED_VERSUS before the Fate guard: {1d20 vs 4dF}cf', () => {
         expectRollError(() => parseAst('{1d20 vs 4dF}cf'), ParseError, 'NESTED_VERSUS');
       });
 
-      // #109 — single-sub-roll Group passthrough also smuggles Versus past
-      // `rejectVersusTarget`'s shallow check at the cs/cf consumer site.
+      // The same passthrough smuggles a Versus past `rejectVersusTarget`'s
+      // shallow check at the cs/cf consumer site.
       it('should reject cs on Versus inside single-sub group: {1d20 vs 15}cs>18', () => {
         expectRollError(() => parseAst('{1d20 vs 15}cs>18'), ParseError, 'NESTED_VERSUS');
       });

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -93,6 +93,7 @@ export class ParseError extends RollParserError {
  *
  * Precedence order (lowest to highest):
  * - Versus (`vs`): 2-3 (lowest — full expressions on both sides)
+ * - Comparison (success-count LED): 8
  * - Addition/subtraction: 10
  * - Multiplication/division/modulo: 20
  * - Unary minus: 25 (binds to complete dice expr: -1d4 = -(1d4))
@@ -101,27 +102,24 @@ export class ParseError extends RollParserError {
  * - Dice: 40-41
  */
 const BP = {
-  // Versus (left-associative, lowest precedence — `1d20+10 vs 25+10` = `(1d20+10) vs (25+10)`)
+  // Lowest, so both sides take a full expression: `1d20+10 vs 25+10` =
+  // `(1d20+10) vs (25+10)`.
   VS_LEFT: 2,
   VS_RIGHT: 3,
-  // Comparison operators used as the success-count LED. Must be below
-  // ADD/MUL so `XdY+N>T` parses as `(XdY+N)>T` and fails the pool-target
-  // guard with a clear error, instead of the `>` stealing `N` from the `+`.
+  // Below ADD/MUL so `XdY+N>T` parses as `(XdY+N)>T` and fails the pool-target
+  // guard with a clear error, instead of `>` stealing `N` from the `+`.
   COMPARE: 8,
-  // Addition/subtraction (left-associative)
   ADD_LEFT: 10,
   ADD_RIGHT: 11,
-  // Multiplication/division/modulo (left-associative)
   MUL_LEFT: 20,
   MUL_RIGHT: 21,
-  // Unary minus: between mul and power so -1d4 = -(1d4) not (-1)d4
+  // Between MUL and POW so `-1d4` = `-(1d4)`, not `(-1)d4`.
   UNARY: 25,
-  // Power (right-associative: left > right)
   POW_LEFT: 31,
   POW_RIGHT: 30,
-  // Postfix modifiers: must be < DICE_RIGHT so they bind to complete dice expr
+  // Must stay below DICE_RIGHT so a postfix modifier binds to the whole dice
+  // expression: `4d6kh3` = `(4d6)kh3`.
   MODIFIER: 35,
-  // Dice operator (highest math precedence)
   DICE_LEFT: 40,
   DICE_RIGHT: 41,
 } as const;
@@ -222,7 +220,6 @@ export class Parser {
 
     const ast = this.parseExpression(0);
 
-    // Ensure we consumed all tokens
     if (this.peek().type !== TokenType.EOF) {
       const token = this.peek();
       throw new ParseError(
@@ -383,7 +380,9 @@ export class Parser {
     }
   }
 
+  //
   // * Node parsers
+  //
 
   /**
    * Zero-width span for synthetic nodes (implicit counts, `d%` sides) that
@@ -415,7 +414,6 @@ export class Parser {
   }
 
   private parsePrefixDice(token: Token): DiceNode {
-    // d20 → Dice(1, 20)
     const sides = this.parseExpression(BP.DICE_RIGHT);
     this.rejectSuccessCountTarget(sides, token);
     this.rejectVersusTarget(sides, token);
@@ -429,7 +427,6 @@ export class Parser {
   }
 
   private parseInfixDice(left: ASTNode, token: Token): DiceNode {
-    // 4d6 → Dice(4, 6)
     this.rejectSuccessCountTarget(left, token);
     this.rejectVersusTarget(left, token);
     this.rejectBareDiceChain(left, token);
@@ -446,7 +443,6 @@ export class Parser {
   }
 
   private parsePrefixDicePercent(token: Token): DiceNode {
-    // d% → Dice(1, 100)
     return {
       type: 'Dice',
       count: Parser.syntheticLiteral(1, token),
@@ -457,7 +453,6 @@ export class Parser {
   }
 
   private parseInfixDicePercent(left: ASTNode, token: Token): DiceNode {
-    // 2d% → Dice(2, 100)
     this.rejectSuccessCountTarget(left, token);
     this.rejectVersusTarget(left, token);
     this.rejectBareDiceChain(left, token);
@@ -471,7 +466,6 @@ export class Parser {
   }
 
   private parsePrefixFateDice(token: Token): FateDiceNode {
-    // dF → FateDice(1)
     return {
       type: 'FateDice',
       count: Parser.syntheticLiteral(1, token),
@@ -481,9 +475,8 @@ export class Parser {
   }
 
   private parseInfixFateDice(left: ASTNode, token: Token): FateDiceNode {
-    // 4dF → FateDice(4). Unlike parseInfixDice, there is no sides sub-parse,
-    // so modifiers (`kh`, `dl`, …) naturally bind at the outer Pratt loop
-    // without BP competition against a right-operand.
+    // No sides sub-parse, unlike `parseInfixDice`, so modifiers (`kh`, `dl`, …)
+    // bind at the outer Pratt loop with no BP competition from a right operand.
     this.rejectSuccessCountTarget(left, token);
     this.rejectVersusTarget(left, token);
     this.rejectBareDiceChain(left, token);
@@ -503,8 +496,8 @@ export class Parser {
 
   private parseGroup(startToken: Token): GroupNode {
     // `LBRACE`/`RBRACE`/`COMMA` all have `getLeftBp === -1`, so inner
-    // `parseExpression(0)` calls terminate at the first `,` or `}` without
-    // competing with modifier/arithmetic BPs.
+    // `parseExpression(0)` calls stop at the first `,` or `}` without competing
+    // with modifier/arithmetic BPs.
     if (this.peek().type === TokenType.RBRACE) {
       throw new ParseError('Empty group', 'UNEXPECTED_TOKEN', startToken.position, startToken);
     }
@@ -534,9 +527,8 @@ export class Parser {
   }
 
   private parseFunctionCall(token: Token): FunctionCallNode {
-    // `FUNCTION` has BP = -1 so callers stop here; `COMMA` and `RPAREN` also
-    // terminate inner `parseExpression(0)` calls, so argument boundaries are
-    // natural.
+    // `FUNCTION`, `COMMA`, and `RPAREN` all sit at BP -1, so argument boundaries
+    // fall out of the inner `parseExpression(0)` calls terminating on their own.
     this.expect(TokenType.LPAREN);
 
     const args: ASTNode[] = [];
@@ -556,9 +548,8 @@ export class Parser {
 
     const arity = FUNCTION_ARITY[token.value];
     if (arity == null) {
-      // ? Unreachable in practice: lexer only emits FUNCTION for registered
-      // names. Kept defensive to keep parser/evaluator error-code contract
-      // symmetrical.
+      // Unreachable: the lexer only emits `FUNCTION` for registered names. Kept
+      // so the parser/evaluator error-code contract stays symmetrical.
       throw new ParseError(
         `Unknown function '${token.value}'`,
         'UNKNOWN_FUNCTION',
@@ -634,10 +625,9 @@ export class Parser {
   }
 
   private rejectSuccessCountTarget(target: ASTNode, token: Token): void {
-    // Narrow unwrap: only `Grouped`. A `SuccessCount` cannot live inside
-    // `Modifier`/`Sort`/`CritThreshold` because each of those parsers calls
-    // this same reject on their target before constructing the wrapper —
-    // so widening the set here would never match.
+    // Narrow unwrap (only `Grouped`): `Modifier`/`Sort`/`CritThreshold` each run
+    // this same reject before building their wrapper, so a `SuccessCount` can
+    // never hide inside one and widening the set would never match.
     const node = unwrapGrouped(target);
     if (isSuccessCount(node)) {
       throw new ParseError(
@@ -657,8 +647,7 @@ export class Parser {
    * cannot smuggle a group past the check (`{1d6}kh1cs>5`, `({1d6})!`,
    * `{1d6}scs>5` all reject the same as `{1d6}!`/`{1d6}cs>5`).
    *
-   * `singleSubRollPasses` opts the caller into the Stage 3 single-sub-roll
-   * passthrough rule (STAGE3.md "Group Semantics: Single vs Multi Sub-Roll"):
+   * `singleSubRollPasses` opts the caller into the single-sub-roll passthrough:
    * a `Group` with one expression is the user's explicit flat-pool escape
    * hatch and is equivalent to its unwrapped form. Currently only
    * `parseCritThreshold` opts in — explode/reroll keep the strict reject so
@@ -675,10 +664,10 @@ export class Parser {
     if (node.type !== 'Group') return;
     if (singleSubRollPasses && node.expressions.length === 1) {
       // ! Deep-walk the inner sub-expression — `unwrapAllTransparent` only peels
-      //   `Grouped`/`Modifier`/`Sort`/`CritThreshold`, so a multi-sub Group
-      //   buried under arithmetic (`{{1d6,2d8}+0}cs>5`), function calls
-      //   (`{abs({1d6,2d8})}cs>5`), or unary ops would otherwise revive the
-      //   exact dropped-die-flag bug from #97.
+      // ! `Grouped`/`Modifier`/`Sort`/`CritThreshold`, so a multi-sub Group
+      // ! buried under arithmetic (`{{1d6,2d8}+0}cs>5`), a function call
+      // ! (`{abs({1d6,2d8})}cs>5`), or a unary op would reach the evaluator and
+      // ! override `critical`/`fumble` on dice from dropped sub-rolls.
       const inner = node.expressions[0];
       if (inner != null && containsMultiSubGroup(inner)) {
         throw new ParseError(`Cannot ${action} a group`, code, token.position, token);
@@ -689,14 +678,12 @@ export class Parser {
   }
 
   private rejectVersusTarget(target: ASTNode, token: Token): void {
-    // Versus produces a PF2e degree outcome — a terminal scalar, not a
-    // valid input to dice count/sides/thresholds. Symmetric with
-    // `rejectSuccessCountTarget`; wrappers like `floor(vs)+0` still
-    // propagate `versusMetadata` via `mergeContext`, so this only blocks
-    // `mergeMetaRolls` sites where metadata would silently vanish.
-    // Narrow unwrap: only `Grouped`. `Modifier`/`Sort`/`CritThreshold`
-    // cannot wrap a `Versus` because `containsDicePool` does not recurse
-    // into `Versus`, so each of those parsers rejects the wrap upstream.
+    // A Versus degree is a terminal scalar, never a valid dice count, sides, or
+    // threshold. Only the `mergeMetaRolls` sites need blocking, where
+    // `versusMetadata` would silently vanish; wrappers like `floor(vs)+0` still
+    // propagate it via `mergeContext`.
+    // Narrow unwrap (only `Grouped`): `containsDicePool` does not recurse into
+    // `Versus`, so `Modifier`/`Sort`/`CritThreshold` reject the wrap upstream.
     const node = unwrapGrouped(target);
     if (node.type === 'Versus') {
       throw new ParseError(
@@ -706,11 +693,11 @@ export class Parser {
         token,
       );
     }
-    // ! Single-sub-roll `Group` passthrough is the new sibling route —
-    //   `containsDicePool` recurses into Group's single sub-expression via
-    //   `deepContainsDicePool`, which traverses Versus's `roll`/`dc`. Deep
-    //   walk for any descendant Versus so `{1d20 vs 15}cs>18`,
-    //   `{1+(1d20 vs 15)}cs>18`, and `4d6>={abs(1d20 vs 15)}` reject too.
+    // ! `containsDicePool` recurses into a single-sub-roll Group via
+    // ! `deepContainsDicePool`, which traverses Versus's `roll`/`dc` — so that
+    // ! route gets a Versus past the shallow guards. Deep-walk for any descendant
+    // ! Versus, or `{1d20 vs 15}cs>18`, `{1+(1d20 vs 15)}cs>18`, and
+    // ! `4d6>={abs(1d20 vs 15)}` would parse while `(1d20 vs 15)cs>18` rejects.
     if (node.type === 'Group' && node.expressions.length === 1) {
       const inner = node.expressions[0];
       if (inner != null && containsVersus(inner)) {
@@ -726,17 +713,14 @@ export class Parser {
 
   private parseModifier(target: ASTNode, token: Token): ModifierNode {
     this.rejectSuccessCountTarget(target, token);
-    // ! Mirror `parseSort`/`parseCritThreshold` — keep/drop applied to a
-    //   Versus target silently drops `degree`/`natural` metadata. Pre-existing
-    //   for `(1d20 vs 15)kh1` (caught upstream by `containsDicePool` with a
-    //   different error code), but the single-sub-roll Group passthrough makes
-    //   `{1d20 vs 15}kh1` reachable past `containsDicePool` (Group's deep
-    //   walk recurses into Versus's roll/dc), so the explicit reject is the
-    //   only thing that closes the metadata-drop hole.
+    // ! Keep/drop on a Versus target silently drops `degree`/`natural` metadata,
+    // ! and `{1d20 vs 15}kh1` gets past `containsDicePool` — whose Group deep
+    // ! walk recurses into Versus's `roll`/`dc` — so this reject is the only
+    // ! thing closing that hole. Mirrors `parseSort`/`parseCritThreshold`.
     this.rejectVersusTarget(target, token);
 
-    // Keep/drop modifiers need a dice pool to select from. Wrapping arithmetic
-    // (e.g. `(1d6+5)kh1`, `4d6+2kh3`) would silently drop user math.
+    // Keep/drop needs a pool to select from; `(1d6+5)kh1` or `4d6+2kh3` would
+    // silently drop the user's arithmetic.
     if (!containsDicePool(target)) {
       throw new ParseError(
         `Keep/drop modifiers require a dice pool target`,
@@ -754,7 +738,6 @@ export class Parser {
         ? 'highest'
         : 'lowest';
 
-    // Default to 1 when no explicit count follows the modifier (e.g., 4d6kh → 4d6kh1)
     const nextToken = this.peek().type;
     const hasExplicitCount =
       nextToken === TokenType.NUMBER ||
@@ -780,13 +763,12 @@ export class Parser {
   private parseExplode(target: ASTNode, token: Token): ExplodeNode {
     this.rejectSuccessCountTarget(target, token);
 
-    // Groups have no explode semantics — reject outright. Must come before
-    // `containsDicePool`, which recurses into `Group` and would otherwise
-    // let `{4d6}!` slip through.
+    // Groups have no explode semantics. Must precede `containsDicePool`, which
+    // recurses into `Group` and would let `{4d6}!` slip through.
     this.rejectGroupTarget(target, token, 'explode', 'INVALID_EXPLODE_TARGET');
 
-    // Explode needs a dice pool to explode on. Wrapping arithmetic (e.g.
-    // `(1d6+5)!`, `floor(1d6/2)!`) would silently drop user math.
+    // Arithmetic wrappers like `(1d6+5)!` or `floor(1d6/2)!` would silently drop
+    // the user's math.
     if (!containsDicePool(target)) {
       throw new ParseError(
         `Explode modifier requires a dice pool target`,
@@ -796,9 +778,8 @@ export class Parser {
       );
     }
 
-    // Fate dice (sides = 0) cannot explode — the symmetric -1/0/+1 range has
-    // no natural "max" trigger, so semantics are undefined. Reject at parse
-    // time rather than silently no-op in the evaluator.
+    // Fate's symmetric -1/0/+1 range has no max face to trigger on, so exploding
+    // it has no defined semantics — reject here rather than no-op in the evaluator.
     if (containsFatePool(target)) {
       throw new ParseError(
         `Fate dice cannot explode`,
@@ -808,8 +789,7 @@ export class Parser {
       );
     }
 
-    // Reject nested explodes (e.g., `1d6!!!`) — a second explode token atop
-    // an ExplodeNode has no meaningful semantics and is rejected per spec.
+    // A second explode token atop an `Explode` (`1d6!!!`) has no semantics.
     if (target.type === 'Explode') {
       throw new ParseError(
         `Cannot chain explode modifiers`,
@@ -819,8 +799,8 @@ export class Parser {
       );
     }
 
-    // ? `parseLed` dispatches here only for the three explode tokens, so the
-    //   lookup always hits; the fallback keeps the type non-optional.
+    // `parseLed` reaches here only for the three explode tokens, so the lookup
+    // always hits; the fallback exists to keep the type non-optional.
     const variant: ExplodeNode['variant'] = EXPLODE_VARIANTS[token.type] ?? 'penetrating';
 
     const start = target.start ?? token.position;
@@ -843,12 +823,12 @@ export class Parser {
   private parseReroll(target: ASTNode, token: Token): RerollNode {
     this.rejectSuccessCountTarget(target, token);
 
-    // Groups have no reroll semantics — reject outright. Must come before
-    // `containsDicePool`, which recurses into `Group`.
+    // Groups have no reroll semantics. Must precede `containsDicePool`, which
+    // recurses into `Group`.
     this.rejectGroupTarget(target, token, 'reroll', 'INVALID_REROLL_TARGET');
 
-    // Reroll needs a dice pool to inspect. Wrapping arithmetic (e.g.
-    // `(1d6+5)r<3`, `floor(1d6/2)ro<3`) would silently drop user math.
+    // Arithmetic wrappers like `(1d6+5)r<3` or `floor(1d6/2)ro<3` would silently
+    // drop the user's math.
     if (!containsDicePool(target)) {
       throw new ParseError(
         `Reroll modifier requires a dice pool target`,
@@ -858,7 +838,6 @@ export class Parser {
       );
     }
 
-    // A reroll token must be followed by a comparison — bare `r` / `ro` is invalid.
     if (!this.isComparePointAhead()) {
       throw new ParseError(
         `Expected comparison operator after '${token.value}'`,
@@ -885,10 +864,9 @@ export class Parser {
     this.rejectSuccessCountTarget(target, token);
     this.rejectVersusTarget(target, token);
 
-    // Sort is purely visual but still needs a dice pool to reorder —
-    // `5s`, `(1+2)s`, or `floor(5)s` have no dice to touch. Uses the deep
-    // guard so arithmetic-wrapped pools like `(1d6+2d8)s` are accepted per
-    // Stage 3 spec, while pure literals/arithmetic reject.
+    // Deep guard, unlike explode/reroll: arithmetic-wrapped pools like
+    // `(1d6+2d8)s` are sortable, while `5s`, `(1+2)s`, and `floor(5)s` have no
+    // dice to reorder.
     if (!deepContainsDicePool(target)) {
       throw new ParseError(
         `Sort modifier requires a dice pool target`,
@@ -898,14 +876,11 @@ export class Parser {
       );
     }
 
-    // ! Multi-sub-roll groups (`{a, b}s`, `({a, b})s`) need hierarchical
-    //   sort per Stage 3 spec §3 (sort dice within each sub-roll, then sort
-    //   sub-rolls by total) — `evalSort` only flat-sorts, so accepting the
-    //   syntax would silently ship non-spec behaviour. Single-sub Groups keep
-    //   passing through (the unwrap returns a `Group` with one expression,
-    //   which is the user's flat-pool escape hatch).
-    // TODO: Implement hierarchical multi-sub-roll group sort, then drop this
-    //   reject.
+    // ! Multi-sub-roll groups (`{a, b}s`, `({a, b})s`) require hierarchical sort —
+    // ! dice within each sub-roll, then sub-rolls by total — but `evalSort` only
+    // ! flat-sorts, so accepting the syntax would silently ship wrong output.
+    // ! Single-sub Groups still pass; that is the flat-pool escape hatch.
+    // TODO: Implement hierarchical group sort, then drop this reject.
     const base = unwrapAllTransparent(target);
     if (base.type === 'Group' && base.expressions.length >= 2) {
       throw new ParseError(
@@ -918,9 +893,8 @@ export class Parser {
 
     const order: SortNode['order'] = token.type === TokenType.SORT_ASC ? 'ascending' : 'descending';
 
-    // Chained sorts (`4d6ss`, `4d6sasd`) are allowed — sort is idempotent
-    // when repeated in the same direction; a later `sd` after `s` just
-    // overrides the order since both pass over the same pool.
+    // Chained sorts (`4d6ss`, `4d6sasd`) are deliberately allowed: repeats are
+    // idempotent and a later `sd` just overrides the order.
     return {
       type: 'Sort',
       order,
@@ -934,12 +908,11 @@ export class Parser {
     this.rejectSuccessCountTarget(target, token);
     this.rejectVersusTarget(target, token);
 
-    // Multi-sub-roll groups have no crit-threshold semantics per Stage 3 spec
-    // — a group there is a container of sub-roll subtotals, not a dice pool,
-    // and applying cs/cf would override `critical`/`fumble` on dropped
-    // sub-roll dice. Single-sub-roll groups pass through under the documented
-    // flat-pool rule (`{1d20}kh1cs>18` ≡ `(1d20)kh1cs>18`). Must run before
-    // `containsDicePool`, which recurses into `Group`.
+    // A multi-sub-roll group is a container of sub-roll subtotals, not a pool:
+    // `cs`/`cf` there would override `critical`/`fumble` on dropped sub-roll
+    // dice. Single-sub-roll groups pass through as the flat-pool form
+    // (`{1d20}kh1cs>18` ≡ `(1d20)kh1cs>18`). Must run before `containsDicePool`,
+    // which recurses into `Group`.
     this.rejectGroupTarget(
       target,
       token,
@@ -948,10 +921,9 @@ export class Parser {
       true,
     );
 
-    // Shallow dice-pool check (bare dice only) — rejects `(1d6+2d8)cs>5`,
-    // `5cs`, `(1+2)cs`, `floor(5)cs`. Matches explode/reroll behavior.
-    // Note: if `target` already is a `CritThresholdNode`, `containsDicePool`
-    // recurses into its `target`, so chained `cs`/`cf` naturally pass.
+    // Shallow check like explode/reroll: `(1d6+2d8)cs>5`, `5cs`, `(1+2)cs`, and
+    // `floor(5)cs` reject. Chained `cs`/`cf` still pass, since `containsDicePool`
+    // recurses into a `CritThreshold`'s own target.
     if (!containsDicePool(target)) {
       throw new ParseError(
         `Crit threshold modifier requires a dice pool target`,
@@ -961,11 +933,9 @@ export class Parser {
       );
     }
 
-    // Bare `cs`/`cf` resolve to a per-die default that assumes max-side / 1
-    // semantics — incompatible with Fate dice (`{-1, 0, +1}`), where the bare
-    // fumble check would flip the best face (`+1`) into a fumble. Custom
-    // thresholds with explicit ComparePoints remain accepted. Mirrors the
-    // Fate-explosion rejection above.
+    // The bare `cs`/`cf` per-die default assumes max-side/1 semantics, which on
+    // Fate's `{-1, 0, +1}` would flag the best face (`+1`) as a fumble. Explicit
+    // ComparePoints stay accepted. Mirrors the Fate-explosion reject above.
     if (!this.isComparePointAhead() && containsFatePool(target)) {
       throw new ParseError(
         `Bare cs/cf cannot apply to Fate dice`,
@@ -980,18 +950,16 @@ export class Parser {
       : 'default';
     const end = threshold === 'default' ? token.end : (threshold.value.end ?? token.end);
 
-    // Unwrap parens so `(1d20cs>19)cs=1` chains into the inner node. Without
-    // unwrapping, the outer `cs` would create a second CritThresholdNode
-    // wrapping the Grouped — the collapse-into-single-node design decision
-    // from STAGE3.md §"CritThreshold Collects Multiple Thresholds" would
-    // be subtly broken for any user who parenthesizes the chain.
+    // Unwrap parens so `(1d20cs>19)cs=1` collapses into the inner node instead of
+    // nesting a second `CritThreshold` around the `Grouped` — every threshold in
+    // a chain must collect on one node, which parenthesizing would break.
     let chainTarget: ASTNode = target;
     while (chainTarget.type === 'Grouped') {
       chainTarget = chainTarget.expression;
     }
     if (isCritThreshold(chainTarget)) {
-      // Rebuilt rather than mutated — `NodeSpan` is readonly, and the
-      // discarded `Grouped` wrapper must not keep a stale `end`.
+      // Rebuilt, not mutated: `NodeSpan` is readonly, and the discarded `Grouped`
+      // wrapper must not leave a stale `end`.
       const isSuccess = token.type === TokenType.CRIT_SUCCESS;
       return {
         ...chainTarget,
@@ -1019,9 +987,9 @@ export class Parser {
     // Success counting is terminal: chaining (`>=5>=3`) has no semantics.
     this.rejectSuccessCountTarget(target, token);
 
-    // Reject non-pool targets like `1>=3`, `(1+2)>=3`, `(1d6*2)>=10`, or
-    // `(1d20 vs 15)>=1`. Success counting operates on a raw dice pool; any
-    // arithmetic or composition wrapping would be silently ignored.
+    // Success counting reads a raw pool, so arithmetic or composition wrappers
+    // (`1>=3`, `(1+2)>=3`, `(1d6*2)>=10`, `(1d20 vs 15)>=1`) would be silently
+    // ignored.
     if (!containsDicePool(target)) {
       throw new ParseError(
         `Success counting requires a dice pool target`,
@@ -1032,7 +1000,7 @@ export class Parser {
     }
 
     const operator = this.getCompareOp(token);
-    // Threshold binding: `BP.DICE_LEFT` — see `parseComparePoint` JSDoc.
+    // Threshold binds at `BP.DICE_LEFT` — see `parseComparePoint` TSDoc.
     const value = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(value, token);
     this.rejectVersusTarget(value, token);
@@ -1071,10 +1039,10 @@ export class Parser {
   private parseVersus(left: ASTNode, token: Token): VersusNode {
     this.rejectSuccessCountTarget(left, token);
 
-    // Chained `a vs b vs c` has no semantics — a degree is a scalar, not a
-    // comparable. Unwrap `Grouped` so `(a vs b) vs c` rejects at parse
-    // time like the bare form; paren-nested DC (`a vs (b vs c)`) is still
-    // caught by the evaluator via `mergeContext`.
+    // A degree is a scalar, not a comparable, so `a vs b vs c` has no semantics.
+    // Unwrapping `Grouped` makes `(a vs b) vs c` reject here like the bare form;
+    // a paren-nested DC (`a vs (b vs c)`) is caught later by the evaluator's
+    // `mergeContext`.
     let leftChain: ASTNode = left;
     while (leftChain.type === 'Grouped') {
       leftChain = leftChain.expression;
@@ -1095,7 +1063,9 @@ export class Parser {
     };
   }
 
+  //
   // * Compare point utilities
+  //
 
   /**
    * Checks whether the next token is a comparison operator.
@@ -1160,7 +1130,9 @@ export class Parser {
     }
   }
 
+  //
   // * Helpers
+  //
 
   private getOperatorSymbol(token: Token): '+' | '-' | '*' | '/' | '%' | '**' {
     switch (token.type) {
@@ -1217,12 +1189,9 @@ export class Parser {
       case TokenType.CRIT_SUCCESS:
       case TokenType.CRIT_FAIL:
         return BP.MODIFIER;
-      // Comparison operators act as LED-dispatched success-count modifiers
-      // at the Pratt level. Sit below ADD/MUL so arithmetic on a dice pool
-      // completes before success counting wraps it — `5d6+2>4` parses as
-      // `(5d6+2)>4` and then cleanly fails the pool-target guard, rather
-      // than the `>` stealing `2` from the `+`. Inside `parseComparePoint`
-      // (called manually by explode/reroll) this BP is bypassed.
+      // Comparison operators act as LED-dispatched success-count modifiers here;
+      // `parseComparePoint`, called manually by explode/reroll, bypasses this BP.
+      // See `BP.COMPARE` for why it sits below ADD/MUL.
       case TokenType.GREATER:
       case TokenType.GREATER_EQUAL:
       case TokenType.LESS:
@@ -1231,12 +1200,10 @@ export class Parser {
         return BP.COMPARE;
       case TokenType.RPAREN:
       case TokenType.EOF:
-      // Punctuation and keywords that terminate expressions
       case TokenType.COMMA:
       case TokenType.FUNCTION:
-      // Group boundaries: `}` closes the current group (consumed inside
-      // `parseGroup`), and a stray `{` after a complete expression is an
-      // error. Both terminate the outer Pratt loop at -1.
+      // `}` is consumed inside `parseGroup`, and a stray `{` after a complete
+      // expression is an error — both must terminate the outer Pratt loop.
       case TokenType.LBRACE:
       case TokenType.RBRACE:
         return -1;

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -85,9 +85,8 @@ describe('property-based invariants', () => {
       );
     });
 
-    // `0dX` and `Nd1` are removed: both are the `[N, N*X]` bound above with
-    // the interval collapsed to a point, and `evaluator.test.ts` already
-    // pins the degenerate pools exactly.
+    // `0dX` and `Nd1` belong in `evaluator.test.ts`: both collapse the
+    // `[N, N*X]` bound above to a point, and their pools are pinned there.
   });
 
   describe('modifier invariants', () => {
@@ -213,11 +212,9 @@ describe('property-based invariants', () => {
   });
 
   describe('arithmetic invariants', () => {
-    // Commutativity of `+`/`*` and the `+0`/`*1` identities are removed:
-    // over literal operands they restate IEEE-754 arithmetic, not this
-    // library's behavior. What they did incidentally exercise — signed
-    // literals in either operand position — is pinned exactly by
-    // `signed literal operands` in `parser.test.ts`.
+    // `+`/`*` commutativity and the `+0`/`*1` identities are out of scope: over
+    // literal operands they restate IEEE-754, not this library. Signed literals
+    // in either operand position are pinned in `parser.test.ts`.
     test('unary minus equivalent to subtraction from zero', () => {
       fc.assert(
         fc.property(
@@ -238,9 +235,8 @@ describe('property-based invariants', () => {
 
   describe('expression round-trip', () => {
     test('reparsing result.expression yields the same total on a replayed seed', () => {
-      // Shapes exercise BinaryOp, UnaryOp, dice count/sides, and function
-      // call argument sites, with randomly injected parentheses around any
-      // subexpression.
+      // Shapes cover BinaryOp, UnaryOp, dice count/sides, and call-argument
+      // sites, each with parentheses somewhere in the tree.
       const shapes = [
         '({L})*{C}d{S}',
         '{C}d{S} + ({L}*{L})',
@@ -261,8 +257,8 @@ describe('property-based invariants', () => {
           fc.integer({ min: 1, max: 6 }),
           seedArb,
           (shapeIdx, count, sides, lit, seed) => {
-            // `kh{L}` needs a selector < count; clamp to keep the notation
-            // legal across all shape generators.
+            // The last shape reuses `{L}` as its `kh` selector, so bound it by
+            // the dice count instead of letting it degenerate to keep-all.
             const keep = Math.min(lit, count);
             const notation = (shapes[shapeIdx] ?? '')
               .replaceAll('{C}', String(count))
@@ -367,9 +363,8 @@ describe('property-based invariants', () => {
       );
     });
 
-    // Non-negativity of a chained keep/drop total is removed: every die
-    // face is >= 1 and the modifiers only ever remove dice, so the sum of a
-    // kept subset cannot be negative regardless of what the evaluator does.
+    // No property pins non-negativity of a chained keep/drop total: faces are
+    // >= 1 and the modifiers only remove dice, so a kept subset cannot sum < 0.
     test('chained modifier order does not affect total (commutativity)', () => {
       fc.assert(
         fc.property(
@@ -391,10 +386,8 @@ describe('property-based invariants', () => {
       );
     });
 
-    // Pool length under chained keep/drop is removed: `rolls array length
-    // matches dice count` above already states it, and keep/drop provably
-    // never adds or removes entries — it only sets the `dropped` flag, which
-    // `chained kh+dl total <= single kh total` covers.
+    // Pool length under chained keep/drop needs no property: keep/drop only
+    // sets the `dropped` flag, it never adds or removes pool entries.
   });
 
   describe('seeded reproducibility', () => {
@@ -432,7 +425,6 @@ describe('property-based invariants', () => {
           seedArb,
           (count, sides, seed) => {
             const result = roll(`${count}d${sides}!`, { seed });
-            // Minimum: every original die rolled 1 → total >= count.
             return result.total >= count && result.rolls.length >= count;
           },
         ),
@@ -501,8 +493,7 @@ describe('property-based invariants', () => {
           (seed, count, sides) => {
             const base = roll(`${count}d${sides}`, { seed });
             const exploded = roll(`${count}d${sides}!`, { seed });
-            // Both runs roll the same first N dice from the seeded RNG, then
-            // `!` potentially adds more. So exploded.total >= base.total.
+            // Same seed → both runs draw the same first N dice; `!` only appends.
             return exploded.total >= base.total;
           },
         ),
@@ -547,8 +538,7 @@ describe('property-based invariants', () => {
     });
 
     test('rerolled intermediate dice are always marked rerolled+dropped', () => {
-      // Use `ro` so the chain always terminates — the invariant is about
-      // modifier flags, not termination behavior.
+      // `ro` guarantees termination — the invariant here is flags, not termination.
       fc.assert(
         fc.property(
           seedArb,
@@ -565,8 +555,8 @@ describe('property-based invariants', () => {
     });
 
     test('seeded reroll is reproducible', () => {
-      // Constrain to cases where recursive reroll terminates: threshold
-      // must be strictly less than `sides` so some results exceed it.
+      // Recursive reroll only terminates while the threshold stays below
+      // `sides`, so some results can exceed it.
       fc.assert(
         fc.property(
           seedArb,
@@ -585,10 +575,8 @@ describe('property-based invariants', () => {
   });
 
   describe('math functions', () => {
-    // Wrapping an expression in a math function does not change what it draws
-    // from the RNG, so a same-seed pair of rolls shares its dice exactly. That
-    // makes the unwrapped roll an exact oracle for the wrapped one, rather than
-    // the one-sided bound an inequality would give.
+    // A math wrapper draws nothing extra from the RNG, so a same-seed pair shares
+    // its dice exactly — the unwrapped roll is an exact oracle, not just a bound.
     test('floor(NdX/Y) equals Math.floor of the same seeded NdX/Y', () => {
       fc.assert(
         fc.property(
@@ -655,9 +643,8 @@ describe('property-based invariants', () => {
             const maxDice = maxed.rolls.map((die) => die.result);
             const minDice = minned.rolls.map((die) => die.result);
 
-            // Dice must match pairwise across the two calls — a wrapper that
-            // draws extra values or swaps argument order diverges here even if
-            // it still reports the extrema of whatever it rolled.
+            // Dice must match pairwise: a wrapper that draws extra values or
+            // swaps argument order still reports extrema, but diverges here.
             return (
               maxDice.length === 2 &&
               minDice.length === 2 &&
@@ -865,9 +852,8 @@ describe('property-based invariants', () => {
       }
     }
 
-    // Strings over the notation alphabet reach far deeper lexer/parser states
-    // than arbitrary Unicode: near-valid modifiers, dangling comparators,
-    // unbalanced groups, huge digit runs.
+    // The notation alphabet reaches far deeper lexer/parser states than arbitrary
+    // Unicode: near-valid modifiers, dangling comparators, unbalanced groups.
     const notationChars = fc.constantFrom(...'0123456789dDkKhHlLfFsSrRoOcCpP!<>=%+-*/(){},@ .');
 
     test('roll() on notation-alphabet strings never escapes the typed-error contract', () => {

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -227,7 +227,7 @@ beforeAll(async () => {
   await ensureFreshDist();
 
   // ! Keep the specifier computed — a literal 'roll-parser' fails `tsc --noEmit`
-  // on a fresh clone, where `dist/` (the self-reference target) does not exist yet.
+  // ! on a fresh clone, where `dist/` (the self-reference target) does not exist yet.
   const packageName = 'roll-parser';
   const api = (await import(packageName)) as Record<string, unknown>;
   const testing = (await import(`${packageName}/testing`)) as Record<string, unknown>;

--- a/src/rng/rng.test.ts
+++ b/src/rng/rng.test.ts
@@ -68,7 +68,6 @@ describe('SeededRNG', () => {
       const rng1 = new SeededRNG(-12345);
       const rng2 = new SeededRNG(-12345);
 
-      // Should produce consistent results
       for (let i = 0; i < 10; i++) {
         expect(rng1.nextInt(1, 100)).toBe(rng2.nextInt(1, 100));
       }
@@ -117,7 +116,6 @@ describe('SeededRNG', () => {
       const rng1 = new SeededRNG('seed');
       const rng2 = new SeededRNG('seed1');
 
-      // At least one of the first 10 values should differ
       let allSame = true;
       for (let i = 0; i < 10; i++) {
         if (rng1.nextInt(1, 100) !== rng2.nextInt(1, 100)) {
@@ -318,7 +316,6 @@ describe('SeededRNG', () => {
     it('should handle single value range (min === max)', () => {
       const rng = new SeededRNG(42);
 
-      // Multiple calls should always return the same value
       expect(rng.nextInt(7, 7)).toBe(7);
       expect(rng.nextInt(0, 0)).toBe(0);
       expect(rng.nextInt(-5, -5)).toBe(-5);
@@ -354,7 +351,7 @@ describe('SeededRNG', () => {
       }
 
       const expected = iterations / 6;
-      const tolerance = expected * 0.05; // 5% tolerance
+      const tolerance = expected * 0.05;
 
       for (let i = 1; i <= 6; i++) {
         expect(counts[i]).toBeGreaterThan(expected - tolerance);
@@ -374,7 +371,7 @@ describe('SeededRNG', () => {
       }
 
       const expected = iterations / 20;
-      const tolerance = expected * 0.1; // 10% tolerance for smaller sample per bucket
+      const tolerance = expected * 0.1; // Looser than d6 — fewer samples per bucket.
 
       for (let i = 1; i <= 20; i++) {
         expect(counts[i]).toBeGreaterThan(expected - tolerance);
@@ -410,7 +407,6 @@ describe('SeededRNG', () => {
       const rng1 = new SeededRNG('consistency-test');
       const rng2 = new SeededRNG('consistency-test');
 
-      // Generate 1000 values and verify they match
       for (let i = 0; i < 1000; i++) {
         expect(rng1.nextInt(1, 1000)).toBe(rng2.nextInt(1, 1000));
       }
@@ -420,15 +416,12 @@ describe('SeededRNG', () => {
       const rng1 = new SeededRNG(42);
       const rng2 = new SeededRNG(42);
 
-      // Consume one value from rng1
       rng1.nextInt(1, 6);
 
-      // Now they should be out of sync
       const seq1 = Array.from({ length: 5 }, () => rng1.nextInt(1, 6));
       const seq2 = Array.from({ length: 5 }, () => rng2.nextInt(1, 6));
 
-      // First value of seq2 should match what rng1 got initially
-      // But the arrays as a whole should differ
+      // Same seed, offset by one draw — the streams overlap but the windows differ.
       expect(seq1).not.toEqual(seq2);
     });
   });
@@ -648,8 +641,7 @@ describe.each(IMPLEMENTATIONS)('RNG conformance — $name', (impl: RngImplementa
   });
 
   it('handles inverted bounds per its documented contract', () => {
-    // ? The two implementations deliberately diverge here; the shared block
-    //   asserts each side of the divergence rather than papering over it.
+    // The divergence is deliberate — assert each side, do not paper over it.
     const rng = impl.create([3]);
 
     if (impl.invertedBounds === 'throw') {
@@ -663,28 +655,25 @@ describe.each(IMPLEMENTATIONS)('RNG conformance — $name', (impl: RngImplementa
 });
 
 describe('SeededRNG golden sequences', () => {
-  // ! Committed output of the shipped algorithm, not a self-comparison. A
-  // ! failure here means the seed → sequence mapping changed, which breaks
-  // ! the README's within-version reproducibility promise even if the new
-  // ! sequence is internally consistent. That is a breaking change: revert,
-  // ! or regenerate deliberately as part of a major release.
+  // ! Committed output of the shipped algorithm, not a self-comparison. A failure
+  // ! means the seed → sequence mapping changed, which breaks the README's
+  // ! within-version reproducibility promise even if the new sequence is
+  // ! internally consistent — revert, or regenerate as part of a major release.
   //
-  // Each field draws from a fresh instance: `d6` exercises the single-draw
-  // rejection path, `wide` the two-draw path above 2^32, `safe` the widest
-  // exactly-representable range, and `next()` the raw float derivation.
+  // Every field draws from a fresh instance, so the vectors are independent.
+  // `safe` is the widest exactly-representable range; `next` pins the raw float
+  // derivation rather than any bounded path.
   //
-  // `d6` only ever reaches that path's accept-on-first-draw case — 2^32 % 6 = 4,
-  // so it resamples with probability ~9.3e-10. `reject` draws from range 2^31 + 1
-  // instead, where the single acceptance zone rejects ~50% of draws, so every
-  // committed vector below crosses the resample loop at least once.
+  // `d6` never crosses the single-draw resample loop — 2^32 % 6 = 4, so it resamples
+  // with probability ~9.3e-10. `reject` uses range 2^31 + 1 instead, where ~50% of
+  // draws reject, so every vector below crosses that loop at least once.
   //
-  // The two-draw path has its own resample loop, and neither `wide` nor `safe`
-  // can reach it: at range 2^40 the limit lands on exactly 2^53 while a composed
-  // value tops out at 2^53 - 1, and at range 2^53 - 1 only that single value is
-  // rejected. `wideReject` draws from range 2^52 + 1, where the limit is 2^52 + 1
-  // and half of all composed values reject. Accepted values there are below the
-  // range, so `value % range` is the identity — these vectors pin the composed
-  // 53-bit value itself, shift and floor included.
+  // Neither `wide` (2^40) nor `safe` (2^53 - 1) can cross the two-draw resample loop:
+  // at 2^40 the limit lands on exactly 2^53 while a composed value tops out at
+  // 2^53 - 1, and at 2^53 - 1 only that single value is rejected. `wideReject` uses
+  // range 2^52 + 1, where half of all composed values reject; accepted values sit
+  // below the range, so `value % range` is the identity — those vectors pin the
+  // composed 53-bit value itself, shift and floor included.
   type GoldenVector = {
     seed: string | number;
     d6: number[];

--- a/src/rng/seeded.ts
+++ b/src/rng/seeded.ts
@@ -76,7 +76,6 @@ export class SeededRNG implements RNG {
   private s3: number;
 
   constructor(seed?: string | number) {
-    // Initialize state to zero, will be set by initState
     this.s0 = 0;
     this.s1 = 0;
     this.s2 = 0;
@@ -84,7 +83,6 @@ export class SeededRNG implements RNG {
 
     this.initState(seed);
 
-    // Warm-up: discard the first draws for better initial distribution
     for (let i = 0; i < WARMUP_DRAWS; i++) {
       this.nextUint32();
     }
@@ -93,7 +91,7 @@ export class SeededRNG implements RNG {
   private initState(seed?: string | number): void {
     const numSeed = this.toNumericSeed(seed);
 
-    // Split seed into 4 state values using splitmix32
+    // splitmix32 expansion into four state words.
     let s = numSeed;
     const state: number[] = [];
 
@@ -110,7 +108,7 @@ export class SeededRNG implements RNG {
     this.s2 = state[2] ?? 0;
     this.s3 = state[3] ?? 0;
 
-    // Ensure non-zero state (xorshift requires at least one non-zero)
+    // All-zero is a fixed point for xorshift — at least one word must be non-zero.
     if (this.s0 === 0 && this.s1 === 0 && this.s2 === 0 && this.s3 === 0) {
       this.s0 = 1;
     }
@@ -124,7 +122,7 @@ export class SeededRNG implements RNG {
   }
 
   private hashString(str: string): number {
-    // djb2 hash algorithm
+    // djb2 — `hash * 33 + c`, held in uint32 by the `>>> 0`.
     let hash = DJB2_SEED;
     for (let i = 0; i < str.length; i++) {
       hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
@@ -133,7 +131,7 @@ export class SeededRNG implements RNG {
   }
 
   private nextUint32(): number {
-    // xorshift128 algorithm
+    // xorshift128 — the 11/8/19 shift triple is part of the algorithm, not a tunable.
     let t = this.s3;
     const s = this.s0;
 
@@ -157,7 +155,6 @@ export class SeededRNG implements RNG {
    * @returns A float in `[0, 1)`
    */
   next(): number {
-    // Convert uint32 to [0, 1) float
     return this.nextUint32() / UINT32_SPACE;
   }
 
@@ -190,13 +187,11 @@ export class SeededRNG implements RNG {
    * ```
    */
   nextInt(min: number, max: number): number {
-    // Handle inverted bounds
     const lo = min > max ? max : min;
     const hi = min > max ? min : max;
 
     const range = hi - lo + 1;
 
-    // Single value case
     if (range <= 1) {
       return lo;
     }
@@ -207,8 +202,8 @@ export class SeededRNG implements RNG {
       return lo + this.nextBoundedWide(range);
     }
 
-    // Rejection sampling for unbiased distribution
-    // Avoids modulo bias by rejecting values that would cause uneven distribution
+    // Rejection sampling: discard the leading `[0, threshold)` values so the
+    // accepted zone `[threshold, 2^32)` is an exact multiple of `range`.
     const threshold = (UINT32_SPACE - range) % range;
     let value: number;
     do {
@@ -229,8 +224,7 @@ export class SeededRNG implements RNG {
       throw new RangeError(`nextInt range ${range} exceeds 2^53 and cannot be sampled exactly`);
     }
 
-    // Largest multiple of `range` below 2^53 — values at or above it are
-    // rejected to avoid modulo bias.
+    // Largest multiple of `range` below 2^53 — values at or above it would bias the modulo.
     const limit = Math.floor(MAX_EXACT_INT / range) * range;
     let value: number;
     do {

--- a/src/roll.ts
+++ b/src/roll.ts
@@ -80,8 +80,7 @@ export type RollOptions = EvaluationLimits & {
  * @category Core
  */
 export function roll(notation: string, options: RollOptions = {}): RollResult {
-  // `limits` is exactly `EvaluationLimits`, so it forwards wholesale — an
-  // explicitly-undefined key is harmless, `evaluate` nullish-checks each one.
+  // Explicitly-undefined limit keys forward harmlessly — `evaluate` nullish-checks each.
   const { rng, seed, ...limits } = options;
 
   return evaluate(parse(notation), rng ?? new SeededRNG(seed), { ...limits, notation });


### PR DESCRIPTION
Audited all ~1,100 inline `//` comments across 40 files. Comment text only — the sole
non-comment edits are tuple element labels in `parts.test.ts` and two TSDoc corrections.

- Removed comments restating adjacent code, test step-narration, and multi-paragraph design stories
- Compacted surviving constraints — precedence rationale, guard invariants, RNG derivations — to one or two lines
- Replaced every issue-number citation in a comment with the constraint it stood for, so no comment needs external context to be read
- Dropped three dead `STAGE3.md` pointers; that file has never existed in the repo
- Demoted `// ?` on settled decisions to plain comments and fixed `// *` divider shape
- Added the missing `COMPARE: 8` row to the `BP` precedence table in `parser.ts`
- Corrected `seeded.ts` rejection sampling — the loop rejects the leading block, not a trailing one
- Documented the continuation-line rule in `.claude/rules/comments.md` and repeated `// !` / `// ?` on every line of a block

`bun validate` passes: 1348 pass, 2 skip, 0 fail.

Closes #195
