### PR TITLE
docs: state the versusMetadata propagation rule where callers read it #259

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -557,9 +557,22 @@ function evalFateDice(node: FateDiceNode, rng: RNG, ctx: EvalContext, env: EvalE
  * the same `RollResult`. No-op when `metadata` is `undefined`.
  *
  * Use this directly when the caller has already pushed (or transformed) `rolls`
- * itself — e.g. `evalSort`, `evalCritThreshold`, `evalGroupKeepDrop`. For the
- * default case where the child's raw rolls flow up unchanged, use
- * `mergeContext` instead.
+ * itself. For the default case where the child's raw rolls flow up unchanged,
+ * use `mergeContext` instead.
+ *
+ * Propagate only when the caller leaves `total` equal to the value the degree
+ * was resolved from — `evalVersus` computes `degree` once, against the total it
+ * saw. That rule, not an oversight, is why most postfix modifiers do not call
+ * this: `evalExplode` adds dice, `evalReroll` replaces them, `evalKeepDrop`
+ * removes them, and `evalSuccessCount` redefines `total` as a success tally, so
+ * a propagated `degree` would contradict the total beside it. `evalSort`
+ * (reorders) and `evalCritThreshold` (tags) leave the total alone and qualify.
+ * `evalGroupKeepDrop` applies the rule per sub-roll, propagating only from
+ * sub-rolls it kept.
+ *
+ * The membership reading — "every die still contributes" — is the trap here.
+ * It admits `evalDieBound`, which drops no dice yet re-sums after clamping and
+ * so ships a stale degree (see issue #260).
  */
 function propagateMetadata(parent: EvalContext, metadata: EvalContext['versusMetadata']): void {
   if (!metadata) return;


### PR DESCRIPTION
Documented the versus-metadata propagation rule on `propagateMetadata`, where callers read it, instead of leaving it stated only in a comment inside `evalGroupKeepDrop`.

The rule: propagate only when the caller leaves `total` equal to the value `evalVersus` resolved the degree from. Named which postfix modifiers qualify (`evalSort` reorders, `evalCritThreshold` tags) and why the other four must not (`evalExplode` adds dice, `evalReroll` replaces them, `evalKeepDrop` removes them, `evalSuccessCount` redefines `total`).

Also recorded the misreading the old wording invited — "every die still contributes" — and the `evalDieBound` deviation it admits, filed as #260.

Dropped the three-item `e.g.` caller list, which read as an inventory of who calls this rather than an example.

Comment-only. `dist/` JS is emitted comment-free, so `check:size` is byte-identical: 11.78 / 5.45 / 11.47 kB / 213 B.

Closes #259

<sub>[Claude Code session](https://claude.ai/code)</sub>
