### PR TITLE
feat: redraw d8/d10/d12 facets and mark the active guide section #265

### DIFF
--- a/site/src/dice.ts
+++ b/site/src/dice.ts
@@ -29,13 +29,13 @@ function escapeAttr(value: string): string {
 
 /**
  * Builds the polygon `points` attribute for a regular N-gon centered at
- * (50, 50), oriented point-up.
+ * (50, 50), oriented point-up. `rotation` (radians) turns it off that axis.
  */
-function polygonPoints(sides: number, radius: number): string {
+function polygonPoints(sides: number, radius: number, rotation = 0): string {
   const points: string[] = [];
 
   for (let i = 0; i < sides; i++) {
-    const angle = (Math.PI * 2 * i) / sides - Math.PI / 2;
+    const angle = (Math.PI * 2 * i) / sides - Math.PI / 2 + rotation;
     const x = 50 + radius * Math.cos(angle);
     const y = 50 + radius * Math.sin(angle);
     points.push(`${x.toFixed(1)},${y.toFixed(1)}`);
@@ -70,13 +70,20 @@ function shapeFor(sides: number): string {
   }
 }
 
-/** The d12 inner-pentagon facet impression: five corner spokes + inner pentagon. */
-function pentagonFacets(): string {
-  const outer = polygonPoints(5, 46).split(' ');
-  const inner = polygonPoints(5, 30).split(' ');
-  const spokes = outer.map((o, i) => `M${o} L${inner[i]}`).join(' ');
+/** Half a pentagon step — the offset that turns the d12's inner face point-down. */
+const PENTAGON_HALF_STEP = Math.PI / 5;
 
-  return `<polygon points="${polygonPoints(5, 30)}" /><path d="${spokes}" />`;
+/** The d12 inner-pentagon facet impression: point-down inner face + five spokes. */
+function pentagonFacets(): string {
+  const innerRadius = 30;
+  const outer = polygonPoints(5, 46).split(' ');
+  const inner = polygonPoints(5, innerRadius, PENTAGON_HALF_STEP);
+  // Out of phase by half a step, so each outer vertex faces an inner *edge*, whose
+  // midpoint shares that angle at radius * cos(36°) — keeping all five spokes radial.
+  const midpoints = polygonPoints(5, innerRadius * Math.cos(PENTAGON_HALF_STEP)).split(' ');
+  const spokes = outer.map((o, i) => `M${o} L${midpoints[i]}`).join(' ');
+
+  return `<polygon points="${inner}" /><path d="${spokes}" />`;
 }
 
 /** The d20 facet pattern — reuses the logo's central-triangle geometry. */
@@ -94,8 +101,8 @@ function facetsFor(sides: number): string {
       // Three lines from each vertex meeting at the triangle centroid.
       return '<path d="M50,8 L50,61.3 M92,88 L50,61.3 M8,88 L50,61.3" />';
     case 8:
-      // Horizontal equator, gapped so the centered digit stays clear.
-      return '<path d="M6,50 L36,50 M64,50 L94,50" />';
+      // Equator plus spine, gapped around the digit — the octahedron seen edge-on.
+      return '<path d="M6,50 L36,50 M64,50 L94,50 M50,6 L50,26 M50,74 L50,94" />';
     case 10:
       // Kite shoulders converging on (50,62), then down to the bottom vertex.
       return '<path d="M10,42 L50,62 M90,42 L50,62 M50,62 L50,96" />';
@@ -106,6 +113,14 @@ function facetsFor(sides: number): string {
     default:
       return '';
   }
+}
+
+/**
+ * Vertical center for the value. The d10 alone sits high: its front kite face is
+ * above the shape's center, where the facet chevron converges.
+ */
+function valueYFor(sides: number): number {
+  return sides === 10 ? 42 : 50;
 }
 
 /** Human-facing label rendered inside the die shape. */
@@ -209,7 +224,7 @@ export function renderDie(die: DieResult, index: number, folded = false): string
     '<svg viewBox="0 0 100 100" aria-hidden="true">',
     `<g class="die-shape">${shapeFor(die.sides)}</g>`,
     facetGroup,
-    `<text class="die-value" x="50" y="50" text-anchor="middle" dominant-baseline="central" font-size="${fontSize}">${label}</text>`,
+    `<text class="die-value" x="50" y="${valueYFor(die.sides)}" text-anchor="middle" dominant-baseline="central" font-size="${fontSize}">${label}</text>`,
     '</svg>',
     badge,
     explodeBadge,

--- a/site/src/reference.css
+++ b/site/src/reference.css
@@ -72,7 +72,7 @@
 
 @media (min-width: 900px) {
   .ref-layout {
-    grid-template-columns: 220px minmax(0, 1fr);
+    grid-template-columns: 192px minmax(0, 1fr);
     gap: 2.75rem;
     align-items: start;
   }
@@ -138,7 +138,8 @@
   /* Sidebar links read as a list, not pills: no tracking, no gap — the padding
      carries the rhythm and doubles as the hover hit area. */
   .toc-link {
-    padding: 0.5rem 0.8rem;
+    position: relative;
+    padding: 0.5rem 0.85rem;
     font-size: 0.875rem;
     letter-spacing: normal;
     border-color: transparent;
@@ -148,6 +149,24 @@
 
   .toc-link:hover {
     background: var(--surface);
+  }
+
+  /* Pseudo-element, not a border or inset shadow: both trace the 999px pill radius
+     the mobile strip needs and ring the whole link. */
+  .toc-link.is-active {
+    color: var(--accent);
+    background: var(--surface);
+  }
+
+  .toc-link.is-active::before {
+    content: '';
+    position: absolute;
+    left: 6px;
+    top: 32%;
+    bottom: 36%;
+    width: 2px;
+    border-radius: 2px;
+    background: var(--accent);
   }
 }
 

--- a/site/src/reference.ts
+++ b/site/src/reference.ts
@@ -229,6 +229,44 @@ function tocMarkup(): string {
   return links;
 }
 
+/**
+ * Marks the TOC entry for the section under the top of the viewport. Sets
+ * `is-active` at every width — only the sidebar layout styles it.
+ */
+function initTocHighlight(toc: HTMLElement, guide: HTMLElement): void {
+  const sections = Array.from(guide.querySelectorAll<HTMLElement>('.ref-section'));
+  const links = new Map(
+    Array.from(toc.querySelectorAll<HTMLAnchorElement>('.toc-link')).map((link) => [
+      link.hash.slice(1),
+      link,
+    ]),
+  );
+  const onscreen = new Set<string>();
+  let active = '';
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        const { id } = entry.target;
+        if (entry.isIntersecting) onscreen.add(id);
+        else onscreen.delete(id);
+      }
+
+      const current = sections.find((section) => onscreen.has(section.id));
+      if (current == null || current.id === active) return;
+
+      links.get(active)?.classList.remove('is-active');
+      links.get(current.id)?.classList.add('is-active');
+      active = current.id;
+    },
+    // ! Both insets must stay percentages. A px top against a % bottom inverts the
+    // ! band on a short viewport, and nothing ever intersects.
+    { rootMargin: '-12% 0px -70% 0px' },
+  );
+
+  for (const section of sections) observer.observe(section);
+}
+
 /** Reads the optional preset context stashed on a widget element. */
 function readContext(widget: HTMLElement): Record<string, number> | undefined {
   const raw = widget.dataset.context;
@@ -272,6 +310,8 @@ function mount(): void {
   toc.innerHTML = tocMarkup();
   guide.innerHTML = SECTIONS.map(sectionMarkup).join('');
   if (versionEl != null) versionEl.textContent = `v${VERSION}`;
+
+  initTocHighlight(toc, guide);
 
   const widgets = Array.from(guide.querySelectorAll<HTMLElement>('.widget'));
 

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -277,7 +277,7 @@ body {
   stroke-width: 2;
   stroke-linejoin: round;
   stroke-linecap: round;
-  opacity: 0.4;
+  opacity: 0.55;
 }
 
 .die-value {


### PR DESCRIPTION
Redrew the d8, d10 and d12 facets so each reads as its polyhedron: a gapped
spine on the d8, the d10 value moved onto its front kite face, and the d12
inner pentagon rotated a half-step with spokes on its edge midpoints.

Raised `.die-facets` opacity to 0.55 so the interiors survive at `--die-size`.

Added an `IntersectionObserver` scroll-spy that marks the active section in the
reference sidebar at `>= 900px`, leaving the mobile pill strip unstyled. Both
`rootMargin` insets are percentages — a px top against a % bottom collapses the
band on a short viewport.

Narrowed the sidebar track to 192px and widened `.toc-link` padding to 0.85rem.

Closes #265
