### PR TITLE
build: emit dist without wiping it so a running site:dev survives #264

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,11 @@ with `biome check --write` and blocks commits on unfixable lint errors.
 
 - Runtime: Bun — never use npm, yarn, or pnpm (npm appears only in the smoke CI jobs and the release publish step). `bunfig.toml` pins `minimumReleaseAge` to 3 days — `bun add` of a freshly published version silently resolves to an older one
 - Library + CLI, ESM-only compiled JS (Node ≥22.12 — first version with unflagged `require(esm)`)
-- `dist/` is a per-file `tsc` emit, never a bundle, in **two** passes: comment-free JS + `.js.map`, then `.d.ts` + `.d.ts.map` with TSDoc intact — one pass cannot do both under TS7 (rationale in the `tsconfig.build*.json` comments). Keep both map kinds. Do not reintroduce a bundler: Bun ≤1.3.11 breaks pure re-export entrypoints (e.g. `src/testing.ts`) and `--target browser` silently stubs `node:` builtins instead of erroring
+- `dist/` is a per-file `tsc` emit, never a bundle, in **two** passes: comment-free JS + `.js.map`, then `.d.ts` + `.d.ts.map` with TSDoc intact — one pass cannot do both under TS7 (rationale in the `tsconfig.build*.json` comments). Keep both map kinds. The emit overwrites in place and never wipes `dist/` first —
+a running `site:dev` resolves `roll-parser` into it and caches resolution failures
+it cannot recover from; `scripts/prune-dist.ts` deletes what the passes did not
+write, and `bun run clean` (which `release:dry` runs) is the pristine path. Do not
+reintroduce a bundler: Bun ≤1.3.11 breaks pure re-export entrypoints (e.g. `src/testing.ts`) and `--target browser` silently stubs `node:` builtins instead of erroring
 - Byte budgets are a release gate (`check:size`): 12.5 kB `index.js`, 6 kB `{ parse }`, 12 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
 - `files` ships `src/` deliberately: `.d.ts.map` points consumer go-to-definition at the real sources. Removing it breaks nothing visibly — the jumps just die
 - Relative imports in `src/` carry explicit `.js` extensions — enforced by `moduleResolution: nodenext` at typecheck time

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "check:changelog": "bun scripts/check-changelog.ts",
     "generate:version": "bun scripts/generate-version.ts",
     "clean": "rm -rf dist",
-    "build": "bun run clean && tsc -p tsconfig.build.json && tsc -p tsconfig.build.types.json && chmod +x dist/cli/index.js",
+    "build": "bun scripts/build.ts",
     "check:package": "attw --pack . --profile esm-only && publint",
     "check:size": "size-limit",
     "bench": "bun run bench/index.bench.ts",
@@ -88,7 +88,7 @@
     "test:watch": "bun test --watch",
     "test:ci": "bun test --bail --coverage",
     "validate": "bun run check && bun run build && bun run check:package && bun run check:size && bun run site:build && bun run site:check && bun test:ci",
-    "release:dry": "bun run check:version && bun run check:changelog && bun audit --audit-level=high && bun run validate",
+    "release:dry": "bun run check:version && bun run check:changelog && bun audit --audit-level=high && bun run clean && bun run validate",
     "prepublishOnly": "bun run release:dry"
   },
   "nano-staged": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,46 @@
