### PR TITLE
feat: strengthen unseeded auto-seed entropy #204

### DIFF
--- a/.claude/rules/rng.md
+++ b/.claude/rules/rng.md
@@ -2,9 +2,10 @@
 
 All dice rolling goes through the `RNG` interface (`src/rng/types.ts`),
 injected via the options parameter, defaulting to `SeededRNG`; tests use
-`createMockRng`. `Math.random()` has exactly one permitted call site: seeding
-`SeededRNG` when the caller supplies no seed. Anywhere else in a roll path is
-a bug.
+`createMockRng`. `Math.random()` has exactly one permitted call site:
+`SeededRNG.toSeedString` building the auto-seed when the caller supplies no
+seed. That site invokes it twice — both draws feed the same entropy string, and
+neither may move elsewhere. Anywhere else in a roll path is a bug.
 
 ## Draw Order
 

--- a/README.md
+++ b/README.md
@@ -341,8 +341,10 @@ renders as `8d6![…]`. Read `result.expression` when you need the modifier back
 
 Every die is drawn through the `RNG` interface — no roll path bypasses the RNG
 you chose. `Math.random()` appears in exactly one place: seeding a `SeededRNG`
-when you do not supply a seed. Pass a seed or your own `RNG` and it is never
-reached.
+when you do not supply a seed — the auto-seed hashes `Date.now()` together with
+two `Math.random()` draws, carrying roughly 100 bits into the 128-bit state
+rather than the 32 an XOR of clock and one draw would cap it at. Pass a seed or
+your own `RNG` and it is never reached.
 
 ```typescript
 type RNG = {

--- a/src/rng/rng.test.ts
+++ b/src/rng/rng.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 import { createMockRng, MockRNGExhaustedError } from './mock.js';
 import { SeededRNG } from './seeded.js';
 import type { RNG } from './types.js';
@@ -136,6 +136,31 @@ describe('SeededRNG', () => {
         }
       }
       expect(allSame).toBe(false);
+    });
+  });
+
+  describe('auto-seeding', () => {
+    it('should draw in range when constructed without a seed', () => {
+      const rng = new SeededRNG();
+
+      for (const value of draws(rng)) {
+        expect(value).toBeGreaterThanOrEqual(1);
+        expect(value).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it('separates instances built in the same millisecond (#204)', () => {
+      // A frozen clock leaves the `Math.random()` draws as the only thing
+      // separating the streams — a clock-only auto-seed makes all 20 identical.
+      const clock = spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+      try {
+        const sequences = Array.from({ length: 20 }, () => draws(new SeededRNG()).join(','));
+
+        expect(new Set(sequences).size).toBe(sequences.length);
+      } finally {
+        clock.mockRestore();
+      }
     });
   });
 

--- a/src/rng/seeded.ts
+++ b/src/rng/seeded.ts
@@ -73,8 +73,9 @@ const CYRB128_MULTIPLIER_4 = 2716044179;
  *
  * Period 2^128 - 1. Every seed is stringified and hashed with cyrb128 into
  * the full 128-bit state, so numeric seeds keep all 53 bits and distinct
- * strings stay distinct; an omitted seed mixes `Date.now()` with
- * `Math.random()`. The first 8 draws are discarded as a run-in.
+ * strings stay distinct; an omitted seed hashes `Date.now()` together with two
+ * `Math.random()` draws, carrying roughly 100 bits of entropy rather than 32.
+ * The first 8 draws are discarded as a run-in.
  *
  * Stringifying means `42` and `'42'` are the same seed — the two forms share
  * one namespace, which matters when seeds arrive from a CLI flag or JSON.
@@ -201,7 +202,8 @@ export class SeededRNG implements RNG {
    * rather than coerced to uint32, so all 53 exact bits reach the hash.
    */
   private toSeedString(seed?: string | number): string {
-    if (seed == null) return String((Date.now() ^ (Math.random() * 0xffffffff)) >>> 0);
+    // ! The library's one permitted `Math.random()` site — both draws stay here.
+    if (seed == null) return `${Date.now()}-${Math.random()}-${Math.random()}`;
     return String(seed);
   }
 


### PR DESCRIPTION
Replaced the 32-bit `Date.now() ^ Math.random()` auto-seed with a `${Date.now()}-${Math.random()}-${Math.random()}` entropy string, so cyrb128 spreads roughly 100 bits over the 128-bit state instead of 32.

Added an auto-seeding test block that freezes `Date.now()`, leaving the `Math.random()` draws as the only thing separating 20 unseeded instances.

Reworded `.claude/rules/rng.md` so the single permitted `Math.random()` call site covers both draws, and updated the README Randomness section and `SeededRNG` TSDoc.

Closes #204
