### PR TITLE
docs: update RNG docs and run final size and bench verification #205

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -105,3 +105,38 @@ Everything else in v3 is new surface rather than a replacement — the `parts`
 tree, injectable RNGs, source spans, safety limits, and the wider notation set
 have no v2 equivalent to migrate from. The
 [full list of breaking changes](CHANGELOG.md) is in the changelog.
+
+## Upgrading from a v3 pre-release
+
+`3.0.0-alpha.0` and `3.0.0-beta.0` derived a single 32-bit number from the seed
+— djb2 for strings, a `>>> 0` truncation for numbers — expanded it with
+splitmix32, and ran an xorshift128 core. `3.0.0` replaces all of it: cyrb128
+hashes the seed straight into the full 128-bit state, and xoshiro128\*\*
+generates the stream. Every seeded sequence therefore changed — the same seed
+and notation roll different dice. Nothing in the API moved, so this surfaces
+only as tests asserting pinned faces, or as saved games that stored a seed.
+
+The fix is the same one the reproducibility contract has always implied: a seed
+is stable within a released version, not across versions, so **persist the
+`RollResult`** — it holds the totals, the per-die faces, and the rendered
+breakdown — rather than re-deriving rolls from a stored seed. Tests that need
+exact faces should use `createMockRng` from `roll-parser/testing`, which is
+engine-independent.
+
+When you need a live generator to survive a save and resume, snapshot its state
+instead of its seed. `state()` returns four unsigned 32-bit words that the
+constructor takes back verbatim, with no re-hashing and no warm-up:
+
+```typescript
+import { SeededRNG, roll } from 'roll-parser';
+
+const rng = new SeededRNG('campaign');
+const save = JSON.stringify(rng.state());
+
+const live = roll('1d20', { rng });
+const resumed = roll('1d20', { rng: new SeededRNG(JSON.parse(save)) });
+live.total === resumed.total; // true
+```
+
+`RngState` carries the same major-version binding as a seed — good for a save
+file within a release line, not across an upgrade.

--- a/README.md
+++ b/README.md
@@ -342,9 +342,11 @@ renders as `8d6![…]`. Read `result.expression` when you need the modifier back
 Every die is drawn through the `RNG` interface — no roll path bypasses the RNG
 you chose. `Math.random()` appears in exactly one place: seeding a `SeededRNG`
 when you do not supply a seed — the auto-seed hashes `Date.now()` together with
-two `Math.random()` draws, carrying roughly 100 bits into the 128-bit state
-rather than the 32 an XOR of clock and one draw would cap it at. Pass a seed or
-your own `RNG` and it is never reached.
+two `Math.random()` draws, giving roughly 100 bits of width rather than the 32 an
+XOR of clock and one draw would cap it at. That width is what keeps two
+auto-seeded generators from landing on the same stream; it is not a claim about
+unpredictability, which stays bounded by however the host engine seeds
+`Math.random()`. Pass a seed or your own `RNG` and it is never reached.
 
 ```typescript
 type RNG = {
@@ -358,6 +360,14 @@ type RNG = {
 `roll(notation)` builds a fresh `SeededRNG` (xoshiro128\*\*, period 2^128 − 1) per
 call. Pass `seed` to make it reproducible, or `rng` to supply your own instance
 — `rng` wins when both are given.
+
+Behind a seed sit three stages. cyrb128 hashes the seed into all four state
+words, so the full 128 bits are seeded rather than a single word; xoshiro128\*\*
+generates the stream; and `nextInt` maps each draw onto the die's faces by
+rejection sampling, discarding the values that would make a plain `% sides`
+favour the low faces. Seeds are stringified before hashing — numeric seeds keep
+all 53 exact bits instead of truncating to 32, distinct strings stay distinct,
+and `42` and `'42'` name the same stream.
 
 ```typescript
 import { SeededRNG, roll } from 'roll-parser';
