### PR TITLE
test: execute bash CLI fences in readme.test.ts #223

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 
 ## Install
 
+<!-- readme-test: skip -->
+
 ```bash
 npm install roll-parser
 ```
@@ -707,6 +709,8 @@ in CI by `@arethetypeswrong/cli` and `publint`.
 
 ## CLI
 
+<!-- readme-test: skip -->
+
 ```bash
 npx roll-parser 2d6+3
 ```
@@ -738,8 +742,8 @@ Error: Invalid dice sides: 0
   2d6+1d0+3
       ^
 
-$ roll-parser -- -1d6+3
-1
+$ roll-parser --seed demo -- -1d6+3
+2
 ```
 
 Verbose mode rewrites the markdown markers for plain terminals: `~~n~~` becomes

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -1,12 +1,15 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
+import { main } from './cli/main.js';
 import { ensureFreshDist } from './test-helpers.js';
 
 /**
- * Executes the `typescript` fenced blocks in README.md and MIGRATION.md
- * against the built package and asserts the outputs their comments claim,
- * so a doc edit that falsifies an example fails the suite.
+ * Executes the fenced examples in README.md and MIGRATION.md and asserts the
+ * outputs they claim, so a doc edit that falsifies an example fails the suite.
+ * Both fence languages are covered — `typescript` blocks run against the built
+ * package, `bash` blocks run the CLI in-process — so neither is an unchecked
+ * place to park a stale value.
  *
- * The per-line convention:
+ * The per-line convention for `typescript` blocks:
  * - `expr; // <literal>` — evaluate `expr` and compare. Prose after ` — ` or
  *   a comma is ignored: `// 14, every run` asserts `14`.
  * - `expr; // throws …` — assert the line throws; when the comment quotes a
@@ -20,7 +23,15 @@ import { ensureFreshDist } from './test-helpers.js';
  * stripped, and every public export plus the free variables some samples
  * lean on (`userInput`, `notation`, `error`) is provided as a binding.
  * A `<!-- readme-test: skip -->` HTML comment directly above a fence opts a
- * block out — used for MIGRATION.md blocks that show the removed v2 API.
+ * block out — used for MIGRATION.md blocks that show the removed v2 API and
+ * for `bash` fences that are not CLI sessions (install lines, `npx`).
+ *
+ * `bash` blocks are shell transcripts: every non-blank line is either a
+ * `$ roll-parser …` command or part of the previous command's output, and the
+ * output is compared against stdout and stderr in write order. A command must
+ * be deterministic to be documented — `--seed`, `--help`/`--version`, or an
+ * `Error:` diagnostic — and a trailing `...` in the expected output makes the
+ * comparison a prefix match, which is how the long `--json` payload is shown.
  */
 
 //
@@ -30,8 +41,13 @@ import { ensureFreshDist } from './test-helpers.js';
 const DOC_FILES = ['README.md', 'MIGRATION.md'];
 const SKIP_MARKER = '<!-- readme-test: skip -->';
 
