### PR TITLE
feat: add RNG state export and restore #203

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,55 @@ produce the same dice. The generator is not cryptographically secure, and its
 output may change between major versions — persist the `RollResult`, not the
 seed.
 
+### Replay and save/resume
+
+`SeededRNG` can hand out its internal state as an `RngState` — four unsigned
+32-bit words — and take one back through its constructor. Restoring copies the
+words verbatim, with no re-hashing and no warm-up draws, so the resumed stream
+continues exactly where the snapshot was taken. That holds for snapshots
+`state()` produced — the type is the contract, and a hand-built tuple is
+coerced to 32 bits per word rather than rejected.
+
+That answers the question an auto-seeded roll otherwise cannot. `roll('1d20')`
+mints a seed and discards it; snapshot the state first and the roll is
+reproducible after the fact:
+
+```typescript
+import { SeededRNG, roll } from 'roll-parser';
+
+const rng = new SeededRNG(); // auto-seeded, seed discarded
+const snapshot = rng.state();
+
+const first = roll('1d20', { rng });
+const replay = roll('1d20', { rng: new SeededRNG(snapshot) });
+first.total === replay.total; // true
+```
+
+The same snapshot is what a mid-session save writes: it is a plain tuple, so
+`JSON.stringify` round-trips it, and loading it resumes the campaign's dice
+rather than restarting them.
+
+Forking a second generator off a live one gives an entity its own substream.
+A fork resumes the parent's stream, so advance the parent between forks —
+two children taken at the same state are the same stream:
+
+```typescript
+import { SeededRNG } from 'roll-parser';
+
+const world = new SeededRNG('world');
+
+const goblin = new SeededRNG(world.state());
+world.next();
+const orc = new SeededRNG(world.state());
+
+goblin.nextInt(1, 20); // 5
+orc.nextInt(1, 20); // 7
+```
+
+`RngState` carries the same version binding as a seed: the words are opaque,
+and a major release may change the engine behind them. Keep snapshots for a
+session or a save file, not across an upgrade.
+
 ### Custom RNGs
 
 Anything structurally matching `RNG` works, so a crypto-backed or table-driven

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export {
   isVersus,
 } from './parser/ast.js';
 export { MAX_PARSE_DEPTH, ParseError, parse } from './parser/parser.js';
+export type { RngState } from './rng/seeded.js';
 export { SeededRNG } from './rng/seeded.js';
 export type { RNG } from './rng/types.js';
 export type { RollOptions } from './roll.js';

--- a/src/rng/rng.test.ts
+++ b/src/rng/rng.test.ts
@@ -438,6 +438,72 @@ describe('SeededRNG', () => {
     });
   });
 
