### PR TITLE
test: establish and verify the supported TypeScript version floor #221

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,132 @@ jobs:
         if: contains(fromJSON('["failure", "cancelled"]'), needs.node-smoke.result)
         run: exit 1
 
+  # The published types on the TypeScript versions consumers actually run.
+  # Typechecks `scripts/ts-compat/consumer.ts` against the packed tarball, so
+  # the `exports` map, both entry points, and the emitted `.d.ts` all take
+  # part — `tsc` resolves here exactly the way a consumer's does. Node-only:
+  # no Bun setup and no root install, since the fixture depends on the tarball
+  # and one matrix TypeScript, nothing else.
+  ts-compat:
+    name: TypeScript Compat (${{ matrix.typescript }}.x)
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        # Declared floor first — `README.md` promises it. 5.9 is the end of the
+        # 5.x line and where most installs sit; 7 is what this repo builds with.
+        typescript: ['5.0', '5.4', '5.9', '6', '7']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          # ! No package-lock.json in this repo — setup-node's npm auto-cache
+          # ! (on by default since v5) hard-fails when it cannot find one.
+          package-manager-cache: false
+
+      - name: Download tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/tarball
+
+      - name: Install fixture against the tarball
+        env:
+          TS_VERSION: ${{ matrix.typescript }}
+        run: |
+          cp -R scripts/ts-compat "$RUNNER_TEMP/ts-compat"
+          cd "$RUNNER_TEMP/ts-compat"
+          npm install --no-audit --no-fund "$RUNNER_TEMP"/tarball/roll-parser-*.tgz "typescript@$TS_VERSION"
+          node -p "'typescript ' + require('typescript/package.json').version"
+
+      - name: Typecheck consumer with moduleResolution bundler
+        working-directory: ${{ runner.temp }}/ts-compat
+        run: ./node_modules/.bin/tsc -p tsconfig.bundler.json
+
+      - name: Typecheck consumer with moduleResolution nodenext
+        working-directory: ${{ runner.temp }}/ts-compat
+        run: ./node_modules/.bin/tsc -p tsconfig.nodenext.json
+
+  # The negative case. Without it the matrix proves only that some versions
+  # pass, never that the floor is where the README says it is. 4.9 is the last
+  # release before `moduleResolution: bundler` existed, so it cannot resolve
+  # the package at all: every import degrades to `any`, and that is precisely
+  # what the fixture's `NotAny` assertions and `@ts-expect-error` lines catch.
+  # (`node16`/`nodenext` do still resolve on 4.9 — 5.0 is the floor because it
+  # is the lowest version where every documented setting works.)
+  ts-compat-floor:
+    name: TypeScript Floor Guard
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          # ! No package-lock.json in this repo — setup-node's npm auto-cache
+          # ! (on by default since v5) hard-fails when it cannot find one.
+          package-manager-cache: false
+
+      - name: Download tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/tarball
+
+      - name: Install fixture against the tarball
+        run: |
+          cp -R scripts/ts-compat "$RUNNER_TEMP/ts-compat"
+          cd "$RUNNER_TEMP/ts-compat"
+          npm install --no-audit --no-fund "$RUNNER_TEMP"/tarball/roll-parser-*.tgz typescript@4.9
+          node -p "'typescript ' + require('typescript/package.json').version"
+
+      - name: Assert the version below the floor fails
+        working-directory: ${{ runner.temp }}/ts-compat
+        run: |
+          if output=$(./node_modules/.bin/tsc -p tsconfig.bundler.json 2>&1); then
+            echo 'TypeScript 4.9 typechecked the published types: either the 5.0 floor in README.md is stale, or the fixture no longer asserts anything.'
+            exit 1
+          fi
+          echo "$output"
+          # A non-zero exit alone would also be satisfied by an unrelated
+          # fixture break, which proves nothing about the floor. TS2792 is the
+          # `exports`-only import going unresolved, TS2344 is the
+          # `Assert<NotAny<…>>` guards catching the `any` that leaves behind.
+          for code in TS2792 TS2344; do
+            if ! printf '%s\n' "$output" | grep -q "$code"; then
+              echo "Expected $code below the floor; got the failure above instead."
+              exit 1
+            fi
+          done
+          echo 'Below-floor typecheck failed for the expected reasons.'
+
+  # Stable fan-in for branch protection, same reasoning as `node-smoke-gate`:
+  # the matrix bakes versions into check names, so protection should require
+  # this one name instead of the legs.
+  ts-compat-gate:
+    name: TypeScript Compat
+    runs-on: ubuntu-latest
+    needs: [ts-compat, ts-compat-floor]
+    if: always()
+    steps:
+      - name: Fail if any TypeScript leg failed
+        if: >-
+          contains(fromJSON('["failure", "cancelled"]'), needs.ts-compat.result) ||
+          contains(fromJSON('["failure", "cancelled"]'), needs.ts-compat-floor.result)
+        run: exit 1
+
   # The neutrality gate Bun's bundler cannot provide: esbuild with
   # `--platform=browser` hard-errors on any Node builtin import (Bun's
   # `--target browser` silently stubs them instead), the minified bundle is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ with `biome check --write` and blocks commits on unfixable lint errors.
 - `files` ships `src/` deliberately: `.d.ts.map` points consumer go-to-definition at the real sources. Removing it breaks nothing visibly — the jumps just die
 - Relative imports in `src/` carry explicit `.js` extensions — enforced by `moduleResolution: nodenext` at typecheck time
 - Library code must stay environment-neutral: no Node/Bun globals or `node:` imports outside `src/cli/` — enforced by Biome `noNodejsModules`, `types: []` in `tsconfig.build.json`, and the `browser-smoke` CI job
