### PR TITLE
fix: reject non-string notation with a typed error #229

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,16 @@ try {
 }
 ```
 
+That filter is complete for untrusted input, including input that is not a
+string at all. `notation` is typed `string`, but the APIs that produce it hand
+you `string | null` — an absent slash-command option, a missing JSON field — so
+a non-string is checked at the boundary and reported as `INVALID_NOTATION_TYPE`
+rather than escaping as a bare `TypeError`:
+
+```typescript
+roll(null as unknown as string); // throws, code 'INVALID_NOTATION_TYPE'
+```
+
 ### Error classes
 
 | Class | Stage | Extra fields |
@@ -627,7 +637,7 @@ or read it uniformly through `getErrorSpan`.
 
 ### Error codes
 
-`RollParserErrorCode` is a union of 31 codes today — match on the code, not the
+`RollParserErrorCode` is a union of 33 codes today — match on the code, not the
 message, and give the `switch` a `default` arm: new codes arrive in minor
 releases (never patches), so an exhaustive switch would turn a minor upgrade
 into a silent fall-through. See [Versioning](#versioning) for the full policy.

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -7,7 +7,13 @@
 
 import { describe, expect, test } from 'bun:test';
 import type { RollParserErrorCode } from './errors.js';
-import { EvaluatorError, getErrorSpan, isRollParserError, RollParserError } from './errors.js';
+import {
+  EvaluatorError,
+  getErrorSpan,
+  isRollParserError,
+  ROLL_PARSER_ERROR_CODES,
+  RollParserError,
+} from './errors.js';
 import { evaluate } from './evaluator/evaluator.js';
 import { LexerError, lex } from './lexer/lexer.js';
 import type { ASTNode } from './parser/ast.js';
@@ -243,9 +249,21 @@ const CODE_CASES: Record<RollParserErrorCode, CodeCase> = {
     why: 'restoring a snapshot is an RNG operation, not a notation one',
   },
   INVALID_EVALUATION_LIMIT: { notation: '1d6', options: { maxDice: 0 } },
+  INVALID_NOTATION_TYPE: {
+    call: () => roll(null as unknown as string),
+    why: 'the case is a non-string notation, which the `notation` field cannot express',
+  },
 };
 
 describe('error code contract', () => {
+  test('README quotes the current code count', async () => {
+    // Prose, so `readme.test.ts` never executes it — nothing else catches the drift.
+    const readme = await Bun.file(new URL('../README.md', import.meta.url)).text();
+    const quoted = readme.match(/union of (\d+) codes/)?.[1];
+
+    expect(quoted).toBe(String(ROLL_PARSER_ERROR_CODES.length));
+  });
+
   for (const [code, testCase] of Object.entries(CODE_CASES) as [RollParserErrorCode, CodeCase][]) {
     test(`${code} is raised and typed`, () => {
       const error = captureError(() => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -57,6 +57,7 @@ export const ROLL_PARSER_ERROR_CODES = [
   'NON_FINITE_RESULT',
   'INCOMPATIBLE_RNG_STATE',
   'INVALID_EVALUATION_LIMIT',
+  'INVALID_NOTATION_TYPE',
 ] as const;
 
 /**
@@ -82,6 +83,9 @@ export const ROLL_PARSER_ERROR_CODES = [
  *
  * Options: `INVALID_EVALUATION_LIMIT` — raised before evaluation begins, from
  * the options object rather than from the notation, so it carries no span.
+ *
+ * Input: `INVALID_NOTATION_TYPE` — raised before lexing, when `notation` is not
+ * a string, so it carries no span either.
  *
  * New codes are only ever introduced in a minor release, never a patch. Treat
  * the union as open when you switch over it: give the switch a `default` arm
@@ -275,6 +279,23 @@ export function isRollParserError(value: unknown): value is RollParserError {
   if (!(value instanceof Error) || !('code' in value)) return false;
   const { code } = value;
   return typeof code === 'string' && VALID_CODES.has(code);
+}
+
+/**
+ * Renders a rejected value for an error message, never coercing an object:
+ * `String(Object.create(null))` throws, and a hostile `toString` can too —
+ * either would replace the typed error with a raw `TypeError`.
+ *
+ * Module-level export, deliberately absent from `src/index.ts` — the package
+ * surface never mentions it.
+ */
+export function describeValue(value: unknown): string {
+  // Quoted, so the message tells `'5'` and `5` apart.
+  if (typeof value === 'string') return JSON.stringify(value);
+  // Ahead of the `typeof` checks: `typeof null` is `'object'`.
+  if (value === null) return 'null';
+  if (typeof value === 'object' || typeof value === 'function') return typeof value;
+  return String(value);
 }
 
 /** True for finite, non-negative integer offsets. */

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -4,7 +4,7 @@
  * @module evaluator/evaluator
  */
 
-import { EvaluatorError, RollParserError } from '../errors.js';
+import { describeValue, EvaluatorError, RollParserError } from '../errors.js';
 import type {
   ASTNode,
   BinaryOpNode,
@@ -106,23 +106,11 @@ function resolveLimit(
   if (value == null) return fallback;
   if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < min) {
     throw new RollParserError(
-      `Option '${option}' must be an integer >= ${min}, received ${describeLimit(value)}`,
+      `Option '${option}' must be an integer >= ${min}, received ${describeValue(value)}`,
       'INVALID_EVALUATION_LIMIT',
     );
   }
   return value;
-}
-
-/**
- * Renders a rejected limit for the error message, never coercing an object:
- * `String(Object.create(null))` throws, and a hostile `toString` can too —
- * either would replace the typed error with a raw `TypeError`.
- */
-function describeLimit(value: unknown): string {
-  // Quoted, so the message tells `'5'` and `5` apart.
-  if (typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'object' || typeof value === 'function') return typeof value;
-  return String(value);
 }
 
 export { DEFAULT_MAX_EXPLODE_ITERATIONS, DEFAULT_MAX_REROLL_ITERATIONS };

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, test } from 'bun:test';
 import { RollParserError } from './errors.js';
 import { EvaluatorError } from './evaluator/evaluator.js';
-import { ParseError } from './parser/parser.js';
+import { ParseError, parse } from './parser/parser.js';
 import { createMockRng } from './rng/mock.js';
 import { roll } from './roll.js';
 import { expectRollError } from './test-helpers.js';
@@ -310,6 +310,27 @@ describe('roll() integration', () => {
 
     test('floating point dice sides throws EvaluatorError', () => {
       expect(() => roll('1d(6.5)')).toThrow(EvaluatorError);
+    });
+
+    test('rejects a non-string notation before rolling (#229)', () => {
+      // `string | null` is what a slash-command option or a parsed JSON field hands over.
+      for (const input of [null, undefined, 42]) {
+        const error = expectRollError(
+          () => roll(input as unknown as string),
+          RollParserError,
+          'INVALID_NOTATION_TYPE',
+        );
+
+        expect(error.name).toBe('RollParserError');
+      }
+    });
+
+    test('rejects a non-string notation from parse() too (#229)', () => {
+      expectRollError(
+        () => parse(null as unknown as string),
+        RollParserError,
+        'INVALID_NOTATION_TYPE',
+      );
     });
   });
 

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { getErrorSpan, isRollParserError, RollParserError } from '../errors.js';
 import { expectRollError } from '../test-helpers.js';
 import { Lexer, LexerError, lex } from './lexer.js';
 import { TokenType } from './tokens.js';
@@ -908,6 +909,47 @@ describe('Lexer', () => {
 
       expect(error.message).toContain('Empty @ variable name');
       expect(error.position).toBe(0);
+    });
+  });
+
+  describe('non-string input', () => {
+    // The signature says `string`; the APIs feeding untrusted notation say `string | null`.
+    const cases: [label: string, input: unknown, received: string][] = [
+      ['null', null, 'null'],
+      ['undefined', undefined, 'undefined'],
+      ['a number', 42, '42'],
+      ['a plain object', {}, 'object'],
+      ['an array', ['1d6'], 'object'],
+      ['a function', () => '1d6', 'function'],
+      ['a String wrapper', new String('1d6'), 'object'],
+    ];
+
+    for (const [label, input, received] of cases) {
+      it(`rejects ${label} with a typed error (#229)`, () => {
+        const error = expectRollError(
+          () => lex(input as string),
+          RollParserError,
+          'INVALID_NOTATION_TYPE',
+        );
+
+        expect(error.message).toBe(`Notation must be a string, received ${received}`);
+        expect(isRollParserError(error)).toBe(true);
+        expect(getErrorSpan(error)).toBeUndefined();
+      });
+    }
+
+    it('rejects an object with a hostile toString (#229)', () => {
+      const hostile = {
+        toString() {
+          throw new Error('nope');
+        },
+      };
+
+      expectRollError(
+        () => lex(hostile as unknown as string),
+        RollParserError,
+        'INVALID_NOTATION_TYPE',
+      );
     });
   });
 

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -5,7 +5,7 @@
  */
 
 import type { RollParserErrorCode } from '../errors.js';
