### PR TITLE
refactor: decide on cyrb128 canonical word derivation before v3.0.0 #210

### DIFF
--- a/src/rng/rng.test.ts
+++ b/src/rng/rng.test.ts
@@ -944,3 +944,61 @@ describe('SeededRNG golden sequences', () => {
     });
   }
 });
+
+describe('SeededRNG cyrb128 conformance', () => {
+  // ! Pins the seed → state derivation to reference cyrb128. "Correcting" it to
+  // ! the withdrawn 2023 variant rewrites every seeded sequence while the
+  // ! determinism-only suites stay green — this is what fails instead.
+  const referenceCyrb128 = (str: string): [number, number, number, number] => {
+    let h1 = 1779033703;
+    let h2 = 3144134277;
+    let h3 = 1013904242;
+    let h4 = 2773480762;
+
+    for (let i = 0; i < str.length; i++) {
+      const k = str.charCodeAt(i);
+      h1 = h2 ^ Math.imul(h1 ^ k, 597399067);
+      h2 = h3 ^ Math.imul(h2 ^ k, 2869860233);
+      h3 = h4 ^ Math.imul(h3 ^ k, 951274213);
+      h4 = h1 ^ Math.imul(h4 ^ k, 2716044179);
+    }
+
+    h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+    h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+    h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+    h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+
+    // The reference writes these as one comma sequence; split for Biome, order
+    // intact. `h1` folds first, so the other three read the folded value.
+    h1 ^= h2 ^ h3 ^ h4;
+    h2 ^= h1;
+    h3 ^= h1;
+    h4 ^= h1;
+
+    return [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+  };
+
+  // The hash output is never observable directly — the run-in has already moved
+  // the state by the time `state()` can be read. Restoring skips the run-in, so
+  // replay it: `next()` is one draw, and `WARMUP_DRAWS` in `seeded.ts` is 8.
+  const seedFromReference = (seed: string): SeededRNG => {
+    const rng = new SeededRNG(referenceCyrb128(seed));
+    for (let i = 0; i < 8; i++) {
+      rng.next();
+    }
+    return rng;
+  };
+
+  const seeds = ['demo', 'test-seed', '12345', '-1', '1.9', '', '🎲✨', 'world:goblin'];
+
+  for (const seed of seeds) {
+    it(`derives its state from reference cyrb128 for ${seed === '' ? 'the empty seed' : `'${seed}'`} (#210)`, () => {
+      const seeded = new SeededRNG(seed);
+      const fromReference = seedFromReference(seed);
+
+      expect(Array.from({ length: 8 }, () => seeded.nextInt(1, 1_000_000))).toEqual(
+        Array.from({ length: 8 }, () => fromReference.nextInt(1, 1_000_000)),
+      );
+    });
+  }
+});

--- a/src/rng/seeded.ts
+++ b/src/rng/seeded.ts
@@ -226,9 +226,10 @@ export class SeededRNG implements RNG {
     h3 = Math.imul(h1 ^ (h3 >>> 17), CYRB128_MULTIPLIER_3);
     h4 = Math.imul(h2 ^ (h4 >>> 19), CYRB128_MULTIPLIER_4);
 
-    // ! Reference cyrb128 derives the trailing three words against `h1`, not
-    // ! `mixed`. The map is invertible, so no entropy is lost — but aligning it
-    // ! with the reference rewrites every seeded sequence. Not a cleanup.
+    // ! Matches reference cyrb128, which folds `h1` first and derives the other
+    // ! three against the folded value. A revision withdrawn in 2023 used the
+    // ! unmixed `h1` and its mirrors still circulate — matching one rewrites
+    // ! every seeded sequence. Pinned by `rng.test.ts`.
     const mixed = h1 ^ h2 ^ h3 ^ h4;
 
     this.s0 = mixed;


### PR DESCRIPTION
Decision: keep the derivation. It already matches reference cyrb128 — the form
the issue cites as canonical is the revision withdrawn in 2023, which derived
the trailing three words against an unmixed `h1`. The current reference folds
`h1` first, matching `hashSeed` exactly. Verified against the Stack Exchange
revision history and empirically across 8 seeds.

No sequence break, so none of #201's regeneration checklist applies.

Corrected the `hashSeed` comment, which asserted divergence from the reference
and was itself the source of the misreading.
Added a `SeededRNG cyrb128 conformance` suite that transcribes the published
reference and pins the seed to state map against it, so swapping in the
withdrawn variant fails a test instead of silently rewriting every seeded
sequence.

Closes #210
