### PR TITLE
chore: attribute commits from the secondary account

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Attributes commits made from the secondary `adiutriel` account. Guarded on the
+# committing email so clones by anyone else are left alone.
+[ "$(git config user.email)" = "adiutriel@gmail.com" ] || exit 0
+[ "$2" = "merge" ] && exit 0
+
+grep -qi '^Co-Authored-By:.*<edloidas@gmail.com>' "$1" && exit 0
+git interpret-trailers --in-place \
+  --trailer 'Co-Authored-By: Mikita Taukachou <edloidas@gmail.com>' "$1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,9 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `bui
 
 - Imperative mood, under 72 chars, no period
 - Include issue number when related: `feat: add parser #5`
-- `Co-Authored-By:` trailer only, no promotional lines
+- No promotional or generated-by lines
+- Add `Co-Authored-By: Mikita Taukachou <edloidas@gmail.com>` — commits here are
+  pushed from the secondary `adiutriel` account, and the trailer attributes them
 - Optional body: past tense, one line per change, backticks for code refs
 - Use `Changelog: skip` body trailer to exclude a commit from release notes (honored by the `release-changelog` skill)
 - PRs should contain a single commit on merge; squash locally and force-push before merging unless the PR combines work from several tasks


### PR DESCRIPTION
Replaced the commit-trailer convention in `CLAUDE.md`: no promotional or generated-by lines, and commits carry a trailer crediting the primary account.

Added `.githooks/prepare-commit-msg`, guarded on the committing email so it no-ops for other contributors, skips merge commits, and stays idempotent across `--amend`.