+/**
+ * Builds `dist/` in the two passes `tsconfig.build*.json` describe, then removes
+ * whatever the passes did not write.
+ *
+ * The emit deliberately does not start by wiping `dist/`. `site:dev` serves
+ * `site/src`, which resolves `roll-parser` into `dist/`; deleting the directory
+ * under a running dev server leaves it caching resolution failures it never
+ * recovers from. Overwriting in place keeps every module resolvable throughout,
+ * and `pruneStale` covers the deletions `tsc` will not do itself.
+ *
+ * `bun run clean` still exists for a pristine rebuild, and `release:dry` runs it
+ * before validating: mtime staleness cannot survive a wipe, so a clock that steps
+ * backward between builds can strand an orphan locally but never in a tarball.
+ */
+
+import { chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pruneStale, stampCutoff } from './prune-dist.js';
+
+const ROOT = join(import.meta.dir, '..');
+const DIST = join(ROOT, 'dist');
+const PROJECTS = ['tsconfig.build.json', 'tsconfig.build.types.json'];
+
+// Anything in `dist/` older than this is from an earlier build: neither project
+// enables `incremental`, so every pass rewrites all of its own outputs.
+const cutoff = await stampCutoff(DIST);
+
+for (const project of PROJECTS) {
+  // `bunx` over `node_modules/.bin/tsc` — the latter is a POSIX shim that
+  // `Bun.spawn` cannot execute on Windows.
+  const { exited } = Bun.spawn(['bunx', 'tsc', '-p', project], {
+    cwd: ROOT,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  const code = await exited;
+
+  // Pruning after a failed pass would delete the outputs it did not get to write.
+  if (code !== 0) process.exit(code);
+}
+
+const removed = await pruneStale(DIST, cutoff);
+
+await chmod(join(DIST, 'cli', 'index.js'), 0o755);
+
+if (removed.length > 0)
+  console.log(`Pruned ${removed.length} stale output(s): ${removed.join(', ')}`);

--- a/scripts/prune-dist.test.ts
+++ b/scripts/prune-dist.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pruneStale, stampCutoff } from './prune-dist.js';
+
+let dir: string;
+let cutoff: number;
+
+/** Writes a file, backdating it well past the cutoff when `stale`. */
+async function write(relative: string, stale: boolean): Promise<string> {
+  const path = join(dir, relative);
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, 'x');
+
+  if (stale) {
+    const seconds = (cutoff - 60_000) / 1000;
+    await utimes(path, seconds, seconds);
+  }
+
+  return path;
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'prune-dist-'));
+  cutoff = await stampCutoff(dir);
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('stampCutoff', () => {
+  it('creates the directory when it does not exist', async () => {
+    const nested = join(dir, 'absent', 'deeper');
+
+    expect(await stampCutoff(nested)).toBeGreaterThan(0);
+    expect((await stat(nested)).isDirectory()).toBe(true);
+  });
+
+  it('leaves no stamp file behind', async () => {
+    await stampCutoff(dir);
+
+    expect(await Bun.file(join(dir, '.build-stamp')).exists()).toBe(false);
+  });
+
+  it('returns a cutoff that keeps files written after it', async () => {
+    // Guards the reason this exists: on Linux, mtimes come from a coarser clock
+    // than `Date.now()`, so a `Date.now()` cutoff can post-date the next write.
+    for (let i = 0; i < 200; i++) await write(`fresh-${i}.js`, false);
+
+    expect(await pruneStale(dir, cutoff)).toEqual([]);
+  });
+});
+
+describe('pruneStale', () => {
+  it('keeps files written at or after the cutoff', async () => {
+    await write('index.js', false);
+    await write('cli/index.js', false);
+
+    expect(await pruneStale(dir, cutoff)).toEqual([]);
+    expect(await Bun.file(join(dir, 'index.js')).exists()).toBe(true);
+    expect(await Bun.file(join(dir, 'cli/index.js')).exists()).toBe(true);
+  });
+
+  it('deletes files older than the cutoff', async () => {
+    await write('index.js', false);
+    await write('removed.js', true);
+
+    expect(await pruneStale(dir, cutoff)).toEqual(['removed.js']);
+    expect(await Bun.file(join(dir, 'removed.js')).exists()).toBe(false);
+    expect(await Bun.file(join(dir, 'index.js')).exists()).toBe(true);
+  });
+
+  it('reports nested paths relative to the pruned directory', async () => {
+    await write('index.js', false);
+    await write('evaluator/gone.js', true);
+    await write('evaluator/kept.js', false);
+
+    expect(await pruneStale(dir, cutoff)).toEqual(['evaluator/gone.js']);
+    expect(await Bun.file(join(dir, 'evaluator/kept.js')).exists()).toBe(true);
+  });
+
+  it('removes a directory left empty by its stale files', async () => {
+    await write('index.js', false);
+    await write('dropped/a.js', true);
+    await write('dropped/b.js', true);
+
+    expect(await pruneStale(dir, cutoff)).toEqual(['dropped/a.js', 'dropped/b.js']);
+    expect(await Bun.file(join(dir, 'dropped')).exists()).toBe(false);
+  });
+
+  it('keeps a directory holding a fresh file under a stale one', async () => {
+    await write('outer/inner/fresh.js', false);
+    await write('outer/stale.js', true);
+
+    expect(await pruneStale(dir, cutoff)).toEqual(['outer/stale.js']);
+    expect(await Bun.file(join(dir, 'outer/inner/fresh.js')).exists()).toBe(true);
+  });
+
+  it('does not follow a symlinked directory out of the tree', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'prune-dist-outside-'));
+    const guarded = join(outside, 'keep.js');
+
+    await writeFile(guarded, 'x');
+    const stamp = (cutoff - 60_000) / 1000;
+    await utimes(guarded, stamp, stamp);
+    await symlink(outside, join(dir, 'link'), 'dir');
+
+    await pruneStale(dir, cutoff);
+
+    expect(await Bun.file(guarded).exists()).toBe(true);
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it('refuses to prune when the directory itself is a symlink', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'prune-dist-root-'));
+    const guarded = join(outside, 'keep.js');
+    const link = join(dir, 'link-root');
+
+    await writeFile(guarded, 'x');
+    const stamp = (cutoff - 60_000) / 1000;
+    await utimes(guarded, stamp, stamp);
+    await symlink(outside, link, 'dir');
+
+    await expect(pruneStale(link, cutoff)).rejects.toThrow(/Refusing to prune through a symlink/);
+    expect(await Bun.file(guarded).exists()).toBe(true);
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it('tolerates a directory that does not exist', async () => {
+    expect(await pruneStale(join(dir, 'absent'), cutoff)).toEqual([]);
+  });
+});

