### PR TITLE
fix: a versus in a count or value position silently loses its degree #267

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { isRollParserError, RollParserError } from '../errors.js';
+import { getErrorSpan, isRollParserError, RollParserError } from '../errors.js';
 import type { ASTNode } from '../parser/ast.js';
 import { parse } from '../parser/parser.js';
 import { createMockRng } from '../rng/mock.js';
@@ -2327,6 +2327,146 @@ describe('evaluate', () => {
 
         expect(result.successes).toBe(1);
         expect(result.total).toBe(1);
+      });
+    });
+
+    // Every meta position funnels through `evalMetaOperand`, which forwards
+    // rolls but not `versusMetadata`. Before #267 the degree simply vanished on
+    // a hand-built AST; now `evaluate()` raises the code `parse()` does.
+    describe('versus in a meta position is rejected (#267)', () => {
+      const lit = (value: number): ASTNode => ({ type: 'Literal', value });
+      const versus = (): ASTNode => parse('1d20 vs 15');
+
+      const positions: ReadonlyArray<readonly [string, (v: ASTNode) => ASTNode]> = [
+        ['dice count', (v) => ({ type: 'Dice', count: v, sides: lit(6) })],
+        ['dice sides', (v) => ({ type: 'Dice', count: lit(1), sides: v })],
+        ['Fate dice count', (v) => ({ type: 'FateDice', count: v })],
+        [
+          'keep/drop count',
+          (v) => ({
+            type: 'KeepDrop',
+            kind: 'keep',
+            selector: 'highest',
+            count: v,
+            target: parse('4d6'),
+          }),
+        ],
+        [
+          'success-count threshold',
+          (v) => ({
+            type: 'SuccessCount',
+            threshold: { operator: '>=', value: v },
+            target: parse('4d6'),
+          }),
+        ],
+        [
+          'explode threshold',
+          (v) => ({
+            type: 'Explode',
+            variant: 'standard',
+            threshold: { operator: '>=', value: v },
+            target: parse('4d6'),
+          }),
+        ],
+        [
+          'reroll condition',
+          (v) => ({
+            type: 'Reroll',
+            once: true,
+            condition: { operator: '<', value: v },
+            target: parse('4d6'),
+          }),
+        ],
+        [
+          'die-bound value',
+          (v) => ({ type: 'DieBound', bound: 'min', value: v, target: parse('4d6') }),
+        ],
+        [
+          'crit-threshold value',
+          (v) => ({
+            type: 'CritThreshold',
+            successThresholds: [{ operator: '>=', value: v }],
+            failThresholds: [],
+            target: parse('4d6'),
+          }),
+        ],
+      ];
+
+      for (const [name, wrap] of positions) {
+        test(`a versus as a ${name} throws NESTED_VERSUS (#267)`, () => {
+          expectRollError(
+            () => evaluate(wrap(versus()), createMockRng([3, 4, 1, 2, 5, 6])),
+            EvaluatorError,
+            'NESTED_VERSUS',
+          );
+        });
+      }
+
+      test('a wrapped versus is caught too (#267)', () => {
+        // The scan is deep, so a function call or arithmetic around the versus
+        // cannot smuggle one into a meta position.
+        const wrapped: ASTNode = {
+          type: 'FunctionCall',
+          name: 'floor',
+          args: [{ type: 'BinaryOp', operator: '+', left: versus(), right: lit(0) }],
+        };
+
+        expectRollError(
+          () => evaluate({ type: 'FateDice', count: wrapped }, createMockRng([3])),
+          EvaluatorError,
+          'NESTED_VERSUS',
+        );
+      });
+
+      test('the error points at the versus subtree, not the consumer (#267)', () => {
+        // The throw never enters the operand's own `evalNode` frame, so without
+        // an explicit stamp the span would be the outer node's — absent here,
+        // since the consumer is hand-built.
+        const error = expectRollError(
+          () => evaluate({ type: 'FateDice', count: versus() }, createMockRng([3])),
+          EvaluatorError,
+          'NESTED_VERSUS',
+        );
+
+        // `1d20 vs 15` — the whole operand, not the FateDice wrapper.
+        expect(getErrorSpan(error)).toEqual({ start: 0, end: 10 });
+      });
+
+      test('a wrapper that voids the metadata is caught too (#267)', () => {
+        // `evalDieBound` drops `versusMetadata` by design (#260), so watching
+        // for surviving metadata would let this one through. The structural
+        // scan does not care what the wrapper does to the degree.
+        const clamped: ASTNode = {
+          type: 'DieBound',
+          bound: 'min',
+          value: lit(20),
+          target: versus(),
+        };
+
+        expectRollError(
+          () => evaluate({ type: 'FateDice', count: clamped }, createMockRng([3])),
+          EvaluatorError,
+          'NESTED_VERSUS',
+        );
+      });
+
+      test('no RNG is drawn before the rejection (#267)', () => {
+        // The scan is structural and runs first, so the operand's dice never
+        // roll. An exhausted mock would surface as MockRNGExhaustedError.
+        expectRollError(
+          () => evaluate({ type: 'FateDice', count: versus() }, createMockRng([])),
+          EvaluatorError,
+          'NESTED_VERSUS',
+        );
+      });
+
+      test('a non-versus meta expression still resolves (#267)', () => {
+        const result = evaluate(
+          { type: 'Dice', count: parse('1d2'), sides: lit(6) },
+          createMockRng([2, 4, 5]),
+        );
+
+        expect(result.total).toBe(9);
       });
     });
 

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -27,6 +27,7 @@ import type {
   VersusNode,
 } from '../parser/ast.js';
 import { isKeepDrop } from '../parser/ast.js';