+// Every shell spelling is covered, so a fence cannot dodge execution by relabelling.
+const FENCE_RE = /^```(typescript|ts|bash|sh|shell|console)\s*$/;
+const TS_LANGS = new Set(['typescript', 'ts']);
+
 type DocBlock = {
   file: string;
+  lang: 'typescript' | 'bash';
   /** 1-based line of the opening fence. */
   fenceLine: number;
   lines: string[];
@@ -43,7 +59,8 @@ function extractBlocks(file: string, text: string): DocBlock[] {
   const blocks: DocBlock[] = [];
 
   for (let i = 0; i < lines.length; i++) {
-    if (!/^```(?:typescript|ts)\s*$/.test(lines[i] ?? '')) {
+    const fence = (lines[i] ?? '').match(FENCE_RE);
+    if (!fence) {
       continue;
     }
 
@@ -59,6 +76,7 @@ function extractBlocks(file: string, text: string): DocBlock[] {
 
     blocks.push({
       file,
+      lang: TS_LANGS.has(fence[1] ?? '') ? 'typescript' : 'bash',
       fenceLine: i + 1,
       lines: lines.slice(i + 1, end),
       skip: (lines[above] ?? '').trim() === SKIP_MARKER,
@@ -336,25 +354,200 @@ async function runBlock(compiled: CompiledBlock): Promise<void> {
 }
 
 //
+// * CLI session fences
+//
+
+const CLI_BIN = 'roll-parser';
+const PROMPT_RE = /^\$\s+(\S.*?)\s*$/;
+// ! A documented output may be cut short (`…,"rendered":"…",...}`). The separator
+// ! before `...` stays in the prefix — without it, `{"total":7` matches a total of 70.
+const TRUNCATION_RE = /\s*\.\.\.\}?$/;
+const SEED_RE = /^--seed(=|$)/;
+const INFORMATIONAL = new Set(['-h', '--help', '--version']);
+
+type CliCase = {
+  file: string;
+  /** 1-based line of the `$ ` command line. */
+  line: number;
+  command: string;
+  argv: string[];
+  expected: string;
+  /** The documented output ends in `...`, so only its prefix is asserted. */
+  truncated: boolean;
+};
+
+/** Splits a documented command the way a shell would, handling both quote styles. */
+function tokenize(command: string, where: string): string[] {
+  const tokens: string[] = [];
+  let current: string | null = null;
+  let quote: "'" | '"' | null = null;
+
+  for (const char of command) {
+    // Escape rules differ per quote context; refuse rather than mis-split silently.
+    if (char === '\\') {
+      throw new Error(`${where} — backslash escapes are not supported in a documented command`);
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current = (current ?? '') + char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      current ??= '';
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current != null) {
+        tokens.push(current);
+        current = null;
+      }
+      continue;
+    }
+    current = (current ?? '') + char;
+  }
+
+  if (quote) {
+    throw new Error(`${where} — unterminated ${quote} in a documented command`);
+  }
+  if (current != null) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+/**
+ * Only a reproducible invocation can have its output pinned in the docs. A seed
+ * makes the roll deterministic; `--help`/`--version` and error paths never draw
+ * from the RNG. Options after `--` are notation, so they do not count.
+ */
+function isDeterministic(argv: string[], expected: string): boolean {
+  const end = argv.indexOf('--');
+  const options = argv.slice(0, end === -1 ? undefined : end);
+  return (
+    options.some((arg) => SEED_RE.test(arg)) ||
+    options.some((arg) => INFORMATIONAL.has(arg)) ||
+    expected.startsWith('Error:')
+  );
+}
+
+function parseCliSession(block: DocBlock): CliCase[] {
+  const cases: CliCase[] = [];
+
+  for (let i = 0; i < block.lines.length; i++) {
+    const line = block.lines[i] ?? '';
+    const lineNo = block.fenceLine + 1 + i;
+    if (line.trim() === '') {
+      continue;
+    }
+
+    const prompt = line.match(PROMPT_RE);
+    if (!prompt) {
+      throw new Error(
+        `${block.file}:${lineNo} — a bash fence must be a '$ ' shell transcript; put ${SKIP_MARKER} above the fence when it is not runnable`,
+      );
+    }
+
+    const command = prompt[1] ?? '';
+    const argv = tokenize(command, `${block.file}:${lineNo}`);
+    if (argv[0] !== CLI_BIN) {
+      throw new Error(
+        `${block.file}:${lineNo} — only '${CLI_BIN}' invocations can be executed, got '${argv[0] ?? ''}'`,
+      );
+    }
+
+    // Output runs to the next prompt, blank lines included — `--help` has them.
+    const output: string[] = [];
+    while (i + 1 < block.lines.length && !PROMPT_RE.test(block.lines[i + 1] ?? '')) {
+      output.push(block.lines[i + 1] ?? '');
+      i++;
+    }
+    while (output.length > 0 && (output.at(-1) ?? '').trim() === '') {
+      output.pop();
+    }
+
+    const expected = output.join('\n');
+    if (!isDeterministic(argv.slice(1), expected)) {
+      throw new Error(
+        `${block.file}:${lineNo} documents an output that is not provably reproducible\n  $ ${command}\n  add --seed, or drop the output lines`,
+      );
+    }
+
+    cases.push({
+      file: block.file,
+      line: lineNo,
+      command,
+      argv: argv.slice(1),
+      expected: expected.replace(TRUNCATION_RE, ''),
+      truncated: TRUNCATION_RE.test(expected),
+    });
+  }
+
+  return cases;
+}
+
+function runCliCase(entry: CliCase): void {
+  let actual = '';
+  const write = (text: string): void => {
+    actual += text;
+  };
+  const exitCode = main({ argv: entry.argv, stdout: write, stderr: write });
+
+  // Without this the README's exit-code table stays entirely unchecked.
+  const diagnostic = entry.expected.startsWith('Error:');
+  if (diagnostic !== (exitCode !== 0)) {
+    throw new Error(
+      `${entry.file}:${entry.line} documents ${diagnostic ? 'an error' : 'a success'} but the CLI exited ${exitCode}\n  $ ${entry.command}`,
+    );
+  }
+
+  const trimmed = actual.replace(/\n$/, '');
+  const matches = entry.truncated ? trimmed.startsWith(entry.expected) : trimmed === entry.expected;
+  if (!matches) {
+    throw new Error(
+      `${entry.file}:${entry.line} documents an output the CLI does not produce\n` +
+        `  $ ${entry.command}\n` +
+        `  expected${entry.truncated ? ' prefix' : ''}: ${JSON.stringify(entry.expected)}\n` +
+        `  actual:   ${JSON.stringify(trimmed)}`,
+    );
+  }
+}
+
+//
 // * Test registration
 //
 
-const corpus: { file: string; compiled: CompiledBlock[]; skipped: DocBlock[] }[] = [];
+const corpus: {
+  file: string;
+  compiled: CompiledBlock[];
+  cliCases: CliCase[];
+  skipped: DocBlock[];
+}[] = [];
 for (const file of DOC_FILES) {
   const text = await Bun.file(new URL(`../${file}`, import.meta.url)).text();
   const blocks = extractBlocks(file, text);
+  const live = blocks.filter((block) => !block.skip);
   corpus.push({
     file,
-    compiled: blocks.filter((block) => !block.skip).map(compileBlock),
+    compiled: live.filter((block) => block.lang === 'typescript').map(compileBlock),
+    cliCases: live.filter((block) => block.lang === 'bash').flatMap(parseCliSession),
     skipped: blocks.filter((block) => block.skip),
   });
 }
 
-for (const { file, compiled, skipped } of corpus) {
+for (const { file, compiled, cliCases, skipped } of corpus) {
   describe(`${file} examples`, () => {
     for (const entry of compiled) {
       test(`block at line ${entry.block.fenceLine}`, async () => {
         await runBlock(entry);
+      });
+    }
+    for (const entry of cliCases) {
+      test(`$ ${entry.command} (line ${entry.line})`, () => {
+        runCliCase(entry);
       });
     }
     for (const block of skipped) {
@@ -367,10 +560,12 @@ describe('doc example corpus', () => {
   test('extraction still finds the fenced blocks', () => {
     const blocks = corpus.flatMap((entry) => entry.compiled);
     const assertions = blocks.reduce((sum, entry) => sum + entry.cases.length, 0);
+    const cliCases = corpus.flatMap((entry) => entry.cliCases);
     // Floors, not exact counts — they catch a fence-language or convention
     // change that silently stops extraction, without rotting on every edit.
     expect(blocks.length).toBeGreaterThanOrEqual(12);
     expect(assertions).toBeGreaterThanOrEqual(15);
+    expect(cliCases.length).toBeGreaterThanOrEqual(5);
   });
 
   // No doc block currently mixes both assertion kinds, so nothing else pins the
@@ -380,7 +575,13 @@ describe('doc example corpus', () => {
     const OVER_LIMIT = "roll('99999d6', { maxDice: 100 }); // throws, code 'DICE_LIMIT_EXCEEDED'";
     const PLAIN_POOL = "roll('2d6', { rng: createMockRng([2, 6]) }).total; // 8";
     const compile = (blockLines: string[]): CompiledBlock =>
-      compileBlock({ file: 'synthetic.md', fenceLine: 10, lines: blockLines, skip: false });
+      compileBlock({
+        file: 'synthetic.md',
+        lang: 'typescript',
+        fenceLine: 10,
+        lines: blockLines,
+        skip: false,
+      });
 
     test('keeps every case aligned with its documented line', async () => {
       const compiled = compile([KEEP_HIGHEST, OVER_LIMIT, PLAIN_POOL]);
@@ -396,6 +597,95 @@ describe('doc example corpus', () => {
       const falsified = [KEEP_HIGHEST, OVER_LIMIT, PLAIN_POOL.replace('// 8', '// 9')];
       await expect(runBlock(compile(falsified))).rejects.toThrow(
         /synthetic\.md:13 documents an output the code does not produce/,
+      );
+    });
+  });
+
+  describe('a bash fence', () => {
+    const session = (blockLines: string[]): CliCase[] =>
+      parseCliSession({
+        file: 'synthetic.md',
+        lang: 'bash',
+        fenceLine: 10,
+        lines: blockLines,
+        skip: false,
+      });
+
+    test('pairs each command with the output lines that follow it', () => {
+      const cases = session([
+        '$ roll-parser "1d20+7 vs 15" --seed demo',
+        '8 vs 15 = Critical Failure',
+        '',
+        '$ roll-parser --version',
+        '9.9.9',
+      ]);
+      expect(cases.map((entry) => ({ line: entry.line, argv: entry.argv }))).toEqual([
+        { line: 11, argv: ['1d20+7 vs 15', '--seed', 'demo'] },
+        { line: 14, argv: ['--version'] },
+      ]);
+      expect(cases[0]?.expected).toBe('8 vs 15 = Critical Failure');
+    });
+
+    test('asserts only the prefix of an output cut short with `...`', () => {
+      const [entry] = session(['$ roll-parser 2d6 --json --seed demo', '{"total":7,...}']);
+      // The comma stays in the prefix, so a total of 70 cannot satisfy it.
+      expect(entry).toMatchObject({ expected: '{"total":7,', truncated: true });
+    });
+
+    test('keeps the blank lines inside a multi-line output', () => {
+      const [entry] = session(['$ roll-parser --help', 'roll-parser v1.0.0', '', 'Usage: …', '']);
+      expect(entry?.expected).toBe('roll-parser v1.0.0\n\nUsage: …');
+    });
+
+    test('reports a documented output the CLI does not produce', () => {
+      const [entry] = session(['$ roll-parser 2d6+3 --seed demo', '11']);
+      expect(entry).toBeDefined();
+      expect(() => {
+        runCliCase(entry as CliCase);
+      }).toThrow(/synthetic\.md:11 documents an output the CLI does not produce/);
+    });
+
+    test('rejects a line that is neither a command nor its output', () => {
+      expect(() => session(['npm install roll-parser'])).toThrow(
+        /synthetic\.md:11 — a bash fence must be a '\$ ' shell transcript/,
+      );
+    });
+
+    test('rejects a command that is not the project CLI', () => {
+      expect(() => session(['$ npx roll-parser 2d6+3'])).toThrow(
+        /only 'roll-parser' invocations can be executed, got 'npx'/,
+      );
+    });
+
+    test('rejects a documented output that is not provably reproducible', () => {
+      expect(() => session(['$ roll-parser 1d6', '4'])).toThrow(
+        /documents an output that is not provably reproducible/,
+      );
+      expect(() => session(['$ roll-parser -- -1d6+3 --seed demo', '1'])).toThrow(
+        /documents an output that is not provably reproducible/,
+      );
+    });
+
+    test('accepts an unseeded command whose output is a diagnostic', () => {
+      const cases = session(['$ roll-parser 1d0', 'Error: Invalid dice sides: 0', '  1d0', '  ^']);
+      expect(cases).toHaveLength(1);
+      runCliCase(cases[0] as CliCase);
+    });
+
+    test('reports an output whose exit code contradicts it', () => {
+      const [entry] = session(['$ roll-parser --version', 'Error: not a real failure']);
+      expect(entry).toBeDefined();
+      expect(() => {
+        runCliCase(entry as CliCase);
+      }).toThrow(/synthetic\.md:11 documents an error but the CLI exited 0/);
+    });
+
+    test('rejects a command it cannot split the way a shell would', () => {
+      expect(() => session(['$ roll-parser "2d6+3'])).toThrow(
+        /synthetic\.md:11 — unterminated " in a documented command/,
+      );
+      expect(() => session(['$ roll-parser "2d6 \\"+3"'])).toThrow(
+        /backslash escapes are not supported/,
       );
     });
   });


### PR DESCRIPTION
`bash` fences in `README.md` and `MIGRATION.md` are now part of the doc-example
corpus: each is parsed as a `$ roll-parser …` shell transcript and executed
through `main()` in-process, with the fence text asserted against stdout and
stderr in write order.

- Determinism gate — a documented command must carry `--seed`, be
  `--help`/`--version`, or produce an `Error:` diagnostic
- `...` truncation convention for the long `--json` payload, keeping the
  separator in the asserted prefix
- Exit codes asserted, so the README's exit-code table is covered
- Fence allowlist widened to `sh`/`shell`/`console` so a relabelled fence cannot
  dodge execution
- Tokenizer rejects unterminated quotes and backslash escapes instead of
  mis-splitting silently
- Install and `npx` fences opted out with the existing `readme-test: skip`
  marker; the `-- -1d6+3` example is now seeded

Closes #223