@@ -403,21 +413,23 @@ The same snapshot is what a mid-session save writes: it is a plain tuple, so
 `JSON.stringify` round-trips it, and loading it resumes the campaign's dice
 rather than restarting them.
 
-Forking a second generator off a live one gives an entity its own substream.
-A fork resumes the parent's stream, so advance the parent between forks —
-two children taken at the same state are the same stream:
+> [!WARNING]
+> `state()` is for replay and save/resume, **not** for forking substreams. A
+> restored generator resumes the parent's stream verbatim, so two children taken
+> a few draws apart replay the same sequence at an offset — their rolls predict
+> each other exactly. xoshiro has no jump function here to separate them.
+
+To give each entity its own stream, derive a seed per entity instead. cyrb128
+sends distinct strings to unrelated states, which is what makes this work:
 
 ```typescript
 import { SeededRNG } from 'roll-parser';
 
-const world = new SeededRNG('world');
+const goblin = new SeededRNG('world:goblin');
+const orc = new SeededRNG('world:orc');
 
-const goblin = new SeededRNG(world.state());
-world.next();
-const orc = new SeededRNG(world.state());
-
-goblin.nextInt(1, 20); // 5
-orc.nextInt(1, 20); // 7
+goblin.nextInt(1, 20); // 9
+orc.nextInt(1, 20); // 1
 ```
 
 `RngState` carries the same version binding as a seed: the words are opaque,

--- a/src/rng/rng.test.ts
+++ b/src/rng/rng.test.ts
@@ -527,6 +527,30 @@ describe('SeededRNG', () => {
 
       expect(rng.state()).toEqual([7, 0xffffffff, 0, 0]);
     });
