### PR TITLE
chore: add issue and PR templates #162

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: A notation parses or rolls wrong, errors unexpectedly, or the CLI misbehaves
+title: 'fix: '
+labels: ['bug']
+body:
+  - type: textarea
+    id: input
+    attributes:
+      label: Notation / input
+      description: The dice notation or CLI invocation that triggers the problem.
+      placeholder: 4d6kh3 + 2
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens instead — include the error message or wrong result verbatim.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: From `npm ls roll-parser` or `roll-parser --version`.
+      placeholder: 3.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: Where does the problem show up?
+      options:
+        - Library
+        - CLI
+        - Both
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing — e.g. how other dice rollers treat this notation.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/edloidas/roll-parser/security/advisories/new
+    about: Report privately via a security advisory — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,19 @@
+name: Feature request
+description: New notation, API, or CLI capability
+title: 'feat: '
+labels: ['feature']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should roll-parser do? Include example notation if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Why is this worth adding?
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!-- Concise, factual summary of the changes — what and why. No emojis. -->
+
+<!-- Optional detail: **bold** group headers over bullet lists, past tense,
+     one line per change, backticks around code references. -->
+
+<!-- Keep every related issue on the one `Closes` line below. Run
+     `bun validate` before opening; a PR should be a single commit
+     when it merges. -->
+
+Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 Thanks for helping out. Bug reports, notation gaps, and pull requests are all
 welcome — open an [issue](https://github.com/edloidas/roll-parser/issues) first
-for anything larger than a fix.
+for anything larger than a fix; the bug and feature forms collect what a report
+needs.
 
 ## Toolchain
 
@@ -67,7 +68,8 @@ references. Add a `Changelog: skip` trailer to keep a commit out of the release
 notes.
 
 A pull request should be a single commit when it merges — squash locally and
-force-push rather than merging a chain of fixups.
+force-push rather than merging a chain of fixups. The pull request template
+prefills the expected body shape.
 
 ## Site and API reference
 


### PR DESCRIPTION
Adds GitHub issue forms and a pull request template, and cross-links them from `CONTRIBUTING.md`.

**Templates**

- Added `bug.yml` issue form: notation/input, expected vs. actual behavior, and version are required; surface dropdown and additional context are optional; prefills a `fix: ` title and applies the `bug` label
- Added `feature.yml` issue form: required description and rationale textareas; prefills a `feat: ` title and applies the `feature` label
- Added `config.yml`: blank issues stay enabled, and the chooser links private security advisory reporting
- Added `PULL_REQUEST_TEMPLATE.md` as a comment-guided skeleton matching the documented PR body format

**Scope**

- `CODE_OF_CONDUCT.md` from the original issue scope is deliberately omitted — direct moderation is preferred over a policy document (noted on the issue)

Closes #162
