### PR TITLE
build: gate validate on site:build and site:check #244

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,8 @@ jobs:
           echo "Dist-tag: $TAG"
 
       # The same gate `prepublishOnly` runs on a manual publish: check, build,
-      # package checks, size budgets, coverage, audit.
+      # package checks, size budgets, site build and check (TypeDoc), coverage,
+      # audit.
       - name: Run release gate
         run: bun run release:dry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,9 @@ edit the `.claude/` originals, never replace a symlink with a real file.
 bun check:fix   # Typecheck + biome check --write (lint + format + import sort) — use during
                 # iteration; the typecheck step rebuilds dist/ as a side effect
 bun test        # Run tests — not read-only: some suites rebuild dist/ in-process
-bun validate    # Full pre-release gate: check + build + check:package + check:size + test:ci
+bun validate    # Full pre-release gate: check + build + check:package + check:size +
+                # site:build + site:check + test:ci — site:build is what runs TypeDoc,
+                # so a TSDoc error that breaks the API reference fails here
 ```
 
 Demo site (`site/`, Cloudflare Pages): `site:dev` (no TypeDoc, so `/docs/` is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ dependency tree than CI resolves.
 bun install     # also installs the pre-commit hook
 bun check:fix   # typecheck + biome check --write (lint, format, import sort)
 bun test        # full suite, ~5s
-bun validate    # full gate: check, build, package checks, size budgets, coverage
+bun validate    # full gate: check, build, package checks, size budgets, site, coverage
 ```
 
 Run `bun check:fix` and `bun test` while you work; run `bun validate` before

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:ci": "bun test --bail --coverage",
-    "validate": "bun run check && bun run build && bun run check:package && bun run check:size && bun test:ci",
+    "validate": "bun run check && bun run build && bun run check:package && bun run check:size && bun run site:build && bun run site:check && bun test:ci",
     "release:dry": "bun run check:version && bun run check:changelog && bun audit --audit-level=high && bun run validate",
     "prepublishOnly": "bun run release:dry"
   },


### PR DESCRIPTION
Added `site:build` and `site:check` to `validate`, ahead of `test:ci`, so TypeDoc runs in the gate that `release:dry` and `prepublishOnly` inherit. A TSDoc error that breaks the API reference now fails locally instead of after publish.

Updated the `validate` step enumerations in `CLAUDE.md`, `CONTRIBUTING.md`, and the release workflow's release-gate comment.

Closes #244