+import { containsVersus } from '../parser/guards.js';
 import type { RNG } from '../rng/types.js';
 import type {
   CompareOp,
@@ -266,6 +267,10 @@ function renderDie(result: number, modifiers: readonly DieModifier[]): string {
  * a SuccessCount leaking into a meta sub-expression (parser rejects all such
  * wrappings; this strip ensures a future parse regression cannot leak tags
  * into the top-level `successes`/`failures` scan).
+ *
+ * `versusMetadata` is deliberately not forwarded — a meta sub-expression
+ * resolves to a scalar. `evalMetaOperand` rejects a versus before reaching
+ * here, so nothing is lost by the omission.
  */
 // Exported rather than `@internal`: the tag strip above is unreachable through
 // any parseable notation, so pinning it needs a direct call with a hand-built
@@ -445,9 +450,29 @@ function evalVariable(node: VariableNode, ctx: EvalContext, env: EvalEnv): EvalR
  * — is answered from the node without allocating the throwaway context: a
  * literal draws no RNG, produces no rolls, and cannot throw, so the merge has
  * nothing to carry. Draw order is untouched (see README, Randomness).
+ *
+ * A versus operand is rejected rather than reduced to its total: this forwards
+ * rolls but not `versusMetadata`, so consuming one would drop the resolved
+ * `degree`/`natural` with no signal. `rejectVersusMetaOperand` refuses the same
+ * positions at parse time; this is the backstop for a hand-built AST.
+ *
+ * The scan is structural and runs first. Watching for surviving `versusMetadata`
+ * instead would miss a versus under a wrapper that voids it (`DieBound`,
+ * `KeepDrop`), lose the race to any other runtime error in the operand, and burn
+ * RNG draws before failing.
  */
 function evalMetaOperand(node: ASTNode, rng: RNG, ctx: EvalContext, env: EvalEnv): number {
   if (node.type === 'Literal') return node.value;
+
+  if (containsVersus(node)) {
+    const error = new EvaluatorError(
+      'Versus cannot be used as a meta-expression',
+      'NESTED_VERSUS',
+      'Versus',
+    );
+    if (node.start != null) stampEvaluatorSpan(error, node.start, node.end);
+    throw error;
+  }
 
   const metaCtx = createContext();
   const value = evalNode(node, rng, metaCtx, env).total;

--- a/src/parser/guards.ts
+++ b/src/parser/guards.ts
@@ -234,11 +234,14 @@ export function containsMultiSubGroup(node: ASTNode): boolean {
 }
 
 /**
- * Deep-walks a node to find any descendant `Versus`. Used by
- * `rejectVersusTarget`'s single-sub-roll Group passthrough so a buried
- * Versus (`{1+(1d20 vs 15)}cs>18`, `{abs(1d20 vs 15)}cs>18`,
- * `{-(1d20 vs 15)}kh1`) still rejects with `NESTED_VERSUS` instead of
- * silently dropping `versusMetadata` at the modifier consumer site.
+ * Deep-walks a node to find any descendant `Versus`. A buried Versus
+ * (`floor(1d20 vs 15)`, `(1d20 vs 15)+0`, `{1+(1d20 vs 15)}`) must reject with
+ * `NESTED_VERSUS` rather than silently drop `versusMetadata` at the consumer.
+ *
+ * Two callers, both on that hole: `rejectVersusMetaOperand` guards every meta
+ * operand — dice count and sides, keep/drop count, thresholds, die bounds — and
+ * `rejectVersusTarget` uses it for its single-sub-roll Group passthrough.
+ * `evalMetaOperand` runs the same walk as the hand-built-AST backstop.
  */
 export function containsVersus(node: ASTNode): boolean {
   return someDescendant(node, isVersusHit);

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1332,8 +1332,9 @@ describe('Parser', () => {
     });
 
     // A single-sub-roll `{...}` Group passes its expression through, so a Versus
-    // inside one reaches sites the shallow `rejectVersusTarget` never looked at —
-    // every parens-form case above needs a `{...}`-form twin.
+    // inside one reaches target sites the shallow `rejectVersusTarget` never
+    // looked at. The meta-operand cases above now share the deep walk, so their
+    // `{...}` twins are no longer a separate bypass — they stay as coverage.
     it('should reject Versus inside parens-wrapped single-sub group as keep-modifier count: 4d6kh({1d20 vs 10})', () => {
       // `kh{...}` is not valid syntax — `kh` requires parens. `kh({...})` is the
       // real bypass route: parens around a single-sub Group around a Versus.
@@ -1363,6 +1364,44 @@ describe('Parser', () => {
       // BinaryOp propagates `versusMetadata` through `mergeContext`, so
       // arithmetic is not a meta-expression site.
       expect(() => parseAst('{1d20 vs 15}+5')).not.toThrow();
+    });
+
+    // The shallow guard unwrapped only `Grouped` and special-cased a single-sub
+    // Group, so a Versus behind a function call or arithmetic parsed and then
+    // lost its degree at `evalMetaOperand`. These all evaluated to a
+    // degree-less result before #267.
+    const wrapped = [
+      '4d6kh(floor(1d20 vs 15))',
+      '4d6kh((1d20 vs 15)+0)',
+      '4d6kh(floor((1d20 vs 15)/10)+1)',
+      '(floor(1d20 vs 15))d6',
+      '1d(floor(1d20 vs 15)+5)',
+      '(abs(1d20 vs 15))dF',
+      '(floor(1d20 vs 15))d%',
+      '4d6>=(floor(1d20 vs 15))',
+      '4d6>=6f(floor(1d20 vs 15))',
+      '4d6min(floor(1d20 vs 15))',
+      '4d6cs>(floor(1d20 vs 15))',
+      '4d6cs>18cf<(floor(1d20 vs 15))',
+      '1d6!>=(floor(1d20 vs 15))',
+      '1d6r<=(floor(1d20 vs 15))',
+      '4d6kh({floor(1d20 vs 15)})',
+    ];
+
+    for (const notation of wrapped) {
+      it(`should reject a wrapper-hidden Versus in a meta position: ${notation} (#267)`, () => {
+        expectRollError(() => parseAst(notation), ParseError, 'NESTED_VERSUS');
+      });
+    }
+
+    it('should still accept a multi-sub group with a Versus as a kh target (#267)', () => {
+      // The meta guard is deep, the target guard stays shallow —
+      // `evalGroupKeepDrop` propagates the degree from kept sub-rolls.
+      expect(() => parseAst('{1d20 vs 15, 1d6}kh1')).not.toThrow();
+    });
+
+    it('should still accept a wrapped Versus outside a meta position (#267)', () => {
+      expect(() => parseAst('floor(1d20 vs 15)+5')).not.toThrow();
     });
   });
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -438,7 +438,7 @@ export class Parser {
   private parsePrefixDice(token: Token): DiceNode {
     const sides = this.parseExpression(BP.DICE_RIGHT);
     this.rejectSuccessCountTarget(sides, token);
-    this.rejectVersusTarget(sides, token);
+    this.rejectVersusMetaOperand(sides, token);
     return {
       type: 'Dice',
       count: Parser.syntheticLiteral(1, token),
@@ -450,11 +450,11 @@ export class Parser {
 
   private parseInfixDice(left: ASTNode, token: Token): DiceNode {
     this.rejectSuccessCountTarget(left, token);
-    this.rejectVersusTarget(left, token);
+    this.rejectVersusMetaOperand(left, token);
     this.rejectBareDiceChain(left, token);
     const sides = this.parseExpression(BP.DICE_RIGHT);
     this.rejectSuccessCountTarget(sides, token);
-    this.rejectVersusTarget(sides, token);
+    this.rejectVersusMetaOperand(sides, token);
     return {
       type: 'Dice',
       count: left,
@@ -476,7 +476,7 @@ export class Parser {
 
   private parseInfixDicePercent(left: ASTNode, token: Token): DiceNode {
     this.rejectSuccessCountTarget(left, token);
-    this.rejectVersusTarget(left, token);
+    this.rejectVersusMetaOperand(left, token);
     this.rejectBareDiceChain(left, token);
     return {
       type: 'Dice',
@@ -500,7 +500,7 @@ export class Parser {
     // No sides sub-parse, unlike `parseInfixDice`, so modifiers (`kh`, `dl`, …)
     // bind at the outer Pratt loop with no BP competition from a right operand.
     this.rejectSuccessCountTarget(left, token);
-    this.rejectVersusTarget(left, token);
+    this.rejectVersusMetaOperand(left, token);
     this.rejectBareDiceChain(left, token);
     return {
       type: 'FateDice',
@@ -700,11 +700,31 @@ export class Parser {
     throw new ParseError(`Cannot ${action} a group`, code, token.position, token);
   }
 
+  /**
+   * Rejects a Versus anywhere inside a meta operand — a dice count, dice sides,
+   * a modifier count, or a threshold/bound value.
+   *
+   * Deep, unlike {@link rejectVersusTarget}: `evalMetaOperand` reduces the
+   * operand to a scalar and forwards rolls but not `versusMetadata`, so
+   * `floor(1d20 vs 15)` or `(1d20 vs 15)+0` buried in a count loses the degree
+   * exactly as a bare one does.
+   */
+  private rejectVersusMetaOperand(operand: ASTNode, token: Token): void {
+    if (containsVersus(operand)) {
+      throw new ParseError(
+        `Versus cannot be used as a meta-expression`,
+        'NESTED_VERSUS',
+        token.position,
+        token,
+      );
+    }
+  }
+
   private rejectVersusTarget(target: ASTNode, token: Token): void {
-    // A Versus degree is a terminal scalar, never a valid dice count, sides, or
-    // threshold. Only the `mergeMetaRolls` sites need blocking, where
-    // `versusMetadata` would silently vanish; wrappers like `floor(vs)+0` still
-    // propagate it via `mergeContext`.
+    // A Versus degree is a terminal scalar, never a valid modifier target —
+    // every one of these modifiers drops `versusMetadata` on the way through.
+    // Shallow on purpose: a multi-sub group like `{1d20 vs 15, 1d6}kh1` is
+    // legal, and `evalGroupKeepDrop` propagates the degree from kept sub-rolls.
     // Narrow unwrap (only `Grouped`): `containsDicePool` does not recurse into
     // `Versus`, so `KeepDrop`/`Sort`/`CritThreshold` reject the wrap upstream.
     const node = unwrapGrouped(target);
@@ -770,7 +790,7 @@ export class Parser {
       ? this.parseExpression(BP.DICE_LEFT)
       : Parser.syntheticLiteral(1, token);
     this.rejectSuccessCountTarget(count, token);
-    this.rejectVersusTarget(count, token);
+    this.rejectVersusMetaOperand(count, token);
 
     return {
       type: 'KeepDrop',
@@ -931,7 +951,7 @@ export class Parser {
 
     const value = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(value, token);
-    this.rejectVersusTarget(value, token);
+    this.rejectVersusMetaOperand(value, token);
 
     return {
       type: 'DieBound',
@@ -1086,7 +1106,7 @@ export class Parser {
     // Threshold binds at `BP.DICE_LEFT` — see `parseComparePoint` TSDoc.
     const value = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(value, token);
-    this.rejectVersusTarget(value, token);
+    this.rejectVersusMetaOperand(value, token);
     const start = target.start ?? token.position;
     const end = value.end ?? token.end;
 
@@ -1114,7 +1134,7 @@ export class Parser {
     // Same threshold binding as `parseComparePoint` (BP.DICE_LEFT).
     const failValue = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(failValue, token);
-    this.rejectVersusTarget(failValue, token);
+    this.rejectVersusMetaOperand(failValue, token);
 
     return { operator: '=', value: failValue };
   }
@@ -1186,7 +1206,7 @@ export class Parser {
 
     const value = this.parseExpression(BP.DICE_LEFT);
     this.rejectSuccessCountTarget(value, token);
-    this.rejectVersusTarget(value, token);
+    this.rejectVersusMetaOperand(value, token);
 
     return { operator, value };
   }


### PR DESCRIPTION
Deepened the parser's versus rejection at every meta-operand site and added the matching evaluator backstop.

## Changes

- Added `rejectVersusMetaOperand`, a `containsVersus` deep walk, at the nine meta-operand parse sites — dice count and sides, keep/drop count, explode and reroll compare points, die bounds, crit thresholds, success-count and bare `fN` thresholds
- Left the four target-position sites on the shallow `rejectVersusTarget`
- Added a structural `containsVersus` scan to `evalMetaOperand`, stamping the operand's span on the `NESTED_VERSUS` it raises

## Breaking

The issue's premise that this was unreachable from notation was wrong. The shallow guard unwrapped only `Grouped` and special-cased a single-sub `Group`, so `4d6kh(floor(1d20 vs 15))`, `(floor(1d20 vs 15))d6` and their kin parsed and then dropped the degree at `evalMetaOperand`. Those notations now raise `NESTED_VERSUS` at parse time — they only ever returned a degree-less result.

Target positions stay shallow because a multi-sub group like `{1d20 vs 15, 1d6}kh1` is legal, and `evalGroupKeepDrop` propagates the degree from kept sub-rolls.

The evaluator scan is structural rather than a check for surviving `versusMetadata`: post-hoc detection would miss a versus under a wrapper that voids the metadata itself (`DieBound`, `KeepDrop`), lose the race to any other runtime error in the operand, and burn RNG draws before failing.

Propagating the metadata instead of rejecting was considered and dropped — a degree resolved against one pool is meaningless beside a total from another, the same reasoning as #258.

Closes #267