+- Published types carry a TypeScript ≥5.0 floor (the first release with `moduleResolution: bundler`, which `README.md` offers) — the `ts-compat` matrix typechecks `scripts/ts-compat/consumer.ts` against the packed tarball, `ts-compat-floor` asserts 4.9 still fails, and raising the floor is a major. That fixture is deliberately not a root workspace: each matrix leg installs its own `typescript`
 - `src/version.ts` is generated from `package.json` by `bun run generate:version` — never edit it by hand; `check:version` and the `index.test.ts` drift test gate the sync
 - TypeDoc runs from `scripts/docs/node_modules/.bin/typedoc`, not the root: 0.28.x peers at TypeScript `<=6` and throws on the root `typescript@7`, so that workspace nests its own `typescript@6`. Do not fold it back into the root until TypeDoc 1.0 ships TS7 support (full rationale in `scripts/docs/package.json`)
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ npm install roll-parser
 
 For TypeScript consumers, `moduleResolution` must be `bundler`, `node16`, or
 `nodenext` — the package resolves through `exports` only, so the legacy `node10`
-resolution does not find it.
+resolution does not find it. **TypeScript ≥ 5.0** is the supported floor — the
+first release with `moduleResolution: bundler`. CI typechecks a consumer fixture
+against the packed tarball on 5.0, 5.4, 5.9, 6.x, and 7.x, and asserts the types
+really resolve rather than degrading to `any`. `node16`/`nodenext` setups do
+resolve on 4.9, but that combination is untested and outside the promise.
 
 Bundlers tree-shake the library cleanly: the library entries are side-effect-free
 and touch no `process` or filesystem globals. Only the CLI entry is marked as
