### PR TITLE
fix: correct the result panel's total display #285 #286

### DIFF
--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -7,7 +7,7 @@
 
 import { isRollParserError, roll, VERSION } from 'roll-parser';
 import { initTrayToggle, renderLegend, renderTray } from './dice.js';
-import { renderErrorSlot, renderResultPanel } from './render.js';
+import { formatTotal, renderErrorSlot, renderResultPanel } from './render.js';
 import { initTheme } from './theme.js';
 import { readUrlState, writeUrlState } from './url.js';
 
@@ -83,7 +83,7 @@ function animateTotal(to: number): void {
   if (el == null) return;
 
   if (prefersReducedMotion() || !Number.isInteger(to) || from === to) {
-    el.textContent = String(to);
+    el.textContent = formatTotal(to);
     return;
   }
 

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -72,8 +72,9 @@ function prefersReducedMotion(): boolean {
 
 /**
  * Eases the big total from {@link lastTotal} up to `to` over {@link COUNT_UP_MS}.
- * Skips (sets the final value immediately) under reduced motion or for
- * non-integer totals, and no-ops when the panel shows counts instead of a sum.
+ * Skips (sets the final value immediately) under reduced motion or for totals
+ * the interpolation cannot represent, and no-ops when the panel shows counts
+ * instead of a sum.
  */
 function animateTotal(to: number): void {
   const el = result.querySelector<HTMLElement>('.total');
@@ -82,7 +83,11 @@ function animateTotal(to: number): void {
 
   if (el == null) return;
 
-  if (prefersReducedMotion() || !Number.isInteger(to) || from === to) {
+  // ! Past `MAX_SAFE_INTEGER` the interpolation swallows the target whole:
+  // ! `1e20 + (13 - 1e20)` is `0`, so the last frame would land on zero.
+  const animatable = Number.isSafeInteger(from) && Number.isSafeInteger(to);
+
+  if (prefersReducedMotion() || !animatable || from === to) {
     el.textContent = formatTotal(to);
     return;
   }

--- a/site/src/render.ts
+++ b/site/src/render.ts
@@ -21,6 +21,22 @@ const MAX_BREAKDOWN_DICE = 500;
 /** Above this many itemizable dice the structured equation is too busy — fall back. */
 const MAX_EQUATION_DICE = 60;
 
+/** Decimals kept when a total is fractional — `sqrt(1d4+12)` is 17 digits raw. */
+const MAX_DECIMALS = 4;
+
+/**
+ * Formats a total for display. Floats from `sqrt` and `/` carry a full
+ * IEEE-754 expansion that overflows the panel, so they are rounded — to
+ * exponential when rounding would show a non-zero total as `0`.
+ */
+export function formatTotal(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+
+  const rounded = Number(value.toFixed(MAX_DECIMALS));
+
+  return rounded === 0 ? value.toExponential(2) : String(rounded);
+}
+
 /** Escapes the five HTML-significant characters. */
 function escapeHtml(value: string): string {
   return value
@@ -102,7 +118,7 @@ function renderEquation(root: RollPart, notation: string): string {
     if (part.type === 'successCount') {
       return `${part.successes} success${part.successes === 1 ? '' : 'es'}`;
     }
-    return String(part.total);
+    return formatTotal(part.total);
   }
 
   function fallbackDiceLabel(part: RollPart): string {
@@ -276,9 +292,11 @@ function expressionNote(result: RollResult): string {
 export function renderResultPanel(result: RollResult): string {
   // Success counting reframes the roll — lead with the counts, not the sum.
   const emphasizeCounts = result.successes != null;
+  const shown = formatTotal(result.total);
+  const exact = shown === String(result.total) ? '' : ` title="${result.total}"`;
   const totalBlock = emphasizeCounts
     ? successSummary(result)
-    : `<div class="total" aria-label="total">${result.total}</div>`;
+    : `<div class="total" aria-label="total"${exact}>${shown}</div>`;
 
   return [degreeBadge(result), totalBlock, breakdownBlock(result), expressionNote(result)].join('');
 }

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -1231,6 +1231,9 @@ button.die-overflow:hover {
 .total {
   /* fit-content keeps the gradient box tight to the digits. */
   width: fit-content;
+  /* Wrap, never clip — a truncated number reads as a different number. */
+  max-width: 100%;
+  overflow-wrap: anywhere;
   margin: 0 auto;
   font-family: var(--font-num);
   font-size: clamp(3rem, 12vw, 5.5rem);


### PR DESCRIPTION
Two independent display defects in the result panel, one commit each.

`formatTotal` rounds fractional totals to four decimals for the big total and the
breakdown subtotals, falling back to exponential where rounding would show a non-zero
total as `0`, and keeps the unrounded value on a `title` attribute. An over-wide total
now wraps inside its box rather than escaping the card — ellipsis was rejected, since a
clipped number reads as a different number. Library values are untouched.

The count-up is gated on `Number.isSafeInteger` for both endpoints: `from + (to - from) * eased`
loses the target when `from` is astronomically larger, so `pow(10,20)+1d4` followed by
`4d6kh3` displayed `0` while the breakdown read `6 + 6 + 3`.

Verified in Chromium against `site:preview` — playground and reference widget, fractional
subtotals, a 21-digit total at 1280px and 390px, and an unbroken count-up sequence.

Closes #285 #286
