### PR TITLE
build: content-hash the site assets #277

### DIFF
--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -6,22 +6,27 @@
  * fonts, and rewrites both HTML files so every asset URL is relative
  * (`./assets/...`, `./fonts/...`) — required for hosting under the
  * `/roll-parser/` path on GitHub Pages. Exits non-zero on any failure.
+ *
+ * Bundles and stylesheets carry a content hash in their filename; fonts and
+ * `favicon.svg` do not, their bytes being fixed for a given name.
  */
 
 import { existsSync } from 'node:fs';
 import { readdir, rm } from 'node:fs/promises';
-import { join } from 'node:path';
-import type { RewritePair } from './site-manifest.js';
+import { basename, join } from 'node:path';
+import type { AssetNames, RewritePair } from './site-manifest.js';
 import {
   ASSETS_DIR_NAME,
   CSS_REWRITES,
   DOCS_DIR_NAME,
   FONTS_DIR_NAME,
   HTML_PAGES,
-  HTML_REWRITES,
+  hashedPattern,
+  htmlRewrites,
   PUBLIC_FILES,
+  SCRIPT_ASSETS,
   SCRIPT_ENTRYPOINTS,
-  STYLESHEETS,
+  STYLE_ASSETS,
 } from './site-manifest.js';
 
 const SITE_DIR = join(import.meta.dir, '..', 'site');