--- a/scripts/prune-dist.ts
+++ b/scripts/prune-dist.ts
@@ -1,0 +1,92 @@
+/**
+ * Removes build outputs that the current emit did not write.
+ *
+ * `tsc` overwrites its outputs in place but never deletes the ones whose source
+ * is gone, so a build that does not wipe `dist/` first needs this instead. See
+ * `build.ts` for why the wipe was dropped.
+ *
+ * @module prune-dist
+ */
+
+import type { Stats } from 'node:fs';
+import { lstat, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const STAMP = '.build-stamp';
+
+/**
+ * Returns a cutoff for {@link pruneStale}, as the mtime of a file written into
+ * `dir` right now. Creates `dir` if absent and leaves nothing behind.
+ *
+ * Not `Date.now()`: Linux mtimes come from the kernel's coarse clock, which lags
+ * the precise one by up to a tick, so a file written after a `Date.now()` cutoff
+ * can still stat as older than it.
+ */
+export async function stampCutoff(dir: string): Promise<number> {
+  const path = join(dir, STAMP);
+
+  await mkdir(dir, { recursive: true });
+  await writeFile(path, '');
+  const { mtimeMs } = await stat(path);
+  await rm(path);
+
+  return mtimeMs;
+}
+
+/**
+ * Deletes every file under `dir` last modified before `cutoffMs`, then the
+ * directories those deletions left empty. Returns the removed files, sorted and
+ * relative to `dir` — emptied directories are cleanup, not results. A missing
+ * `dir` yields `[]`.
+ *
+ * The caller must take `cutoffMs` before the emit starts, and must not call this
+ * after a failed emit — a pass that wrote nothing makes every file look stale.
+ *
+ * Throws if `dir` is itself a symlink, rather than deleting through it.
+ */
+export async function pruneStale(dir: string, cutoffMs: number): Promise<string[]> {
+  const removed: string[] = [];
+  let root: Stats;
+
+  try {
+    root = await lstat(dir);
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ENOENT') return [];
+    throw error;
+  }
+
+  if (root.isSymbolicLink()) throw new Error(`Refusing to prune through a symlink: ${dir}`);
+
+  async function walk(current: string, prefix: string): Promise<boolean> {
+    const entries = await readdir(current);
+    let kept = 0;
+
+    for (const name of entries) {
+      const path = join(current, name);
+      const relative = prefix === '' ? name : `${prefix}/${name}`;
+      // ! `lstat`, not `stat` — recursing through a symlinked directory would put
+      // ! `rm` outside the tree this is allowed to delete from.
+      const info = await lstat(path);
+
+      if (info.isDirectory()) {
+        if (await walk(path, relative)) kept++;
+        else await rm(path, { recursive: true });
+        continue;
+      }
+
+      if (info.mtimeMs >= cutoffMs) {
+        kept++;
+        continue;
+      }
+
+      await rm(path);
+      removed.push(relative);
+    }
+
+    return kept > 0;
+  }
+
+  await walk(dir, '');
+
+  return removed.sort();
+}


### PR DESCRIPTION
Replaced the `clean && tsc && tsc && chmod` chain with `scripts/build.ts`, which
overwrites `dist/` in place instead of deleting it first, so a running `site:dev`
never loses the modules it resolves `roll-parser` into.

Added `scripts/prune-dist.ts` to delete the outputs the passes did not write —
the staleness `tsc` will not clean up itself. The cutoff is a stamp file's mtime
rather than `Date.now()`, because Linux mtimes come from the kernel's coarse
clock and a file written after a `Date.now()` cutoff can still stat as older.
`lstat` plus a symlinked-root guard keep `rm` inside the tree.

Ran `clean` from `release:dry` so a published tarball is always built from a
pristine `dist/`.

Documented the non-destructive emit in `CLAUDE.md` beside the two-pass rule.

Verified by running `check`, `site:build` and a full `validate` against a live
`site:dev` — the sequence that previously left the dev server showing 11
unrecoverable resolution errors.

Closes #264