+
+    it('replays the parent stream at an offset rather than forking it (#205)', () => {
+      const parent = new SeededRNG('world');
+      const first = new SeededRNG(parent.state());
+      parent.next();
+      const second = new SeededRNG(parent.state());
+
+      const firstDraws = Array.from({ length: 32 }, () => first.nextInt(1, 20));
+      const secondDraws = Array.from({ length: 32 }, () => second.nextInt(1, 20));
+
+      expect(secondDraws.slice(0, 31)).toEqual(firstDraws.slice(1));
+    });
+
+    it('gives derived seeds unrelated streams (#205)', () => {
+      const goblin = new SeededRNG('world:goblin');
+      const orc = new SeededRNG('world:orc');
+
+      const goblinDraws = Array.from({ length: 32 }, () => goblin.nextInt(1, 20));
+      const orcDraws = Array.from({ length: 32 }, () => orc.nextInt(1, 20));
+
+      for (let offset = 0; offset < 8; offset++) {
+        expect(orcDraws.slice(0, 24)).not.toEqual(goblinDraws.slice(offset, offset + 24));
+      }
+    });
   });
 
   describe('table-driven invariants', () => {

--- a/src/rng/seeded.ts
+++ b/src/rng/seeded.ts
@@ -74,8 +74,10 @@ const CYRB128_MULTIPLIER_4 = 2716044179;
  * Period 2^128 - 1. Every seed is stringified and hashed with cyrb128 into
  * the full 128-bit state, so numeric seeds keep all 53 bits and distinct
  * strings stay distinct; an omitted seed hashes `Date.now()` together with two
- * `Math.random()` draws, carrying roughly 100 bits of entropy rather than 32.
- * The first 8 draws are discarded as a run-in.
+ * `Math.random()` draws, roughly 100 bits of width rather than 32 — enough that
+ * auto-seeded generators do not collide, though unpredictability stays bounded
+ * by the host engine's `Math.random()` seeding. The first 8 draws are discarded
+ * as a run-in.
  *
  * Stringifying means `42` and `'42'` are the same seed — the two forms share
  * one namespace, which matters when seeds arrive from a CLI flag or JSON.
@@ -178,19 +180,16 @@ export class SeededRNG implements RNG {
    * first.total === replay.total; // true
    * ```
    *
-   * @example Split per-entity substreams off one parent
+   * Not a fork primitive. A restored generator replays the parent's stream, so
+   * children taken at different points are the same sequence at an offset, not
+   * independent substreams — derive a seed per entity instead.
+   *
+   * @example Per-entity streams — derive seeds, do not fork state
    * ```typescript
    * import { SeededRNG } from 'roll-parser';
    *
-   * const world = new SeededRNG('world');
-   *
-   * // A fork resumes the parent's stream, so advance the parent between
-   * // forks — two children taken at the same state are the same stream.
-   * const goblin = new SeededRNG(world.state());
-   * world.next();
-   * const orc = new SeededRNG(world.state());
-   *
-   * goblin.nextInt(1, 20); // advances the goblin only
+   * const goblin = new SeededRNG('world:goblin');
+   * const orc = new SeededRNG('world:orc');
    * ```
    */
   state(): RngState {
@@ -227,6 +226,9 @@ export class SeededRNG implements RNG {
     h3 = Math.imul(h1 ^ (h3 >>> 17), CYRB128_MULTIPLIER_3);
     h4 = Math.imul(h2 ^ (h4 >>> 19), CYRB128_MULTIPLIER_4);
 
+    // ! Reference cyrb128 derives the trailing three words against `h1`, not
+    // ! `mixed`. The map is invertible, so no entropy is lost — but aligning it
+    // ! with the reference rewrites every seeded sequence. Not a cleanup.
     const mixed = h1 ^ h2 ^ h3 ^ h4;
 
     this.s0 = mixed;
@@ -236,7 +238,9 @@ export class SeededRNG implements RNG {
   }
 
   private nextUint32(): number {
-    // xoshiro128** 1.0 — these constants are part of the algorithm, not tunables.
+    // xoshiro128** 1.1 — these constants are part of the algorithm, not tunables.
+    // ! Scrambling `s1`, not `s0`, is what makes this 1.1; 1.0 used `s0` and was
+    // ! withdrawn for it.
     const scrambled = rotl(Math.imul(this.s1, SCRAMBLE_MULTIPLIER_1), SCRAMBLE_ROTATION);
     const result = Math.imul(scrambled, SCRAMBLE_MULTIPLIER_2) >>> 0;
 


### PR DESCRIPTION
Closes the RNG rework epic: brings the docs in line with the final engine and records
the epic's size and bench verification against the pre-epic baseline (`b90cea7`).

Documented the cyrb128 seeding half of the pipeline and the rejection-sampled `nextInt`
in the README Randomness section, and added a MIGRATION.md section for v3 pre-release
upgraders covering the changed seeded sequences and the `state()` save/resume recipe.

Review of the epic surfaced two defects in shipped docs, both fixed here:

- The fork-by-state recipe was wrong. Restoring a snapshot replays the parent stream, so
  the documented "substreams" were one sequence at an offset — `orc[i] === goblin[i+1]`
  for every `i`, and the README's own printed outputs were consecutive draws. Replaced
  with seed derivation in the README and the `state()` TSDoc, pinned by regression tests.
- The auto-seed "~100 bits of entropy" claim conflated width with unpredictability.
  Reworded to name the property it actually describes.

Also corrected the core's version label to xoshiro128\*\* 1.1 — it scrambles `s1`; 1.0
scrambled `s0` and was withdrawn — and pinned the deliberate cyrb128 word-derivation
deviation with a `// !` comment.

Verification recorded in [a closing comment on #200](https://github.com/edloidas/roll-parser/issues/200#issuecomment-5160442878):
`bun validate` green, `{ roll }` +100 B against the ≈+165 B estimate, and an
interleaved paired bench showing `1d20` ~−27% and `1000d6` neutral. The CI bench trend was not
usable as a baseline — it reports 20-40% drift on `lex` and `parse`, paths the epic never
touched.

Closes #205

<sub>[Claude Code session](https://claude.ai/code)</sub>

