### PR TITLE
docs: note the master branch protection gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `bui
   <sub>[Claude Code session](<link>)</sub>
   ```
 
+`master` merges through a PR, must be up to date with it, and must pass the eight
+contexts the `protect-master` ruleset requires — that ruleset is the source of
+truth. Renaming a job leaves its old context pending forever.
+
 ## Releasing
 
 Order: update `CHANGELOG.md` via the local `release-changelog` skill → bump


### PR DESCRIPTION
Documented the `protect-master` gate in `CLAUDE.md`: PR-only merges, an up-to-date branch, and the eight required contexts, with the ruleset named as the source of truth rather than the list duplicated.

Follow-up to #252, which added `Build Site` to the required contexts and enabled the up-to-date requirement.
