### PR TITLE
docs: fix three false or overclaimed README statements #218

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ For TypeScript consumers, `moduleResolution` must be `bundler`, `node16`, or
 `nodenext` — the package resolves through `exports` only, so the legacy `node10`
 resolution does not find it.
 
-Bundlers tree-shake the library cleanly: it is marked `sideEffects: false` and
-touches no `process` or filesystem globals.
+Bundlers tree-shake the library cleanly: the library entries are side-effect-free
+and touch no `process` or filesystem globals. Only the CLI entry is marked as
+having effects, since it calls `main()` at module scope.
 
 ### CDN / browser without a bundler
 
@@ -367,8 +368,9 @@ words, so the full 128 bits are seeded rather than a single word; xoshiro128\*\*
 generates the stream; and `nextInt` maps each draw onto the die's faces by
 rejection sampling, discarding the values that would make a plain `% sides`
 favour the low faces. Seeds are stringified before hashing — numeric seeds keep
-all 53 exact bits instead of truncating to 32, distinct strings stay distinct,
-and `42` and `'42'` name the same stream.
+all 53 exact bits instead of truncating to 32, unrelated strings are
+overwhelmingly unlikely to land on the same state, and `42` and `'42'` name the
+same stream.
 
 ```typescript
 import { SeededRNG, roll } from 'roll-parser';
@@ -424,7 +426,8 @@ rather than restarting them.
 > each other exactly. xoshiro has no jump function here to separate them.
 
 To give each entity its own stream, derive a seed per entity instead. cyrb128
-sends distinct strings to unrelated states, which is what makes this work:
+sends unrelated strings to states that are overwhelmingly unlikely to coincide,
+which is what makes this work:
 
 ```typescript
 import { SeededRNG } from 'roll-parser';
@@ -849,8 +852,8 @@ in place. See [Working with results](#working-with-results).
 
 **Runtimes.** The supported floor is Node ≥ 22.12, current Bun, and any browser
 with ES2022. Raising the floor is a major. The library imports no `node:`
-builtins, which is enforced in CI, so Deno and edge runtimes work too — they are
-just not yet in the smoke matrix.
+builtins, which is enforced in CI, so Deno and edge runtimes are expected to work
+too — they are just not yet in the smoke matrix, so nothing has verified them.
 
 ## Contributing
 

--- a/src/rng/seeded.ts
+++ b/src/rng/seeded.ts
@@ -108,12 +108,12 @@ function assertRestorable(state: RngState): void {
  * `roll(notation, { seed })` builds one from your seed.
  *
  * Period 2^128 - 1. Every seed is stringified and hashed with cyrb128 into
- * the full 128-bit state, so numeric seeds keep all 53 bits and distinct
- * strings stay distinct; an omitted seed hashes `Date.now()` together with two
- * `Math.random()` draws, roughly 100 bits of width rather than 32 — enough that
- * auto-seeded generators do not collide, though unpredictability stays bounded
- * by the host engine's `Math.random()` seeding. The first 8 draws are discarded
- * as a run-in.
+ * the full 128-bit state, so numeric seeds keep all 53 bits and unrelated
+ * strings are overwhelmingly unlikely to share a state; an omitted seed hashes
+ * `Date.now()` together with two `Math.random()` draws, roughly 100 bits of
+ * width rather than 32 — wide enough that concurrently created generators are
+ * very unlikely to collide, though unpredictability stays bounded by the host
+ * engine's `Math.random()` seeding. The first 8 draws are discarded as a run-in.
  *
  * Stringifying means `42` and `'42'` are the same seed — the two forms share
  * one namespace, which matters when seeds arrive from a CLI flag or JSON.


### PR DESCRIPTION
Reworded the tree-shaking note to match the `sideEffects` manifest narrowed by #213 — library entries side-effect-free, CLI entry marked as having effects.

Replaced the impossible "distinct strings stay distinct" cyrb128 claim with collision resistance in `README.md` and the `SeededRNG` TSDoc, keeping the true 53-exact-bit claim. Also softened the same overclaim in the per-entity substream section, which stated it a second time and is not listed in the issue.

Softened the Deno and edge runtime claim to "expected to work" until a smoke job covers them.

No source behaviour changes. `src/readme.test.ts` executes `typescript` fences only, so these prose edits are not auto-checked — they were read against `package.json`, `CHANGELOG.md`, and the cyrb128 implementation.

Closes #218
