### PR TITLE
perf: recover the pool-operation cost of the versus DC exclusion #281

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,8 @@ precedes them. Errors go to stderr; only the result goes to stdout.
 | `1d20` | 85 ns | 164 ns | **0.49 µs** (~2.0M rolls/s) |
 | `2d6+3` | 98 ns | 215 ns | **0.77 µs** |
 | `4d6kh3` | 122 ns | 245 ns | **1.2 µs** |
-| `10d10>=6f1` | 161 ns | 336 ns | **2.0 µs** |
+| `4d6sd` | 101 ns | 211 ns | **0.84 µs** |
+| `10d10>=6f1` | 161 ns | 336 ns | **1.6 µs** |
 | `100d6` | 82 ns | 168 ns | **2.6 µs** |
 
 The `roll` column pays for a fresh `SeededRNG` per call, which an injected RNG
@@ -906,12 +907,20 @@ Values are **p50**, from
 (`.gc('inner')`), taken as the per-record median of four full
 `bun run bench:json` passes, every row agreeing within 5% except
 `lex / 4d6kh3` at 7%. Measured 2026-08-05 on Bun
-1.3.14, Apple M2 Pro, macOS, idle and on AC power. The `4d6kh3` and
-`10d10>=6f1` `roll` figures were re-measured 2026-08-06 over three passes
-agreeing within 4%, after per-die `'dc'` tag checks entered the keep/drop and
-success-count paths; the remaining rows re-measured within noise. Read them as
+1.3.14, Apple M2 Pro, macOS, idle and on AC power. Read them as
 two significant digits: another machine shifts every row, and a busy one
 inflates the heavy cases most.
+
+The `10d10>=6f1` `roll` figure and the `4d6sd` row come from a later
+five-pass measurement on the same machine, after the per-die `'dc'` tag checks
+that had entered the keep/drop, success-count, and sort paths were hoisted out
+of those loops. That session was not idle: `evaluate / 10d10>=6f1` and
+`evaluate / 10d10sd` each read bimodally across passes with roughly 10% between
+the two modes, so those two are quoted as "recovered to the pre-exclusion
+range" rather than to a point value. The rows this hoist does not touch
+(`1d20`, `2d6+3`, `4d6kh3`, `100d6`) re-measured within noise of the figures
+above and are left as first measured, since the earlier idle session is the
+better data for them.
 
 p50 rather than mean, because the mean here is effectively a GC-pause
 histogram and swings ±40% between processes. Every bench body is JIT-primed