+  describe('state()', () => {
+    it('should resume the exact sequence from a captured state', () => {
+      const source = new SeededRNG('replay');
+      source.nextInt(1, 6);
+
+      const restored = new SeededRNG(source.state());
+
+      expect(draws(restored)).toEqual(draws(source));
+    });
+
+    it('should skip the warm-up so a restored state round-trips unchanged', () => {
+      const snapshot = new SeededRNG('roundtrip').state();
+
+      expect(new SeededRNG(snapshot).state()).toEqual(snapshot);
+    });
+
+    it('should return unsigned words', () => {
+      const rng = new SeededRNG('unsigned');
+
+      for (const word of rng.state()) {
+        expect(word).toBeGreaterThanOrEqual(0);
+        expect(word).toBeLessThan(0x100000000);
+      }
+    });
+
+    it('should not advance the source instance', () => {
+      const rng = new SeededRNG('untouched');
+      const before = rng.state();
+      rng.state();
+
+      expect(rng.state()).toEqual(before);
+    });
+
+    it('should leave the source unaffected when the restored clone advances', () => {
+      const source = new SeededRNG('independence');
+      const reference = new SeededRNG('independence');
+      const restored = new SeededRNG(source.state());
+
+      restored.nextInt(1, 6);
+
+      expect(draws(source)).toEqual(draws(reference));
+    });
+
+    it('should leave the restored clone unaffected when the source advances', () => {
+      const source = new SeededRNG('reverse-independence');
+      const snapshot = source.state();
+      const restored = new SeededRNG(snapshot);
+
+      source.nextInt(1, 6);
+
+      expect(restored.state()).toEqual(snapshot);
+    });
+
+    it('should guard an all-zero state', () => {
+      const rng = new SeededRNG([0, 0, 0, 0]);
+
+      expect(rng.state()).toEqual([1, 0, 0, 0]);
+    });
+
+    it('should truncate out-of-range words to 32 bits', () => {
+      const rng = new SeededRNG([0x1_0000_0007, -1, 0, 0]);
+
+      expect(rng.state()).toEqual([7, 0xffffffff, 0, 0]);
+    });
+  });
+
   describe('table-driven invariants', () => {
     it('nextInt always returns value in valid range across fixed seeds', () => {
       const testCases = [

--- a/src/rng/seeded.ts
+++ b/src/rng/seeded.ts
@@ -7,6 +7,20 @@
 import type { RNG } from './types.js';
 
 /**
+ * A snapshot of {@link SeededRNG}'s four internal state words, as unsigned
+ * 32-bit integers. Pass one back to the constructor to resume the exact
+ * sequence it was taken from.
+ *
+ * Opaque and bound to the major version, the same contract seeds carry: the
+ * words mean nothing outside the engine that produced them, and a major
+ * release may change that engine. Safe to hold in memory or serialize for a
+ * save file; not safe to persist across a major upgrade.
+ *
+ * @category RNG
+ */
+export type RngState = readonly [number, number, number, number];
+
+/**
  * Rotates the low 32 bits of `value` left by `bits`, returning a signed int32.
  * Callers that need the unsigned reading apply `>>> 0` themselves.
  */
@@ -65,11 +79,16 @@ const CYRB128_MULTIPLIER_4 = 2716044179;
  * Stringifying means `42` and `'42'` are the same seed — the two forms share
  * one namespace, which matters when seeds arrive from a CLI flag or JSON.
  *
+ * {@link state} snapshots the four state words as an {@link RngState}, and
+ * passing one to the constructor resumes that exact sequence — restore copies
+ * the words verbatim, skipping both the hash and the run-in. The type is the
+ * contract: a hand-built tuple is coerced to 32 bits per word, not rejected.
+ *
  * Reproducibility guarantee: within one released version, the same seed and
- * the same notation always produce the same dice. The sequence is *not*
- * cryptographically secure and is not guaranteed stable across major
- * versions — do not persist rolls by re-deriving them from a seed, persist
- * the {@link RollResult}.
+ * the same notation always produce the same dice. The same version binding
+ * covers `RngState`. The sequence is *not* cryptographically secure and is not
+ * guaranteed stable across major versions — do not persist rolls by
+ * re-deriving them from a seed, persist the {@link RollResult}.
  *
  * @example
  * ```typescript
@@ -100,11 +119,22 @@ export class SeededRNG implements RNG {
   private s2: number;
   private s3: number;
 
-  constructor(seed?: string | number) {
+  constructor(seed?: string | number | RngState) {
     this.s0 = 0;
     this.s1 = 0;
     this.s2 = 0;
     this.s3 = 0;
+
+    if (seed !== null && typeof seed === 'object') {
+      // ! No hashing and no warm-up — either would diverge the resumed stream.
+      // ! Signed on write to keep the Smi invariant above; `state()` re-widens.
+      this.s0 = seed[0] | 0;
+      this.s1 = seed[1] | 0;
+      this.s2 = seed[2] | 0;
+      this.s3 = seed[3] | 0;
+      this.guardZeroState();
+      return;
+    }
 
     this.initState(seed);
 
@@ -115,11 +145,55 @@ export class SeededRNG implements RNG {
 
   private initState(seed?: string | number): void {
     this.hashSeed(this.toSeedString(seed));
+    this.guardZeroState();
+  }
 
-    // All-zero is a fixed point for xoshiro — at least one word must be non-zero.
+  /** All-zero is a fixed point for xoshiro — at least one word must be non-zero. */
+  private guardZeroState(): void {
     if (this.s0 === 0 && this.s1 === 0 && this.s2 === 0 && this.s3 === 0) {
       this.s0 = 1;
     }
+  }
+
+  /**
+   * Returns the current state as four unsigned 32-bit words. Feeding the
+   * snapshot back to the constructor resumes this exact sequence; the source
+   * instance is untouched, and the two then advance independently.
+   *
+   * The words are {@link RngState} — opaque, and stable only within a major
+   * version.
+   *
+   * @returns A snapshot of the four state words
+   *
+   * @example Replay a roll that was never seeded
+   * ```typescript
+   * import { SeededRNG, roll } from 'roll-parser';
+   *
+   * const rng = new SeededRNG();
+   * const snapshot = rng.state();
+   *
+   * const first = roll('1d20', { rng });
+   * const replay = roll('1d20', { rng: new SeededRNG(snapshot) });
+   * first.total === replay.total; // true
+   * ```
+   *
+   * @example Split per-entity substreams off one parent
+   * ```typescript
+   * import { SeededRNG } from 'roll-parser';
+   *
+   * const world = new SeededRNG('world');
+   *
+   * // A fork resumes the parent's stream, so advance the parent between
+   * // forks — two children taken at the same state are the same stream.
+   * const goblin = new SeededRNG(world.state());
+   * world.next();
+   * const orc = new SeededRNG(world.state());
+   *
+   * goblin.nextInt(1, 20); // advances the goblin only
+   * ```
+   */
+  state(): RngState {
+    return [this.s0 >>> 0, this.s1 >>> 0, this.s2 >>> 0, this.s3 >>> 0];
   }
 
   /**


### PR DESCRIPTION
`SeededRNG.state()` returns the four engine words as unsigned int32, and the constructor now accepts one back — widened to `string | number | RngState`. A state input copies the words verbatim, skipping both the cyrb128 hash and the warm-up draws, so `new SeededRNG(rng.state())` continues the sequence identically. The all-zero fixed-point guard moved into `guardZeroState()`, shared by the seed and restore paths. `RngState` is exported from the package root; the `RNG` interface is untouched — state is a `SeededRNG` capability, not part of the injectable contract.

Restore normalizes with `| 0` rather than `>>> 0`: the state words are stored signed on purpose (a word above 2^31 leaves V8's Smi representation and roughly doubles per-draw cost), bit patterns are identical, and `state()` widens at the boundary. Malformed tuples stay coerced rather than validated, per the issue's stated decision; the docs scope the exactness guarantee to snapshots `state()` produced.

Replay of unseeded rolls, mid-session save/resume, and per-entity substreams are documented as README recipes and TSDoc examples rather than APIs. MIGRATION.md, the TypeDoc regeneration, and the epic's final size/bench report belong to #205.

Verification: `bun validate` green (1360 pass, 0 fail, 100% functions); `check:size` `{ roll }` 10.74 kB → 10.81 kB (+70 B, limit 11.5 kB) and `index.js` 10.97 kB → 11.05 kB (+80 B, limit 12 kB), `{ parse }` and `testing.js` unmoved; `bench:roll` unchanged — no hot-path edit.

Closes #203