-import { RollParserError } from '../errors.js';
+import { describeValue, RollParserError } from '../errors.js';
 import { type Token, TokenType } from './tokens.js';
 
 /**
@@ -416,6 +416,8 @@ export class Lexer {
  * @returns Every token in source order, always ending with one
  *   `TokenType.EOF` token
  * @throws {LexerError} If an invalid character or unknown identifier is found
+ * @throws {RollParserError} `INVALID_NOTATION_TYPE` when `input` is not a
+ *   string — raised before scanning, so it carries no position
  *
  * @example
  * ```typescript
@@ -431,5 +433,13 @@ export class Lexer {
  * @category Core
  */
 export function lex(input: string): Token[] {
+  // ! The pipeline's only notation type guard — `parse` and `roll` both funnel through here.
+  if (typeof input !== 'string') {
+    throw new RollParserError(
+      `Notation must be a string, received ${describeValue(input)}`,
+      'INVALID_NOTATION_TYPE',
+    );
+  }
+
   return new Lexer(input).tokenize();
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1290,6 +1290,8 @@ export class Parser {
  * @returns The root AST node, with `start`/`end` spans on every node
  * @throws {LexerError} If the input contains invalid characters
  * @throws {ParseError} If the input has invalid syntax
+ * @throws {RollParserError} `INVALID_NOTATION_TYPE` when `notation` is not a
+ *   string — raised before lexing, so it carries no position
  *
  * @example
  * ```typescript

--- a/src/roll.ts
+++ b/src/roll.ts
@@ -56,6 +56,8 @@ export type RollOptions = EvaluationOptions & {
  * @throws {EvaluatorError} On a limit breach or an impossible expression
  * @throws {RollParserError} `INVALID_EVALUATION_LIMIT` when a supplied limit is
  *   not an integer in range — raised before any die is rolled
+ * @throws {RollParserError} `INVALID_NOTATION_TYPE` when `notation` is not a
+ *   string, so `isRollParserError` still filters untrusted input completely
  *
  * @example
  * ```typescript


### PR DESCRIPTION
`roll`, `parse`, and `lex` did no runtime type check on `notation`, so a non-string failed downstream as a bare `TypeError` with no `code` — which `isRollParserError` rejects, making the documented catch pattern rethrow routine bad input as a library bug.

- Added `INVALID_NOTATION_TYPE`, raised from `lex` as a base `RollParserError` before scanning, so it carries no span
- Guarded in `lex` alone — `parse` and `roll` both funnel through it, so per-entry guards would be dead duplicates
- Lifted `describeLimit` into `errors.ts` as the shared `describeValue`, with a `null` branch ahead of the `typeof` checks
- Documented the code on `roll`, `parse`, `lex` and in the README error-handling section
- Corrected the README code count, which had already drifted to 31 against an actual 32, and added a drift test

New error code, so this ships in a minor.

Closes #229
