### PR TITLE
fix: stop @internal members leaking into the published .d.ts #220

### DIFF
--- a/src/cli/package-smoke.test.ts
+++ b/src/cli/package-smoke.test.ts
@@ -86,4 +86,15 @@ describe('two-pass emit', () => {
       expect(existsSync(map)).toBe(true);
     }
   });
+
+  test('strips @internal members from declarations (#220)', async () => {
+    const declaration = await Bun.file('./dist/errors.d.ts').text();
+
+    expect(declaration).not.toContain('@internal');
+    expect(declaration).not.toContain('stampSpan');
+
+    // Stripping must be surgical — the public accessors over the span survive.
+    expect(declaration).toContain('get start()');
+    expect(declaration).toContain('get end()');
+  });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -219,7 +219,8 @@ export class EvaluatorError extends RollParserError {
    * first stamp wins, so the innermost `evalNode` frame keeps the tightest
    * span as the error bubbles up.
    *
-   * @internal Called only by `evalNode`; not part of the public API.
+   * @internal Called only by `evalNode`; `stripInternal` drops it from the
+   * published `.d.ts`.
    */
   stampSpan(start: number, end: number | undefined): void {
     if (this.#start != null) return;

--- a/tsconfig.build.types.json
+++ b/tsconfig.build.types.json
@@ -10,7 +10,10 @@
     "declaration": true,
     "declarationMap": true,
     "removeComments": false,
-    "sourceMap": false
+    "sourceMap": false,
+    // Not the same lever as TypeDoc's `excludeInternal`, which only hides
+    // `@internal` from the docs site — `tsc` emits the member either way.
+    "stripInternal": true
   },
   // `exclude` does not merge on `extends` — restated so tests stay out here too.
   "exclude": ["node_modules", "dist", "**/*.test.ts", "src/test-helpers.ts"]


### PR DESCRIPTION
Set `stripInternal` on the declaration-emit pass so `@internal`-tagged members are dropped from `dist/**/*.d.ts` instead of only being hidden from the TypeDoc site by `excludeInternal`.

`EvaluatorError.stampSpan` is gone from the published types. The JS emit is byte-identical, both map kinds are still emitted, and `dist/errors.d.ts.map` still resolves to the shipped `src/`. attw + publint clean, all four size budgets unchanged.

Added a `two-pass emit` regression test asserting no `@internal` or `stampSpan` in `dist/errors.d.ts` while the public span accessors survive.

Closes #220
