### PR TITLE
refactor: seal stampSpan and fix the error-contract docs #232

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,10 @@ throws a typed `MAX_DEPTH_EXCEEDED` instead of blowing the stack, which keeps
 
 ## Error handling
 
-Every failure extends `RollParserError` and carries a stable `code`. Use
+Every failure raised by lexing, parsing, evaluation, or options validation
+extends `RollParserError` and carries a stable `code`. Two failures do not, and
+both need an injected mock to occur — see [Errors outside the
+hierarchy](#errors-outside-the-hierarchy). Use
 `isRollParserError` as the outer filter — anything it rejects came from
 somewhere else, so rethrow it. What it does *not* tell you is whose fault the
 failure was: it answers `true` for bad notation, for a bad options object, and
@@ -649,6 +652,29 @@ try {
   post({ ok: false, code: error.code, message: error.message });
 }
 ```
+
+### Errors outside the hierarchy
+
+Two failures can surface from `roll()` without extending `RollParserError` or
+carrying a `code`, and both come from `roll-parser/testing`:
+
+| Thrown | When |
+|--------|------|
+| `MockRNGExhaustedError` | a `createMockRng` sequence runs out of values mid-roll |
+| `RangeError` | a scripted value falls outside the `[min, max]` a die asked for |
+
+Neither is reachable unless you passed `{ rng: createMockRng(...) }` yourself, so
+the filter stays complete for untrusted notation — this is a miscounted test
+fixture, not a runtime failure mode, and it is deliberately left un-branded so it
+cannot be mistaken for one. `isRollParserError` returns `false` for both, which
+means the `if (!isRollParserError(error)) throw error` line above already does
+the right thing: the exhausted mock propagates to your test runner and fails the
+test, rather than being swallowed by a `catch` written for bad dice notation.
+
+Nothing else in the library documents `instanceof` as the check — for these two
+it is the only option, and `MockRNGExhaustedError` exposes `consumed` to tell you
+how many draws the sequence supplied before it ran dry. See
+[Testing](#testing) for the worked example.
 
 ### Notation errors
 

--- a/src/cli/package-smoke.test.ts
+++ b/src/cli/package-smoke.test.ts
@@ -91,10 +91,18 @@ describe('two-pass emit', () => {
     const declaration = await Bun.file('./dist/errors.d.ts').text();
 
     expect(declaration).not.toContain('@internal');
-    expect(declaration).not.toContain('stampSpan');
+    expect(declaration).not.toContain('stampEvaluatorSpan');
 
     // Stripping must be surgical — the public accessors over the span survive.
     expect(declaration).toContain('get start()');
     expect(declaration).toContain('get end()');
+  });
+
+  // ! `stripInternal` only reaches the declaration it annotates. A re-export from
+  // ! `index.ts` would carry no `@internal` of its own and reopen the span setter.
+  test('keeps the span setter out of the entry point (#232)', async () => {
+    for (const entry of ['./dist/index.d.ts', './dist/index.js']) {
+      expect(await Bun.file(entry).text()).not.toContain('stampEvaluatorSpan');
+    }
   });
 });

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -15,12 +15,13 @@ import {
   NOTATION_ERROR_CODES,
   ROLL_PARSER_ERROR_CODES,
   RollParserError,
+  stampEvaluatorSpan,
 } from './errors.js';
 import { evaluate } from './evaluator/evaluator.js';
 import { LexerError, lex } from './lexer/lexer.js';
 import type { ASTNode } from './parser/ast.js';
 import { MAX_PARSE_DEPTH, ParseError, parse } from './parser/parser.js';
-import { createMockRng } from './rng/mock.js';
+import { createMockRng, MockRNGExhaustedError } from './rng/mock.js';
 import { SeededRNG } from './rng/seeded.js';
 import type { RollOptions } from './roll.js';
 import { roll } from './roll.js';
@@ -242,11 +243,55 @@ describe('EvaluatorError span', () => {
   test('the innermost stamp wins', () => {
     const error = new EvaluatorError('boom', 'DIVISION_BY_ZERO', 'BinaryOp');
 
-    error.stampSpan(4, 7);
-    error.stampSpan(0, 9);
+    stampEvaluatorSpan(error, 4, 7);
+    stampEvaluatorSpan(error, 0, 9);
 
     expect(error.start).toBe(4);
     expect(error.end).toBe(7);
+  });
+
+  test('an undefined end stamps alongside the start', () => {
+    const error = new EvaluatorError('boom', 'DIVISION_BY_ZERO', 'BinaryOp');
+
+    stampEvaluatorSpan(error, 4, undefined);
+
+    expect(error.start).toBe(4);
+    expect(error.end).toBeUndefined();
+  });
+
+  test('a start of 0 still blocks a re-stamp', () => {
+    const error = new EvaluatorError('boom', 'DIVISION_BY_ZERO', 'BinaryOp');
+
+    stampEvaluatorSpan(error, 0, 3);
+    stampEvaluatorSpan(error, 5, 9);
+
+    expect(error.start).toBe(0);
+    expect(error.end).toBe(3);
+  });
+
+  test('the stamping method is not on the class (#232)', () => {
+    const error = new EvaluatorError('boom', 'DIVISION_BY_ZERO', 'BinaryOp');
+
+    expect('stampSpan' in error).toBe(false);
+    expect(Object.getOwnPropertySymbols(EvaluatorError.prototype)).toEqual([]);
+  });
+});
+
+describe('errors outside the hierarchy (#232)', () => {
+  test('MockRNGExhaustedError carries no code and is not ours', () => {
+    const error = captureError(() => roll('4d6', { rng: createMockRng([1, 2, 3]) }));
+
+    expect(error).toBeInstanceOf(MockRNGExhaustedError);
+    expect(error).not.toBeInstanceOf(RollParserError);
+    expect(isRollParserError(error)).toBe(false);
+    expect(error).not.toHaveProperty('code');
+  });
+
+  test('an out-of-range scripted value escapes as a bare RangeError', () => {
+    const error = captureError(() => roll('1d6', { rng: createMockRng([7]) }));
+
+    expect(error).toBeInstanceOf(RangeError);
+    expect(isRollParserError(error)).toBe(false);
   });
 });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -259,6 +259,24 @@ export class RollParserError extends Error {
 }
 
 /**
+ * Records the source span of the node being evaluated on an
+ * {@link EvaluatorError}. Idempotent — the first stamp wins, so the innermost
+ * `evalNode` frame keeps the tightest span as the error bubbles up.
+ *
+ * @internal Called only by `evalNode`; `stripInternal` drops it from the
+ * published `.d.ts`.
+ */
+// ! A module-scoped function, not a method: `EvaluatorError` is exported, so a
+// ! method would let any consumer overwrite a caught error's span. Assigned from
+// ! the `static` block below — the only scope `#start` / `#end` are reachable
+// ! from — and never re-exported from `index.ts`.
+export let stampEvaluatorSpan!: (
+  error: EvaluatorError,
+  start: number,
+  end: number | undefined,
+) => void;
+
+/**
  * Error thrown during AST evaluation.
  *
  * Lives here rather than in `evaluator/evaluator.ts` so the modifier
@@ -319,18 +337,12 @@ export class EvaluatorError extends RollParserError {
     return this.#end;
   }
 
-  /**
-   * Records the source span of the node being evaluated. Idempotent — the
-   * first stamp wins, so the innermost `evalNode` frame keeps the tightest
-   * span as the error bubbles up.
-   *
-   * @internal Called only by `evalNode`; `stripInternal` drops it from the
-   * published `.d.ts`.
-   */
-  stampSpan(start: number, end: number | undefined): void {
-    if (this.#start != null) return;
-    this.#start = start;
-    this.#end = end;
+  static {
+    stampEvaluatorSpan = (error, start, end) => {
+      if (error.#start != null) return;
+      error.#start = start;
+      error.#end = end;
+    };
   }
 }
 

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -4,7 +4,7 @@
  * @module evaluator/evaluator
  */
 
-import { describeValue, EvaluatorError, RollParserError } from '../errors.js';
+import { describeValue, EvaluatorError, RollParserError, stampEvaluatorSpan } from '../errors.js';
 import type {
   ASTNode,
   BinaryOpNode,
@@ -279,7 +279,7 @@ function evalNode(node: ASTNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eval
     return evalNodeInner(node, rng, ctx, env);
   } catch (error) {
     if (error instanceof EvaluatorError && node.start != null) {
-      error.stampSpan(node.start, node.end);
+      stampEvaluatorSpan(error, node.start, node.end);
     }
     throw error;
   }

--- a/src/rng/mock.ts
+++ b/src/rng/mock.ts
@@ -15,6 +15,13 @@ import type { RNG } from './types.js';
  * sequence supplied — count the dice, including explosions, rerolls, and
  * meta-expressions, and check the draw order in the roll-parser README.
  *
+ * Deliberately outside the `RollParserError` hierarchy — no `code`, and
+ * `isRollParserError` answers `false` for it. An exhausted mock is a bug in the
+ * test fixture, not a failure mode of the notation, so the
+ * `if (!isRollParserError(error)) throw error` line a consumer writes around
+ * `roll()` rethrows it and fails the test instead of routing it to a "bad dice"
+ * message. `instanceof` is the check here — there is no `code` to branch on.
+ *
  * @example
  * ```typescript
  * import { roll } from 'roll-parser';
@@ -57,6 +64,10 @@ export class MockRNGExhaustedError extends Error {
  * - It never wraps around. Running out throws {@link MockRNGExhaustedError}.
  * - `nextInt` rejects a scripted value outside the requested `[min, max]`
  *   with a `RangeError`, so `createMockRng([7])` cannot satisfy a `d6`.
+ *
+ * Both are the only failures that reach a caller of `roll()` without a
+ * roll-parser `code`, and only ever when a mock was injected — see
+ * {@link MockRNGExhaustedError} for why they stay outside the hierarchy.
  *
  * Draw order matters when the notation contains meta-expressions. Keep/drop
  * counts (`4d6kh(1d2)`) are drawn *before* the pool; threshold expressions


### PR DESCRIPTION
Sealed `EvaluatorError.stampSpan` behind a module-scoped `stampEvaluatorSpan` assigned from a `static` block, the only scope `#start` / `#end` are reachable from. A method on an exported class let any consumer overwrite a caught error's span, and sealing it needs a major once v3.0.0 ships.

Corrected `README.md`, which claimed absolutely that "every failure extends `RollParserError` and carries a stable `code`". It does not: `MockRNGExhaustedError extends Error` with no `code`, and `nextInt` throws a bare `RangeError`. Both surface from inside `roll()` when a consumer injects `createMockRng`, and the claim sat in the exact paragraph a consumer reads to write their `catch`. A new Errors outside the hierarchy section states where the two sit relative to `isRollParserError`.

The issue's fallback — give `MockRNGExhaustedError` a `code` without inheritance so the duck-typing branch accepts it — was not applied. #230 replaced that branch with a `Symbol.for` brand check, so a bare `code` is inert; branding a testing-only error would make `isRollParserError` narrow it to `RollParserError & { code: RollParserErrorCode }`, which it is not. The errors stay foreign and are documented as such.

Costs 110 B on the `{ parse }` budget (5.31 kB of 5.5 kB): the `static` block makes the class declaration impure, so `EvaluatorError` no longer tree-shakes out of the parse-only entry. All four size gates pass unchanged.

Closes #232