@@ -42,7 +47,7 @@ async function build(): Promise<void> {
     outdir: ASSETS_DIR,
     target: 'browser',
     minify: true,
-    naming: '[name].[ext]',
+    naming: '[name].[hash].[ext]',
   });
 
   if (!output.success) {
@@ -51,10 +56,11 @@ async function build(): Promise<void> {
     process.exit(1);
   }
 
-  await copyStyles();
+  const assets: AssetNames = new Map([...bundleNames(output), ...(await copyStyles())]);
+
   await copyFonts();
   await copyPublicFiles();
-  await writeHtml();
+  await writeHtml(assets);
 
   await generateDocs();
   await injectDocsThemeScript();
@@ -134,15 +140,52 @@ async function generateDocs(): Promise<void> {
 }
 
 /**
- * Copies the stylesheets into `assets/`, rewriting the dev-relative font path
- * (`../public/fonts/`) to its dist location (`../fonts/`) so `url(...)` still
- * resolves from the CSS file's new home in `assets/`.
+ * Pairs each entrypoint with the hashed basename Bun wrote for it, read back
+ * from the build output rather than predicted.
  */
-async function copyStyles(): Promise<void> {
-  for (const name of STYLESHEETS) {
-    const css = await Bun.file(join(SRC_DIR, name)).text();
-    await Bun.write(join(ASSETS_DIR, name), applyRewrites(css, CSS_REWRITES));
+function bundleNames(output: Bun.BuildOutput): [string, string][] {
+  const emitted = output.outputs
+    .filter((artifact) => artifact.kind === 'entry-point')
+    .map((artifact) => basename(artifact.path));
+
+  return SCRIPT_ASSETS.map((asset) => {
+    const pattern = hashedPattern(asset);
+    const matches = emitted.filter((file) => pattern.test(file));
+    const [bundle] = matches;
+
+    if (bundle === undefined || matches.length > 1) {
+      throw new Error(`expected one bundle matching ${pattern.source}, found ${matches.length}`);
+    }
+
+    return [asset.source, bundle];
+  });
+}
+
+/**
+ * Copies the stylesheets into `assets/` under hashed names, rewriting the
+ * dev-relative font path (`../public/fonts/`) to its dist location
+ * (`../fonts/`) so `url(...)` still resolves from the CSS file's new home.
+ *
+ * The hash covers the rewritten text, so a change to {@link CSS_REWRITES}
+ * moves the name too.
+ */
+async function copyStyles(): Promise<[string, string][]> {
+  const emitted: [string, string][] = [];
+
+  for (const { source, stem, extension } of STYLE_ASSETS) {
+    const css = applyRewrites(await Bun.file(join(SRC_DIR, source)).text(), CSS_REWRITES);
+    const hashed = `${stem}.${contentHash(css)}.${extension}`;
+
+    await Bun.write(join(ASSETS_DIR, hashed), css);
+    emitted.push([source, hashed]);
   }
+
+  return emitted;
+}
+
+/** Stands in for Bun's `[hash]` slot, which only covers what the bundler writes. */
+function contentHash(content: string): string {
+  return new Bun.CryptoHasher('sha256').update(content).digest('hex').slice(0, 8);
 }
 
 /** Copies the loose `public/` files that sit at the `dist/` root. */
@@ -164,10 +207,12 @@ async function copyFonts(): Promise<void> {
 }
 
 /** Rewrites each dev HTML file's asset paths to the built, relative ones. */
-async function writeHtml(): Promise<void> {
+async function writeHtml(assets: AssetNames): Promise<void> {
+  const rewrites = htmlRewrites(assets);
+
   for (const page of HTML_PAGES) {
     const html = await Bun.file(join(SITE_DIR, page)).text();
-    await Bun.write(join(DIST_DIR, page), applyRewrites(html, HTML_REWRITES));
+    await Bun.write(join(DIST_DIR, page), applyRewrites(html, rewrites));
   }
 }
 

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -12,7 +12,14 @@
 
 import { readdir } from 'node:fs/promises';
 import { join, normalize } from 'node:path';
-import { DOCS_DIR_NAME, FONTS_DIR_NAME, REQUIRED_FILES } from './site-manifest.js';
+import {
+  ASSETS_DIR_NAME,
+  DOCS_DIR_NAME,
+  FONTS_DIR_NAME,
+  HASHED_ASSETS,
+  hashedPattern,
+  REQUIRED_FILES,
+} from './site-manifest.js';
 
 const DIST_DIR = join(import.meta.dir, '..', 'site', 'dist');
 
@@ -29,6 +36,7 @@ const errors: string[] = [];
 
 async function main(): Promise<void> {
   await checkRequiredFiles();
+  await checkHashedAssets();
   await checkFontsPresent();
   await checkHtmlReferences();
 
@@ -45,6 +53,32 @@ async function checkRequiredFiles(): Promise<void> {
   for (const relative of REQUIRED_FILES) {
     if (!(await Bun.file(join(DIST_DIR, relative)).exists())) {
       errors.push(`missing required file: ${relative}`);
+    }
+  }
+}
+
+/**
+ * Bundles and stylesheets are named `<stem>.<hash>.<ext>`, which this process
+ * cannot predict — it counts matches per stem instead of resolving a path.
+ */
+async function checkHashedAssets(): Promise<void> {
+  let entries: string[];
+
+  try {
+    entries = await readdir(join(DIST_DIR, ASSETS_DIR_NAME));
+  } catch {
+    errors.push(`missing required directory: ${ASSETS_DIR_NAME}/`);
+    return;
+  }
+
+  for (const asset of HASHED_ASSETS) {
+    const pattern = hashedPattern(asset);
+    const matches = entries.filter((entry) => pattern.test(entry)).length;
+
+    if (matches !== 1) {
+      errors.push(
+        `expected exactly one ${ASSETS_DIR_NAME}/${asset.stem}.<hash>.${asset.extension}, found ${matches}`,
+      );
     }
   }
 }

--- a/scripts/site-manifest.test.ts
+++ b/scripts/site-manifest.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test';
+import { HASHED_ASSETS, type HashedAsset, hashedPattern, htmlRewrites } from './site-manifest.js';
+
+const asset = (source: string, stem: string, extension: string): HashedAsset => ({
+  source,
+  stem,
+  extension,
+});
+
+/** The emitted name for every hashed asset, as the build would report it. */
+const emittedNames = new Map(
+  HASHED_ASSETS.map(({ source, stem, extension }) => [source, `${stem}.abcd1234.${extension}`]),
+);
+
+describe('hashedPattern', () => {
+  it('matches the emitted name for each declared asset', () => {
+    for (const declared of HASHED_ASSETS) {
+      const emitted = emittedNames.get(declared.source) ?? '';
+
+      expect(hashedPattern(declared).test(emitted)).toBe(true);
+    }
+  });
+
+  it('accepts both the base-36 bundle hash and the hex stylesheet hash', () => {
+    const script = asset('main.ts', 'main', 'js');
+
+    expect(hashedPattern(script).test('main.43478gn4.js')).toBe(true);
+    expect(hashedPattern(asset('style.css', 'style', 'css')).test('style.ecbae398.css')).toBe(true);
+  });
+
+  it('rejects a sibling whose stem only shares a prefix (#277)', () => {
+    const pattern = hashedPattern(asset('main.ts', 'main', 'js'));
+
+    expect(pattern.test('main.worker.abcd1234.js')).toBe(false);
+    expect(pattern.test('main-admin.abcd1234.js')).toBe(false);
+  });
+
+  it('rejects an unhashed name', () => {
+    expect(hashedPattern(asset('main.ts', 'main', 'js')).test('main.js')).toBe(false);
+  });
+
+  it('treats a dot inside the stem literally (#277)', () => {
+    const pattern = hashedPattern(asset('main.test.css', 'main.test', 'css'));
+
+    expect(pattern.test('main.test.abcd1234.css')).toBe(true);
+    expect(pattern.test('mainXtest.abcd1234.css')).toBe(false);
+  });
+});
+
+describe('htmlRewrites', () => {
+  it('points every dev asset URL at the emitted name', () => {
+    const rewrites = htmlRewrites(emittedNames);
+
+    for (const { source } of HASHED_ASSETS) {
+      const pair = rewrites.find(([from]) => from === `./src/${source}`);
+
+      expect(pair?.[1]).toBe(`./assets/${emittedNames.get(source)}`);
+    }
+  });
+
+  it('leaves fonts and public files unhashed', () => {
+    const rewrites = htmlRewrites(emittedNames);
+
+    expect(rewrites).toContainEqual(['./public/fonts/', './fonts/']);
+    expect(rewrites).toContainEqual(['./public/favicon.svg', './favicon.svg']);
+  });
+
+  it('throws when an asset was never emitted', () => {
+    expect(() => htmlRewrites(new Map())).toThrow('no emitted name for "main.ts"');
+  });
+});

--- a/scripts/site-manifest.ts
+++ b/scripts/site-manifest.ts
@@ -14,6 +14,14 @@
 /** A literal `from` → `to` substitution applied with `String.replaceAll`. */
 export type RewritePair = readonly [from: string, to: string];
 
+/**
+ * Source name (`main.ts`, `style.css`) → emitted basename (`main.a1b2c3d4.js`).
+ *
+ * The build fills this in from what it actually wrote, so a hash never has to be
+ * predicted twice.
+ */
+export type AssetNames = ReadonlyMap<string, string>;
+
 /** Directory names inside `site/dist/`. */
 export const ASSETS_DIR_NAME = 'assets';
 export const FONTS_DIR_NAME = 'fonts';
@@ -38,24 +46,27 @@ export const HTML_PAGES = ['index.html', 'reference.html', '404.html'];
 /** Single files copied from `site/public/` into the `dist/` root. */
 export const PUBLIC_FILES = ['favicon.svg'];
 
-/** `main.ts` → `main.js`; the bundler renames entrypoints on the way out. */
-function toBundleName(entrypoint: string): string {
-  return entrypoint.replace(/\.ts$/, '.js');
-}
-
 /**
  * Rewrites applied to every page in {@link HTML_PAGES}.
  *
  * No pattern is a prefix of another, so the order is not significant.
+ *
+ * Fonts and {@link PUBLIC_FILES} keep their source names — same name, same bytes.
  */
-export const HTML_REWRITES: RewritePair[] = [
-  ...STYLESHEETS.map((name): RewritePair => [`./src/${name}`, `./${ASSETS_DIR_NAME}/${name}`]),
-  ...SCRIPT_ENTRYPOINTS.map(
-    (name): RewritePair => [`./src/${name}`, `./${ASSETS_DIR_NAME}/${toBundleName(name)}`],
-  ),
-  [`./public/${FONTS_DIR_NAME}/`, `./${FONTS_DIR_NAME}/`],
-  ...PUBLIC_FILES.map((name): RewritePair => [`./public/${name}`, `./${name}`]),
-];
+export function htmlRewrites(assets: AssetNames): RewritePair[] {
+  const emitted = (name: string): RewritePair => {
+    const basename = assets.get(name);
+    if (basename === undefined) throw new Error(`no emitted name for "${name}"`);
+
+    return [`./src/${name}`, `./${ASSETS_DIR_NAME}/${basename}`];
+  };
+
+  return [
+    ...HASHED_ASSETS.map((asset) => emitted(asset.source)),
+    [`./public/${FONTS_DIR_NAME}/`, `./${FONTS_DIR_NAME}/`],
+    ...PUBLIC_FILES.map((name): RewritePair => [`./public/${name}`, `./${name}`]),
+  ];
+}
 
 /**
  * Rewrite applied to every stylesheet. The dev path is one level deeper than
@@ -65,11 +76,53 @@ export const CSS_REWRITES: RewritePair[] = [
   [`../public/${FONTS_DIR_NAME}/`, `../${FONTS_DIR_NAME}/`],
 ];
 
-/** Every file the build must emit, as a `dist`-relative path. */
+/**
+ * Every unhashed file the build must emit, as a `dist`-relative path.
+ *
+ * Bundles and stylesheets are absent by design — {@link HASHED_ASSETS} covers those.
+ */
 export const REQUIRED_FILES: string[] = [
   ...HTML_PAGES,
   ...PUBLIC_FILES,
-  ...SCRIPT_ENTRYPOINTS.map((name) => `${ASSETS_DIR_NAME}/${toBundleName(name)}`),
-  ...STYLESHEETS.map((name) => `${ASSETS_DIR_NAME}/${name}`),
   `${DOCS_DIR_NAME}/index.html`,
 ];
+
+/** An asset emitted into `assets/` as `<stem>.<hash>.<extension>`. */
+export type HashedAsset = {
+  readonly source: string;
+  readonly stem: string;
+  readonly extension: string;
+};
+
+/** What {@link SCRIPT_ENTRYPOINTS} becomes once bundled. */
+export const SCRIPT_ASSETS: readonly HashedAsset[] = SCRIPT_ENTRYPOINTS.map((source) =>
+  hashedAsset(source, 'js'),
+);
+
+/** {@link STYLESHEETS}, copied rather than bundled, so the extension is unchanged. */
+export const STYLE_ASSETS: readonly HashedAsset[] = STYLESHEETS.map((source) =>
+  hashedAsset(source, extensionOf(source)),
+);
+
+/** Every hashed file the build must emit exactly one of. */
+export const HASHED_ASSETS: readonly HashedAsset[] = [...SCRIPT_ASSETS, ...STYLE_ASSETS];
+
+/**
+ * Matches the single file the build emits for an asset. A stem keeps its inner
+ * dots, so leaving it unescaped would also match a sibling that differs there.
+ */
+export function hashedPattern({ stem, extension }: HashedAsset): RegExp {
+  return new RegExp(`^${escapeRegExp(stem)}\\.[0-9a-z]+\\.${escapeRegExp(extension)}$`);
+}
+
+function hashedAsset(source: string, extension: string): HashedAsset {
+  return { source, stem: source.replace(/\.[^.]+$/, ''), extension };
+}
+
+function extensionOf(source: string): string {
+  return source.slice(source.lastIndexOf('.') + 1);
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
`assets/` bundles and stylesheets now carry a content hash, so the zone's 4-hour Browser Cache TTL can no longer serve a visitor JS or CSS from an older build than the HTML they just fetched.

- Emitted `assets/` bundles and stylesheets as `<stem>.<hash>.<ext>`
- Derived the HTML rewrites from what the build wrote, replacing the fixed-name `HTML_REWRITES` constant
- Narrowed `REQUIRED_FILES` to the unhashed files; `site:check` matches the rest by pattern, one per stem
- Added `scripts/site-manifest.test.ts` covering pattern matching and the rewrite mapping

Fonts and `favicon.svg` stay unhashed — same name, same bytes. `site/dist/docs/**` is TypeDoc's output under TypeDoc's filenames, so the API reference keeps its 4-hour window; closing that is separate work.

Verified with `bun validate` (1574 tests, all four size budgets), plus negative checks that `site:check` fails on a duplicate hashed asset and on a missing one.

Closes #277
