### PR TITLE
docs: link the published benchmark trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,8 +924,10 @@ mis-times mid-weight cases by 10-30x.
 Run `bun run bench` for the full suite, or `bench:lex` / `bench:parse` /
 `bench:evaluate` / `bench:roll` for one stage. Cross-library numbers live in
 the [competitor suite](https://github.com/edloidas/roll-parser/tree/master/bench/competitors)
-(`bun run bench:competitors`). Bundle size is gated in CI by `size-limit`; the
-budgets live in `package.json`.
+(`bun run bench:competitors`). Every push to `master` publishes its p50s to a
+[trend chart](https://edloidas.io/roll-parser/dev/bench/), and CI comments on
+any commit that regresses a case past 1.75x. Bundle size is gated in CI by
+`size-limit`; the budgets live in `package.json`.
 
 ## Known limitations
 


### PR DESCRIPTION
Adds a link to the CI-published p50 trend chart in the Performance section, now that `gh-pages` serves only the benchmark data and a redirect.

Related cleanup already pushed directly to `gh-pages` (unprotected, not part of this PR):
- removed 25 JSDoc 3.4.3 files documenting the removed 1.x API
- root `index.html` now redirects to `roll-parser.edloidas.io`
- `404.html` points dead 1.x doc links at the current docs
- added `.nojekyll`; `dev/bench/` untouched