### PR TITLE
refactor: dedupe the lit test factory and the NESTED_VERSUS throw sites #272

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -34,6 +34,11 @@ function getDie(rolls: DieResult[], index: number): DieResult {
   return die;
 }
 
+/** Literal node factory for the hand-built ASTs below. */
+function lit(value: number): ASTNode {
+  return { type: 'Literal', value };
+}
+
 /** Runs `fn`, returning whatever it threw. Fails when nothing is thrown. */
 function captureError(fn: () => unknown): unknown {
   try {
@@ -2131,7 +2136,6 @@ describe('evaluate', () => {
     // sums, selects, clamps, rerolls, explodes, or tallies its target's dice
     // reached across into the DC side.
     describe('DC dice are excluded from every pool operation (#262)', () => {
-      const lit = (value: number): ASTNode => ({ type: 'Literal', value });
       const diceDc = (): ASTNode => parse('1d20 vs 2d10');
 
       // Each case picks draws that would make the modifier *fire* on the DC
@@ -2334,7 +2338,6 @@ describe('evaluate', () => {
     // rolls but not `versusMetadata`. Before #267 the degree simply vanished on
     // a hand-built AST; now `evaluate()` raises the code `parse()` does.
     describe('versus in a meta position is rejected (#267)', () => {
-      const lit = (value: number): ASTNode => ({ type: 'Literal', value });
       const versus = (): ASTNode => parse('1d20 vs 15');
 
       const positions: ReadonlyArray<readonly [string, (v: ASTNode) => ASTNode]> = [

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -710,14 +710,22 @@ export class Parser {
    * exactly as a bare one does.
    */
   private rejectVersusMetaOperand(operand: ASTNode, token: Token): void {
-    if (containsVersus(operand)) {
-      throw new ParseError(
-        `Versus cannot be used as a meta-expression`,
-        'NESTED_VERSUS',
-        token.position,
-        token,
-      );
-    }
+    if (containsVersus(operand)) Parser.throwVersusMetaExpression(token);
+  }
+
+  /**
+   * The wording the meta-expression rejections share. Not every `NESTED_VERSUS`
+   * throw — `parseVersus` says "Cannot chain versus operators" for `a vs b vs c`,
+   * a different condition. Routing that one through here would silently rewrite
+   * its message, and `expectRollError` asserts only the code.
+   */
+  private static throwVersusMetaExpression(token: Token): never {
+    throw new ParseError(
+      `Versus cannot be used as a meta-expression`,
+      'NESTED_VERSUS',
+      token.position,
+      token,
+    );
   }
 
   private rejectVersusTarget(target: ASTNode, token: Token): void {
@@ -728,14 +736,7 @@ export class Parser {
     // Narrow unwrap (only `Grouped`): `containsDicePool` does not recurse into
     // `Versus`, so `KeepDrop`/`Sort`/`CritThreshold` reject the wrap upstream.
     const node = unwrapGrouped(target);
-    if (node.type === 'Versus') {
-      throw new ParseError(
-        `Versus cannot be used as a meta-expression`,
-        'NESTED_VERSUS',
-        token.position,
-        token,
-      );
-    }
+    if (node.type === 'Versus') Parser.throwVersusMetaExpression(token);
     // ! `containsDicePool` recurses into a single-sub-roll Group via
     // ! `deepContainsDicePool`, which traverses Versus's `roll`/`dc` — so that
     // ! route gets a Versus past the shallow guards. Deep-walk for any descendant
@@ -743,14 +744,7 @@ export class Parser {
     // ! `4d6>={abs(1d20 vs 15)}` would parse while `(1d20 vs 15)cs>18` rejects.
     if (node.type === 'Group' && node.expressions.length === 1) {
       const inner = node.expressions[0];
-      if (inner != null && containsVersus(inner)) {
-        throw new ParseError(
-          `Versus cannot be used as a meta-expression`,
-          'NESTED_VERSUS',
-          token.position,
-          token,
-        );
-      }
+      if (inner != null && containsVersus(inner)) Parser.throwVersusMetaExpression(token);
     }
   }
 


### PR DESCRIPTION
Collapsed two duplications left behind by #267. No behaviour change.

## Changes

- Hoisted the `lit` literal-node factory in `evaluator.test.ts` to module scope, next to `getDie` and `captureError`, and dropped both per-`describe` copies
- Routed the three verbatim `Versus cannot be used as a meta-expression` throws in `parser.ts` through a private `throwVersusMetaExpression` helper

Three copies of one message meant a future wording change could miss a site, and `expectRollError` asserts only the code — a drifted message would not fail a test. The helper's TSDoc names `parseVersus`'s "Cannot chain versus operators" as the site that deliberately stays out, since routing it through would silently rewrite a user-facing message.

The evaluator's `evalMetaOperand` / `propagateMetadata` pair is left alone: the messages there describe different conditions, so merging them would force one wording on both.

Closes #272
