### PR TITLE
fix: expose the sorted pool on the sort RollPart #242

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ describe(roll('4d6kh3 + 2', { rng: createMockRng([3, 6, 2, 5]) }).parts);
 
 Invariants worth relying on: `result.parts.total === result.total`,
 `successCount.total === successes - failures`, and every part's `rolls[]`
-sharing references with `result.rolls`.
+sharing references with `result.rolls`. A `sort` part's `rolls[]` is its
+target's pool in sorted order — chained sorts (`4d6s sd`) nest, and the
+outermost one holds the order `rendered` shows.
 
 Meta-expressions do **not** appear as nested parts. `(1d4)d6`, `4d6kh(1d2)`, and
 `1d6!>(1d2+3)` surface only their resolved numbers in the owning part; their

--- a/site/src/render.ts
+++ b/site/src/render.ts
@@ -149,14 +149,18 @@ function renderEquation(root: RollPart, notation: string): string {
   /** Renders a modifier-family part as one chip, unwrapping to the dice it decorates. */
   function modifierLike(part: RollPart, isOutermost: boolean): string {
     let core: RollPart = part;
-    while ('target' in core) core = core.target;
+    let sortedRolls: DieResult[] | undefined;
+    while ('target' in core) {
+      if (core.type === 'sort') sortedRolls ??= core.rolls;
+      core = core.target;
+    }
 
     const label = sliceOf(part);
 
     if (core.type === 'dice' || core.type === 'fateDice') {
       return groupChip(
         label || fallbackDiceLabel(core),
-        core.rolls,
+        sortedRolls ?? core.rolls,
         subtotalText(part),
         isOutermost,
       );

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1058,6 +1058,7 @@ function evalSort(node: SortNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eva
     part: {
       type: 'sort',
       order: node.order,
+      rolls: sortedRolls,
       target: target.part,
       total: target.total,
       ...partSpan(node),

--- a/src/evaluator/parts.test.ts
+++ b/src/evaluator/parts.test.ts
@@ -352,6 +352,18 @@ describe('RollResult.parts', () => {
         target: { type: 'dice' },
         total: 10,
       });
+      if (result.parts.type !== 'sort') throw new Error('expected sort root');
+      expect(result.parts.rolls.map((d) => d.result)).toEqual([1, 2, 3, 4]);
+    });
+
+    test('chained sort nests, each level carrying its own pool (#242)', () => {
+      const result = roll('4d6s sd', { rng: createMockRng([3, 1, 4, 2]) });
+      if (result.parts.type !== 'sort' || result.parts.target.type !== 'sort') {
+        throw new Error('expected nested sort parts');
+      }
+      expect(result.parts.order).toBe('descending');
+      expect(result.parts.rolls.map((d) => d.result)).toEqual([4, 3, 2, 1]);
+      expect(result.parts.target.rolls.map((d) => d.result)).toEqual([1, 2, 3, 4]);
     });
 
     test('critThreshold chain surfaces resolved threshold arrays', () => {
@@ -458,6 +470,36 @@ describe('RollResult.parts', () => {
       expect(result.rolls[0]).toBe(
         result.parts.target.rolls[0] as NonNullable<(typeof result.rolls)[number]>,
       );
+    });
+  });
+
+  describe('sort part pool', () => {
+    test('shares DieResult objects with result.rolls (#242)', () => {
+      const result = roll('4d6s', { rng: createMockRng([3, 1, 4, 2]) });
+      if (result.parts.type !== 'sort') throw new Error('expected sort root');
+      for (let i = 0; i < result.parts.rolls.length; i++) {
+        expect(result.parts.rolls[i]).toBe(
+          result.rolls[i] as NonNullable<(typeof result.rolls)[number]>,
+        );
+      }
+    });
+
+    test('keeps meta dice, which rendered hides (#242)', () => {
+      const result = roll('(1d4)d6s', { rng: createMockRng([3, 5, 2, 6]) });
+      if (result.parts.type !== 'sort') throw new Error('expected sort root');
+      expect(result.parts.rolls.map((d) => d.result)).toEqual([2, 3, 5, 6]);
+      expect(result.parts.rolls[1]?.modifiers).toContain('meta');
+      expect(result.rendered).toBe('3d6s[2, 5, 6] = 13');
+    });
+
+    test('shows flags set after the sort ran (#242)', () => {
+      const result = roll('4d6s dl1', { rng: createMockRng([3, 1, 4, 2]) });
+      if (result.parts.type !== 'keepDrop' || result.parts.target.type !== 'sort') {
+        throw new Error('unexpected parts shape');
+      }
+      const sorted = result.parts.target.rolls;
+      expect(sorted.map((d) => d.result)).toEqual([1, 2, 3, 4]);
+      expect(sorted[0]?.modifiers).toEqual(['dropped']);
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,7 +305,18 @@ export type RollPart =
   | (RollPartBase & { type: 'versus'; roll: RollPart; dc: RollPart; degree: DegreeOfSuccess })
   | (RollPartBase & { type: 'functionCall'; name: string; args: RollPart[] })
   | (RollPartBase & { type: 'group'; parts: RollPart[]; keptIndices?: number[] })
-  | (RollPartBase & { type: 'sort'; order: 'ascending' | 'descending'; target: RollPart })
+  | (RollPartBase & {
+      type: 'sort';
+      order: 'ascending' | 'descending';
+      /**
+       * Every die the target produced, in sorted order, sharing `DieResult`
+       * references with `target` — so flags set after the sort (`4d6s dl1`)
+       * show through both. Like `RollResult.rolls` it keeps `'meta'` dice,
+       * which `rendered` omits from the bracket.
+       */
+      rolls: DieResult[];
+      target: RollPart;
+    })
   | (RollPartBase & {
       type: 'critThreshold';
       successThresholds: ResolvedCritThreshold[];


### PR DESCRIPTION
Added `rolls: DieResult[]` to the `sort` variant of `RollPart`, set to the sorted array `evalSort` already computes and sharing `DieResult` references so post-sort flags (`4d6s dl1`) show through.

The site equation renderer now prefers the outermost sort part's pool over the unwrapped dice core, closing the split where `3d20s` rendered in draw order while `61d20s` rendered sorted.

`parts.test.ts` pins the sorted pool, reference sharing, chained sorts (`4d6s sd`), and meta-dice retention.

Closes #242
