### PR TITLE
perf: revalidate the README performance table on a quiet machine #224

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,25 +874,29 @@ precedes them. Errors go to stderr; only the result goes to stdout.
 
 | Notation | `lex` | `parse` | `roll` (end to end) |
 |----------|------:|--------:|--------------------:|
-| `1d20` | 0.15 µs | 0.35 µs | **1.5 µs** (~660k rolls/s) |
-| `2d6+3` | 0.21 µs | 0.53 µs | **2.5 µs** |
-| `4d6kh3` | 0.26 µs | 0.62 µs | **3.9 µs** |
-| `10d10>=6f1` | 0.35 µs | 0.83 µs | **5.6 µs** |
-| `100d6` | 0.14 µs | 0.36 µs | **12 µs** |
+| `1d20` | 86 ns | 165 ns | **0.52 µs** (~1.9M rolls/s) |
+| `2d6+3` | 99 ns | 217 ns | **0.82 µs** |
+| `4d6kh3` | 124 ns | 247 ns | **1.3 µs** |
+| `10d10>=6f1` | 161 ns | 339 ns | **2.2 µs** |
+| `100d6` | 83 ns | 168 ns | **5.3 µs** |
 
 The `roll` column pays for a fresh `SeededRNG` per call, which an injected RNG
 avoids. Every roll also builds the `parts` tree; there is no opt-out and these
-numbers include it. A 1000-die pool costs roughly 60x a `1d20` (~90 µs here),
-while lexing and parsing stay flat at ~0.14 / ~0.36 µs.
+numbers include it. A 1000-die pool costs roughly 96x a `1d20` (~49 µs here),
+while lexing and parsing stay flat at ~84 / ~168 ns.
 
 <details>
 <summary>Measurement protocol</summary>
 
 Values are **p50**, from
 [mitata](https://github.com/evanwashere/mitata) with forced per-iteration GC
-(`.gc('inner')`), averaged over two full `bun run bench:json` passes that agreed
-within 15%. Measured 2026-07-27 on Bun 1.3.11, Intel Xeon @ 2.80 GHz, 4 vCPU
-container. p50 rather than mean, because the mean here is effectively a GC-pause
+(`.gc('inner')`), taken as the per-record median of three full
+`bun run bench:json` passes agreeing within 5%. Measured 2026-08-05 on Bun
+1.3.14, Apple M2 Pro, macOS, idle and on AC power. Read them as two significant
+digits: another machine shifts every row, and a busy one inflates the heavy
+cases most.
+
+p50 rather than mean, because the mean here is effectively a GC-pause
 histogram and swings ±40% between processes. Every bench body is JIT-primed
 before measurement and pinned to mitata's batched sampling mode, so all cases
 are timed the same way — mitata otherwise picks the mode from cold calls and


### PR DESCRIPTION
Re-baselined the performance table on an idle M2 Pro, Bun 1.3.14. Every figure moved: the previous numbers came from a 4 vCPU Intel Xeon container, so the table spans both a machine change and the `xoshiro128**` engine swap and does not separate the two. No case reads slower than the pre-swap figures, but that is not a clean no-regression result — the hardware changed at the same time.

Changes:

- Re-measured all five table rows plus the 1000-die prose figure
- Switched the `lex` and `parse` columns to nanoseconds, now that both are sub-microsecond and two decimals in µs collapsed distinct rows
- Updated the 1000-die ratio to `1d20`, 60x to 96x
- Tightened the protocol to the median of three passes agreeing within 5%, from two averaged within 15%

The protocol change is the one judgment call here. One pass in eight ran uniformly slow — above the others on 84 of 95 records, by a margin growing with case cost to +13.8% on the heaviest. A two-pass comparison detects that the passes disagree but cannot tell which one is the outlier, and a 15% gate is loose enough to admit it. Three mutually-agreeing passes identify the outlier by its disagreement with the other two.

Verification: `bun validate` green, including the four `check:size` budgets. The table is documentation and gates nothing.

<details>
<summary>Raw measurements, eight passes</summary>

Passes 1-3 were taken with a browser running at roughly 200% CPU and are superseded. A-E were taken on an idle machine with a 90s settle between each. The published figures are the per-record median of B, C and E.

| Pass | Machine state | Role |
|---|---|---|
| 1 | busy | superseded |
| 2 | busy | superseded |
| 3 | busy | superseded |
| A | idle | outlier, excluded |
| B | idle | used |
| C | idle | used |
| D | idle | excluded |
| E | idle | used |

Table records, every pass, p50 ns:

| Record | 1 | 2 | 3 | A | B | C | D | E | median B/C/E |
|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|
| `lex / 1d20` | 88 | 86 | 88 | 78 | 86 | 85 | 86 | 86 | **86** |
| `lex / 2d6+3` | 102 | 98 | 100 | 109 | 99 | 97 | 99 | 99 | **99** |
| `lex / 4d6kh3` | 122 | 122 | 124 | 131 | 124 | 121 | 123 | 124 | **124** |
| `lex / 10d10>=6f1` | 167 | 163 | 164 | 169 | 161 | 158 | 162 | 161 | **161** |
| `lex / 100d6` | 83 | 88 | 84 | 75 | 83 | 81 | 83 | 83 | **83** |
| `lex / 1000d6` | 86 | 84 | 84 | 77 | 84 | 83 | 85 | 84 | **84** |
| `parse / 1d20` | 160 | 165 | 158 | 156 | 165 | 162 | 165 | 165 | **165** |
| `parse / 2d6+3` | 207 | 218 | 208 | 225 | 217 | 213 | 217 | 217 | **217** |
| `parse / 4d6kh3` | 237 | 247 | 238 | 255 | 247 | 243 | 245 | 248 | **247** |
| `parse / 10d10>=6f1` | 329 | 340 | 326 | 355 | 339 | 334 | 337 | 339 | **339** |
| `parse / 100d6` | 169 | 169 | 161 | 159 | 168 | 165 | 169 | 169 | **168** |
| `parse / 1000d6` | 163 | 172 | 163 | 159 | 170 | 166 | 168 | 168 | **168** |
| `roll (seeded) / 1d20` | 566 | 525 | 517 | 546 | 511 | 515 | 533 | 515 | **515** |
| `roll (seeded) / 2d6+3` | 912 | 834 | 867 | 878 | 818 | 821 | 843 | 827 | **821** |
| `roll (seeded) / 4d6kh3` | 1393 | 1389 | 1345 | 1449 | 1335 | 1342 | 1354 | 1338 | **1338** |
| `roll (seeded) / 10d10>=6f1` | 2129 | 2207 | 2136 | 2371 | 2168 | 2172 | 2193 | 2179 | **2172** |
| `roll (seeded) / 100d6` | 5442 | 5874 | 5382 | 6353 | 5303 | 5320 | 5400 | 5370 | **5320** |
| `roll (seeded) / 1000d6` | 51184 | 51013 | 49277 | 59678 | 48960 | 49280 | 49403 | 49419 | **49280** |

Every record reported `mode=batch` in all eight passes, so no case switched sampling mode.

Pass A sat above the B/C/E median on 84 of 95 records, +13.8% mean on the nine cases over 10 µs — a whole-process offset rather than per-case noise. Pass D was +0.6% on heavy cases but drifted 16-18% on two ~300 ns `evaluate` records; neither feeds the table. B, C and E agree pairwise within 3.4% across all 95 records, with zero records over 5%.

The full 95-record JSON exports live in the gitignored `.tmp/` and are not committed — bench series history belongs to the `bench-trend` job on gh-pages, and a second machine-inconsistent copy in git would invite cross-hardware comparison.

</details>

Closes #224