--- a/bench/_cases.ts
+++ b/bench/_cases.ts
@@ -60,6 +60,11 @@ export const BENCH_CASES: BenchCase[] = [
   { id: '{1d6+2}kh1', notation: '{1d6+2}kh1', tier: 'common' },
   { id: '2d20kh1 vs 15', notation: '2d20kh1 vs 15', tier: 'common' },
   { id: '10d10>=6f1', notation: '10d10>=6f1', tier: 'common' },
+  { id: '4d6sd', notation: '4d6sd', tier: 'common' },
+  { id: '10d10sd', notation: '10d10sd', tier: 'common' },
+  // Sort composed with a success pool — the two pool passes that cost the most
+  // per die, so the shape most exposed to a per-die regression in either (#281).
+  { id: '10d10sd>=6f1', notation: '10d10sd>=6f1', tier: 'common' },
   { id: '4d6r<2', notation: '4d6r<2', tier: 'common', variableWork: true },
   { id: 'floor((1d4+1)*2/3)', notation: 'floor((1d4+1)*2/3)', tier: 'common' },
   { id: '@atk+1d20', notation: '@atk+1d20', tier: 'common', context: { atk: 7 } },
@@ -74,6 +79,7 @@ export const BENCH_CASES: BenchCase[] = [
   { id: 'sum-20-terms', notation: FLAT_SUM_NOTATION, tier: 'heavy' },
   { id: '100d6', notation: '100d6', tier: 'heavy' },
   { id: '100d6kh1', notation: '100d6kh1', tier: 'heavy' },
+  { id: '100d6sa', notation: '100d6sa', tier: 'heavy' },
 
   { id: '1000d6', notation: '1000d6', tier: 'pathological' },
 ];

--- a/src/evaluator/env.ts
+++ b/src/evaluator/env.ts
@@ -36,6 +36,17 @@ export type EvalEnv = {
    */
   insideVersus: boolean;
   /**
+   * `true` once a `vs` has tagged its DC dice `'dc'`. Lets every pool
+   * operation skip its per-die `isVersusDc` check outright — the tag exists in
+   * a small minority of notation, and the call inside the loop cost 11-38% on
+   * keep/drop, success, and sort notation that can never carry one (#281).
+   *
+   * ! Monotonic: set by `evalVersus`, never cleared. `insideVersus` is not a
+   * ! model for it — that flag resets in a `finally`, and it is false exactly
+   * ! when the tagged DC dice become visible to the enclosing pool.
+   */
+  hasVersusDc: boolean;
+  /**
    * User-supplied variable map for `@name` / `@{name}` references. Always
    * defined — `evaluate()` defaults to an empty object so lookups can be
    * branch-free on presence.

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -952,11 +952,15 @@ function flattenKeepDropChain(
  * selects against the unmodified pool: `markDroppedIndices` reads results and
  * writes only into `droppedMask`, so no spec can observe another's outcome.
  */
-function mergeDropSets(baseDice: DieResult[], specs: KeepDropChainEntry[]): DieResult[] {
+function mergeDropSets(
+  baseDice: DieResult[],
+  specs: KeepDropChainEntry[],
+  hasVersusDc: boolean,
+): DieResult[] {
   const droppedMask = new Uint8Array(baseDice.length);
 
   for (const spec of specs) {
-    markDroppedIndices(baseDice, spec.count, spec.kind, spec.selector, droppedMask);
+    markDroppedIndices(baseDice, spec.count, spec.kind, spec.selector, droppedMask, hasVersusDc);
   }
 
   for (let index = 0; index < baseDice.length; index++) {
@@ -1050,7 +1054,7 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   // are self-evident, explosion origin is otherwise invisible.
   ctx.renderedParts.push(`${targetExpr}${code}${renderDice(expanded)}`);
 
-  const total = sumKeptDice(expanded);
+  const total = sumKeptDice(expanded, env.hasVersusDc);
   return { total, part: buildPart(total) };
 }
 
@@ -1071,7 +1075,7 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
   if (targetCtx.rolls.length === 0) {
     ctx.expressionParts.push(`${targetExpr}${code}`);
     ctx.renderedParts.push(`${targetExpr}${code}`);
-    const total = sumKeptDice(targetCtx.rolls);
+    const total = sumKeptDice(targetCtx.rolls, env.hasVersusDc);
     return {
       total,
       part: {
@@ -1093,7 +1097,7 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
   ctx.expressionParts.push(`${targetExpr}${code}`);
   ctx.renderedParts.push(`${targetExpr}${code}${renderDice(pool)}`);
 
-  const total = sumKeptDice(pool);
+  const total = sumKeptDice(pool, env.hasVersusDc);
   return {
     total,
     part: {
@@ -1126,7 +1130,7 @@ function evalDieBound(node: DieBoundNode, rng: RNG, ctx: EvalContext, env: EvalE
     );
   }
 
-  applyDieBound(targetCtx.rolls, node.bound, boundValue);
+  applyDieBound(targetCtx.rolls, node.bound, boundValue, env.hasVersusDc);
 
   appendAll(ctx.rolls, targetCtx.rolls);
   // ! No `propagateMetadata` here: clamping re-sums, so a propagated `degree`
@@ -1141,7 +1145,7 @@ function evalDieBound(node: DieBoundNode, rng: RNG, ctx: EvalContext, env: EvalE
   ctx.expressionParts.push(`${targetExpr}${code}`);
   ctx.renderedParts.push(`${targetExpr}${code}${renderDice(targetCtx.rolls)}`);
 
-  const total = sumKeptDice(targetCtx.rolls);
+  const total = sumKeptDice(targetCtx.rolls, env.hasVersusDc);
   return {
     total,
     part: {
@@ -1175,7 +1179,7 @@ function evalSort(node: SortNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eva
   const targetCtx = createContext();
   const target = evalNode(node.target, rng, targetCtx, env);
 
-  const sortedRolls = sortDice(targetCtx.rolls, node.order);
+  const sortedRolls = sortDice(targetCtx.rolls, node.order, env.hasVersusDc);
 
   appendAll(ctx.rolls, sortedRolls);
   propagateMetadata(ctx, targetCtx.versusMetadata);
@@ -1233,7 +1237,7 @@ function evalCritThreshold(
     successResolved.length > 0 ? successResolved : ['default'];
   const failApplied: ResolvedCritThreshold[] = failResolved.length > 0 ? failResolved : ['default'];
 
-  applyCritThresholds(targetCtx.rolls, successApplied, failApplied);
+  applyCritThresholds(targetCtx.rolls, successApplied, failApplied, env.hasVersusDc);
 
   appendAll(ctx.rolls, targetCtx.rolls);
   propagateMetadata(ctx, targetCtx.versusMetadata);
@@ -1296,11 +1300,11 @@ function evalKeepDrop(node: KeepDropNode, rng: RNG, ctx: EvalContext, env: EvalE
   const targetCtx = createContext();
   const target = evalNode(baseTarget, rng, targetCtx, env);
 
-  const mergedDice = mergeDropSets(targetCtx.rolls, specs);
+  const mergedDice = mergeDropSets(targetCtx.rolls, specs, env.hasVersusDc);
 
   appendAll(ctx.rolls, mergedDice);
 
-  const total = sumKeptDice(mergedDice);
+  const total = sumKeptDice(mergedDice, env.hasVersusDc);
 
   const targetExpr = targetCtx.expressionParts.join('');
   const keepDropCodes = specs.map((s) => `${s.code}${s.count}`).join('');
@@ -1383,7 +1387,7 @@ function evalGroupKeepDrop(
     fumble: false,
   }));
 
-  const mergedSynthetic = mergeDropSets(syntheticDice, specs);
+  const mergedSynthetic = mergeDropSets(syntheticDice, specs, env.hasVersusDc);
 
   const outerRendered: string[] = [];
   const keptIndices: number[] = [];
@@ -1541,6 +1545,7 @@ function evalSuccessCount(
     failValue != null && node.failThreshold != null
       ? { operator: node.failThreshold.operator, value: failValue }
       : undefined,
+    env.hasVersusDc,
   );
 
   appendAll(ctx.rolls, targetCtx.rolls);
@@ -1637,6 +1642,8 @@ function evalVersus(node: VersusNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
     for (const die of dcCtx.rolls) {
       die.modifiers.push('dc');
     }
+    // Arms the exclusion checks every enclosing pool operation skips by default.
+    if (dcCtx.rolls.length > 0) env.hasVersusDc = true;
     appendAll(ctx.rolls, dcCtx.rolls);
 
     const rollExpr = rollCtx.expressionParts.join('');
@@ -1730,6 +1737,7 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
     totalDiceRolled: 0,
     hasSuccessCount: false,
     insideVersus: false,
+    hasVersusDc: false,
     context,
     onMissingVariable,
   };
@@ -1761,21 +1769,24 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
     rendered,
     rolls: ctx.rolls,
     parts: part,
-    ...(env.hasSuccessCount ? countTaggedDice(ctx.rolls) : {}),
+    ...(env.hasSuccessCount ? countTaggedDice(ctx.rolls, env.hasVersusDc) : {}),
     ...(versus ? { degree: versus.degree } : {}),
     ...(versus?.natural != null ? { natural: versus.natural } : {}),
   };
 }
 
 /** Tallies the `'success'` / `'failure'` tags across a whole roll. */
-function countTaggedDice(rolls: DieResult[]): { successes: number; failures: number } {
+function countTaggedDice(
+  rolls: DieResult[],
+  hasVersusDc: boolean,
+): { successes: number; failures: number } {
   let successes = 0;
   let failures = 0;
 
   for (const die of rolls) {
     // A success-count inside the DC sub-expression tags its own dice before
     // `evalVersus` marks them `'dc'`, so they arrive here already tagged.
-    if (isVersusDc(die)) continue;
+    if (hasVersusDc && isVersusDc(die)) continue;
     if (die.modifiers.includes('success')) successes += 1;
     else if (die.modifiers.includes('failure')) failures += 1;
   }

--- a/src/evaluator/modifiers/crit-threshold.ts
+++ b/src/evaluator/modifiers/crit-threshold.ts
@@ -31,9 +31,11 @@ export function applyCritThresholds(
   dice: DieResult[],
   successThresholds: ResolvedCritThreshold[],
   failThresholds: ResolvedCritThreshold[],
+  hasVersusDc: boolean,
 ): void {
   for (const die of dice) {
-    if (die.modifiers.includes('meta') || isVersusDc(die)) continue;
+    if (die.modifiers.includes('meta')) continue;
+    if (hasVersusDc && isVersusDc(die)) continue;
 
     die.critical = successThresholds.some((t) => matchesCrit(t, die));
     die.fumble = failThresholds.some((t) => matchesFumble(t, die));

--- a/src/evaluator/modifiers/die-bound.ts
+++ b/src/evaluator/modifiers/die-bound.ts
@@ -25,9 +25,15 @@ import { isVersusDc } from './flags.js';
  * `bound: 'min'` lifts lower results up to `value`; `'max'` caps higher
  * results down to it. Untouched dice keep their tags.
  */
-export function applyDieBound(dice: DieResult[], bound: 'min' | 'max', value: number): void {
+export function applyDieBound(
+  dice: DieResult[],
+  bound: 'min' | 'max',
+  value: number,
+  hasVersusDc: boolean,
+): void {
   for (const die of dice) {
-    if (die.modifiers.includes('meta') || isVersusDc(die)) continue;
+    if (die.modifiers.includes('meta')) continue;
+    if (hasVersusDc && isVersusDc(die)) continue;
 
     const clamped = bound === 'min' ? Math.max(die.result, value) : Math.min(die.result, value);
     if (clamped === die.result) continue;

--- a/src/evaluator/modifiers/explode.ts
+++ b/src/evaluator/modifiers/explode.ts
@@ -84,8 +84,8 @@ function explodeLimitError(maxIterations: number): EvaluatorError {
  * never fire during normal flow. Keeping it ensures `rng.nextInt(1, 0)`
  * can never be reached if a future AST path slips past the parser gate.
  */
-function canExplode(die: DieResult): boolean {
-  if (isVersusDc(die)) return false;
+function canExplode(die: DieResult, hasVersusDc: boolean): boolean {
+  if (hasVersusDc && isVersusDc(die)) return false;
   if (die.modifiers.includes('dropped')) return false;
   if (die.sides < 1) return false;
   return true;
@@ -111,7 +111,7 @@ function applyAppendingExplode(
 
   for (const original of pool) {
     result.push(original);
-    if (!canExplode(original)) continue;
+    if (!canExplode(original, env.hasVersusDc)) continue;
 
     const sides = original.sides;
     let lastRaw = original.result;
@@ -172,7 +172,7 @@ export function applyCompoundExplode(
   env: EvalEnv,
 ): DieResult[] {
   for (const original of pool) {
-    if (!canExplode(original)) continue;
+    if (!canExplode(original, env.hasVersusDc)) continue;
 
     const sides = original.sides;
     let accumulated = original.result;

--- a/src/evaluator/modifiers/flags.ts
+++ b/src/evaluator/modifiers/flags.ts
@@ -20,6 +20,10 @@ import type { DieModifier, DieResult } from '../../types.js';
  * operates on. Nothing may sum, select, clamp, reroll, explode, or tally them
  * — a `d10` on the DC side must never come back clamped to 20, and
  * `{1d20 vs 2d10, 1d4}>=5` must not count the DC faces as successes.
+ *
+ * ! Call this behind the shared `hasVersusDc` env flag, never bare. Unguarded
+ * ! inside a per-die loop it cost 11-38% on notation that cannot carry the tag
+ * ! (#281); the flag is `false` until a `vs` has actually tagged something.
  */
 export function isVersusDc(die: DieResult): boolean {
   return die.modifiers.includes('dc');

--- a/src/evaluator/modifiers/keep-drop.ts
+++ b/src/evaluator/modifiers/keep-drop.ts
@@ -29,9 +29,10 @@ export function markDroppedIndices(
   kind: KeepDropSpec['kind'],
   selector: KeepDropSpec['selector'],
   droppedMask: Uint8Array,
+  hasVersusDc: boolean,
 ): void {
   if (count === 1) {
-    markSingleExtreme(dice, kind, selector, droppedMask);
+    markSingleExtreme(dice, kind, selector, droppedMask, hasVersusDc);
     return;
   }
 
@@ -40,7 +41,7 @@ export function markDroppedIndices(
   for (let index = 0; index < dice.length; index++) {
     const die = dice[index];
     if (die == null) continue;
-    if (isVersusDc(die)) continue;
+    if (hasVersusDc && isVersusDc(die)) continue;
 
     if (die.modifiers.includes('dropped')) {
       droppedMask[index] = 1;
@@ -91,6 +92,7 @@ function markSingleExtreme(
   kind: KeepDropSpec['kind'],
   selector: KeepDropSpec['selector'],
   droppedMask: Uint8Array,
+  hasVersusDc: boolean,
 ): void {
   const isKeep = kind === 'keep';
   const wantHighest = selector === 'highest';
@@ -101,7 +103,7 @@ function markSingleExtreme(
   for (let index = 0; index < dice.length; index++) {
     const die = dice[index];
     if (die == null) continue;
-    if (isVersusDc(die)) continue;
+    if (hasVersusDc && isVersusDc(die)) continue;
 
     if (die.modifiers.includes('dropped')) {
       droppedMask[index] = 1;
@@ -135,13 +137,15 @@ function markSingleExtreme(
  * Calculates total from dice, excluding dropped dice.
  *
  * @param dice - Array of die results
+ * @param hasVersusDc - Shared env flag; skips the DC exclusion when no `vs` has
+ *   tagged anything
  * @returns Sum of non-dropped dice
  */
-export function sumKeptDice(dice: DieResult[]): number {
+export function sumKeptDice(dice: DieResult[], hasVersusDc: boolean): number {
   let total = 0;
 
   for (const die of dice) {
-    if (isVersusDc(die)) continue;
+    if (hasVersusDc && isVersusDc(die)) continue;
     if (!die.modifiers.includes('dropped')) total += die.result;
   }
 

--- a/src/evaluator/modifiers/reroll.ts
+++ b/src/evaluator/modifiers/reroll.ts
@@ -54,8 +54,9 @@ function rerollLimitError(maxIterations: number): EvaluatorError {
  * True for dice eligible to start rerolling. Dropped dice (from a preceding
  * keep/drop modifier) are left alone.
  */
-function canReroll(die: DieResult): boolean {
-  return !die.modifiers.includes('dropped') && !isVersusDc(die);
+function canReroll(die: DieResult, hasVersusDc: boolean): boolean {
+  if (hasVersusDc && isVersusDc(die)) return false;
+  return !die.modifiers.includes('dropped');
 }
 
 /**
@@ -76,7 +77,7 @@ export function applyRecursiveReroll(
   const result: DieResult[] = [];
 
   for (const original of pool) {
-    if (!canReroll(original)) {
+    if (!canReroll(original, env.hasVersusDc)) {
       result.push(original);
       continue;
     }
@@ -120,7 +121,7 @@ export function applyRerollOnce(
   const result: DieResult[] = [];
 
   for (const original of pool) {
-    if (!canReroll(original)) {
+    if (!canReroll(original, env.hasVersusDc)) {
       result.push(original);
       continue;
     }

--- a/src/evaluator/modifiers/sort.ts
+++ b/src/evaluator/modifiers/sort.ts
@@ -26,17 +26,23 @@ import { isVersusDc } from './flags.js';
  * Relies on `Array.prototype.sort` being stable — equal-valued dice retain
  * their original insertion order.
  */
-export function sortDice(dice: DieResult[], order: 'ascending' | 'descending'): DieResult[] {
+export function sortDice(
+  dice: DieResult[],
+  order: 'ascending' | 'descending',
+  hasVersusDc: boolean,
+): DieResult[] {
   const cmp =
     order === 'ascending'
       ? (a: DieResult, b: DieResult) => a.result - b.result
       : (a: DieResult, b: DieResult) => b.result - a.result;
 
-  const sortable = dice.filter((die) => !isVersusDc(die));
-  if (sortable.length === dice.length) return [...dice].sort(cmp);
+  // Scan before allocating: the `filter` this replaced built a throwaway array
+  // on every sort to serve a case only a `vs` can produce (#281).
+  if (!hasVersusDc || !dice.some(isVersusDc)) return [...dice].sort(cmp);
 
   // Sort only the pool members, then lay them back into the slots they came
   // from, leaving every DC die exactly where it was.
+  const sortable = dice.filter((die) => !isVersusDc(die));
   sortable.sort(cmp);
   let next = 0;
   return dice.map((die) => (isVersusDc(die) ? die : (sortable[next++] as DieResult)));

--- a/src/evaluator/modifiers/success-count.ts
+++ b/src/evaluator/modifiers/success-count.ts
@@ -28,13 +28,21 @@ export type SuccessCountResult = {
 export function countSuccesses(
   dice: DieResult[],
   threshold: ResolvedComparePoint,
-  failThreshold?: ResolvedComparePoint,
+  failThreshold: ResolvedComparePoint | undefined,
+  hasVersusDc: boolean,
 ): SuccessCountResult {
   let successes = 0;
   let failures = 0;
 
-  for (const die of dice) {
-    if (isVersusDc(die)) continue;
+  // ! Excluded up front, never inside the loop below. Even short-circuited on a
+  // ! false flag, a `hasVersusDc && isVersusDc(die)` guard in this loop costs
+  // ! ~9% on `10d10>=6f1` — measured, not assumed (#281). Filtering keeps the
+  // ! hot body identical to the pre-exclusion one and pays an allocation only
+  // ! on the `vs` path. The dice are the same objects either way, so the
+  // ! `'success'` / `'failure'` tags written below still land on the pool.
+  const pool = hasVersusDc ? dice.filter((die) => !isVersusDc(die)) : dice;
+
+  for (const die of pool) {
     if (die.modifiers.includes('dropped')) continue;
 
     if (matchesCondition(die.result, threshold.operator, threshold.value)) {


### PR DESCRIPTION
Recovers the 11–38% pool-operation regression #262 introduced, without weakening any of its exclusion guarantees.

- Added `hasVersusDc` to `EvalEnv`, set once by `evalVersus` when it tags DC dice, so all eleven `isVersusDc` call sites skip the per-die check for notation that cannot carry the tag
- Rewrote `sortDice` to scan before allocating, dropping the unconditional `filter` the common path never needed
- Excluded DC dice in `countSuccesses` by filtering up front instead of guarding inside the loop
- Added `4d6sd`, `10d10sd`, `100d6sa`, and `10d10sd>=6f1` bench cases — sort notation had no coverage, which is why the regression shipped unseen
- Restated the `10d10>=6f1` `roll` figure and added a `4d6sd` row to the README performance table

Every regressed case now measures inside its pre-#262 range and clear of the released build, as `evaluate` p50 with the min–max band across passes:

| Notation | baseline `2010b6f~1` | released `v3.0.0` | this branch | vs released |
|----------|---------------------:|------------------:|------------:|------------:|
| `4d6kh3` | 778 [728–808] | 850 [837–874] | 746 [732–761] | −12% |
| `4d6sd` | 559 [546–568] | 612 [610–616] | 542 [538–548] | −12% |
| `10d10sd` | 907 [894–945] | 1102 [1096–1196] | 869 [844–973] | −21% |
| `100d6sa` | 7308 [7210–7340] | 8779 [8676–8797] | 7131 [6868–7317] | −18% |
| `10d10sd>=6f1` | 1637 [1596–1670] | 2163 [2144–2332] | 1636 [1534–1715] | −24% |
| `10d10>=6f1` | 1135 [1125–1157] | 1513 [1489–1624] | 1193 [1087–1197] | −21% |
| `100d6` (control) | 2458 [2369–2543] | 2404 [2387–2405] | 2359 [2257–2449] | −2% |

All four configs were measured on one machine in one session, 3–5 passes each. `10d10>=6f1` and `10d10sd` read bimodally with roughly 10% between the two modes, so recovery is stated as range overlap rather than a point delta.

The residual the issue left open — +8.7–11.5% on `>=6f1`, attributed there to cross-build layout or JIT variance — turned out to be the guard itself. Restoring the original `countSuccesses` loop body cleared it entirely, which is why that one site filters rather than branches while the other ten short-circuit in place. No follow-up issue is needed.

Costs 70 B on `index.js` (11.89 → 11.96 kB) and `{ roll }` (11.64 → 11.71 kB), inside the existing budgets; `{ parse }` unchanged. The six changed exported signatures are unreachable from the published surface — the `exports` map exposes only `.`, `./testing`, and `./package.json`, and none are re-exported from `src/index.ts`.

Closes #281