@@ -859,8 +863,9 @@ mutable so you can annotate your own views; the AST and tokens are typed
 `readonly` throughout, so the compiler rejects mutating a parsed node or token
 in place. See [Working with results](#working-with-results).
 
-**Runtimes.** The supported floor is Node ≥ 22.12, current Bun, and any browser
-with ES2022. Raising the floor is a major. The library imports no `node:`
+**Runtimes.** The supported floor is Node ≥ 22.12, current Bun, any browser
+with ES2022, and TypeScript ≥ 5.0 for the shipped types. Raising a floor is a
+major. The library imports no `node:`
 builtins, which is enforced in CI, so Deno and edge runtimes are expected to work
 too — they are just not yet in the smoke matrix, so nothing has verified them.
 

--- a/scripts/ts-compat/consumer.ts
+++ b/scripts/ts-compat/consumer.ts
@@ -1,0 +1,78 @@
+/**
+ * Consumer fixture for the TypeScript version-floor matrix.
+ *
+ * Typechecked against the packed tarball — never `src/` — by the `ts-compat`
+ * and `ts-compat-floor` jobs in `.github/workflows/ci.yml`.
+ *
+ * A green `tsc` proves nothing on its own: when resolution fails every import
+ * silently becomes `any`, and a plain smoke import still compiles. The
+ * assertions below are what a passing run actually means.
+ */
+
+import type {
+  ASTNode,
+  DieResult,
+  KeepDropSpec,
+  RNG,
+  RollPart,
+  RollPartType,
+  RollResult,
+} from 'roll-parser';
+import { DegreeOfSuccess, parse, RollParserError, roll, SeededRNG, VERSION } from 'roll-parser';
+import { createMockRng, MockRNGExhaustedError } from 'roll-parser/testing';
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type NotAny<T> = IsAny<T> extends true ? false : true;
+/** Violates its own constraint — and so fails to compile — when `T` is `false`. */
+type Assert<T extends true> = T;
+
+export type ResultResolved = Assert<NotAny<RollResult>>;
+export type PartResolved = Assert<NotAny<RollPart>>;
+export type AstResolved = Assert<NotAny<ASTNode>>;
+export type DieResolved = Assert<NotAny<DieResult>>;
+export type SpecResolved = Assert<NotAny<KeepDropSpec>>;
+
+const rng: RNG = createMockRng([3, 6, 2, 5]);
+const result: RollResult = roll('4d6kh3', { rng });
+const total: number = result.total;
+const rendered: string = result.rendered;
+const version: string = VERSION;
+const seeded: RNG = new SeededRNG('ci');
+const ast: ASTNode = parse('2d6');
+
+/** Narrowing on the discriminant must survive resolution, not collapse to `any`. */
+function describe(part: RollPart): string {
+  switch (part.type) {
+    case 'dice':
+      return `${part.count}d${part.sides}:${part.rolls.length}`;
+    case 'keepDrop':
+      return `${describe(part.target)}:${part.specs.map((spec) => spec.kind).join()}`;
+    case 'binaryOp':
+      return `${describe(part.left)} ${part.operator} ${describe(part.right)}`;
+    case 'literal':
+      return String(part.value);
+    default: {
+      const rest: Exclude<RollPartType, 'dice' | 'keepDrop' | 'binaryOp' | 'literal'> = part.type;
+      return rest;
+    }
+  }
+}
+
+// @ts-expect-error — a number is not an expression string
+roll(42);
+
+// @ts-expect-error — not one of the 16 RollPart discriminants
+const unknownPartType: RollPartType = 'nope';
+
+export const checks = [
+  total,
+  rendered,
+  version,
+  describe(result.parts),
+  ast.type,
+  seeded.next(),
+  DegreeOfSuccess.CriticalSuccess,
+  RollParserError.name,
+  MockRNGExhaustedError.name,
+  unknownPartType,
+];

--- a/scripts/ts-compat/package.json
+++ b/scripts/ts-compat/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@roll-parser/ts-compat",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Consumer fixture for the TypeScript version-floor matrix. Deliberately NOT a root workspace: CI copies this directory to a scratch dir and installs the packed tarball plus one matrix TypeScript version into it, so the root dependency tree never sees a second typescript. See the ts-compat jobs in .github/workflows/ci.yml."
+}

--- a/scripts/ts-compat/tsconfig.bundler.json
+++ b/scripts/ts-compat/tsconfig.bundler.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    // Off on purpose, unlike a typical consumer: it is what surfaces a `.d.ts`
+    // the matrix version cannot parse, which is half of what this job tests.
+    "skipLibCheck": false
+  },
+  "files": ["consumer.ts"]
+}

--- a/scripts/ts-compat/tsconfig.nodenext.json
+++ b/scripts/ts-compat/tsconfig.nodenext.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2022"],
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "files": ["consumer.ts"]
+}


### PR DESCRIPTION
Declares TypeScript 5.0 as the supported floor and tests it. The floor was determined empirically, not assumed: 5.0 is the first release with `moduleResolution: bundler`, which `README.md` offers as one of three supported settings. `node16`/`nodenext` still resolve on 4.9, but that combination is untested and outside the promise.

Added `scripts/ts-compat/`, a consumer fixture typechecked against the packed tarball under both `moduleResolution: bundler` and `nodenext`. It asserts resolved types rather than a zero exit — `Assert<NotAny<…>>` guards, a narrowing `switch` over `RollPart`, and two `@ts-expect-error` lines all fail when imports degrade to `any`, which is exactly what a failed resolution produces.

Three CI jobs: `ts-compat` (matrix over 5.0, 5.4, 5.9, 6.x, 7.x, consuming the tarball `build` already packs), `ts-compat-floor` (runs the fixture on 4.9 and requires the failure to carry `TS2792` and `TS2344`, so an unrelated break cannot pass for a floor proof), and `ts-compat-gate` (stable fan-in for branch protection, matching `node-smoke-gate`).

Verified locally against a freshly packed tarball: 4.9.5 fails under `bundler` with `TS2792`, `TS2344` on all five guards, and `TS2578` on both expect-errors; 5.0.4, 5.4.5, 5.9.3, 6.0.3, and 7.0.2 all pass under both resolution modes. `bun validate` is unaffected — the fixture is deliberately not a root workspace, is outside every root `tsconfig` include, and is not packed.

Follow-up, not in this PR: `TypeScript Compat` needs adding to the `protect-master` required checks.

Closes #221
