### PR TITLE
fix: cs/cf default rule compares accumulated result, not natural face #288

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -3910,6 +3910,95 @@ describe('evaluate', () => {
       expect(result.rolls.every((d) => d.critical === false)).toBe(true);
     });
 
+    test('default cs after compound explode reads the natural face (#288)', () => {
+      // [6, 6, 2]: the 6 compounds twice into result 14, initialResult 6.
+      const ast = parse('1d6!!cs');
+      const result = evaluate(ast, createMockRng([6, 6, 2]));
+
+      expect(result.rendered).toBe('1d6!!cs[14] = 14');
+      expect(getDie(result.rolls, 0).critical).toBe(true);
+    });
+
+    test('default cs is order-independent across compound explode (#288)', () => {
+      const before = evaluate(parse('1d6cs!!'), createMockRng([6, 6, 2]));
+      const after = evaluate(parse('1d6!!cs'), createMockRng([6, 6, 2]));
+
+      // Same faces, same total — only the modifier order in the expression
+      // differs, so the flags must not.
+      expect(after.total).toBe(before.total);
+      expect(getDie(after.rolls, 0).critical).toBe(getDie(before.rolls, 0).critical);
+      expect(getDie(after.rolls, 0).fumble).toBe(getDie(before.rolls, 0).fumble);
+    });
+
+    test('default cf after a min clamp reads the natural face (#288)', () => {
+      // min5 lifts the natural 1 to 5 and stores 1 in initialResult.
+      const ast = parse('1d6min5cf');
+      const result = evaluate(ast, createMockRng([1]));
+
+      expect(result.total).toBe(5);
+      expect(getDie(result.rolls, 0).fumble).toBe(true);
+    });
+
+    test('default cs after a max clamp reads the natural face (#288)', () => {
+      const ast = parse('1d6max3cs');
+      const result = evaluate(ast, createMockRng([6]));
+
+      expect(result.total).toBe(3);
+      expect(getDie(result.rolls, 0).critical).toBe(true);
+    });
+
+    test('explicit threshold still reads the accumulated result (#288)', () => {
+      // Deliberate asymmetry: `cs>6` is a predicate over the die's value, so
+      // it matches the compounded 14 rather than the natural 6.
+      const ast = parse('1d6!!cs>6');
+      const result = evaluate(ast, createMockRng([6, 6, 2]));
+
+      expect(result.total).toBe(14);
+      expect(getDie(result.rolls, 0).critical).toBe(true);
+    });
+
+    test('cf after compound explode leaves an untouched die alone (#288)', () => {
+      // A 1 never triggers the explosion, so `result` is still the raw face.
+      const ast = parse('1d6!!cf');
+      const result = evaluate(ast, createMockRng([1, 1, 2]));
+
+      expect(result.total).toBe(1);
+      expect(getDie(result.rolls, 0).fumble).toBe(true);
+      expect(getDie(result.rolls, 0).initialResult).toBeUndefined();
+    });
+
+    test('default cf after an accumulating compound explode (#288)', () => {
+      // `!!<2` triggers on the 1, so the fumble branch sees an accumulated
+      // result (4) over a natural 1 — the only way to reach it via explode.
+      const ast = parse('1d6!!<2cf');
+      const result = evaluate(ast, createMockRng([1, 1, 2]));
+
+      expect(result.total).toBe(4);
+      expect(getDie(result.rolls, 0).initialResult).toBe(1);
+      expect(getDie(result.rolls, 0).fumble).toBe(true);
+    });
+
+    test('a clamp before a compound explode keeps the raw face (#288)', () => {
+      // min6 lifts the natural 2 to 6, which then compounds. The default rule
+      // must see the 2, not the clamp that manufactured the max face.
+      const ast = parse('1d6min6!!cs');
+      const result = evaluate(ast, createMockRng([2, 3]));
+
+      expect(result.total).toBe(9);
+      expect(getDie(result.rolls, 0).initialResult).toBe(2);
+      expect(getDie(result.rolls, 0).critical).toBe(false);
+    });
+
+    test('explicit cs and default cf can disagree on a clamped die (#288)', () => {
+      // Pins the deliberate asymmetry: `cs>4` reads the clamped 5, the
+      // implicit `cf` reads the natural 1, so die 0 is both.
+      const ast = parse('4d6min5cs>4');
+      const result = evaluate(ast, createMockRng([1, 2, 5, 6]));
+
+      expect(result.rolls.map((d) => d.critical)).toEqual([true, true, true, true]);
+      expect(result.rolls.map((d) => d.fumble)).toEqual([true, false, false, false]);
+    });
+
     test('cs after sort — flags applied on sorted pool', () => {
       const ast = parse('4d6s cs>4');
       const rng = createMockRng([5, 2, 6, 3]);

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1214,8 +1214,8 @@ function evalSort(node: SortNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eva
  * crit criteria and `cf` thresholds replace only the fumble criteria. When a
  * side has no explicit threshold, the `'default'` rule applies — so
  * `1d20cf<3` keeps the default nat-20 crit. Bare `cs`/`cf` uses the
- * `'default'` sentinel resolved per-die to `result === sides` or
- * `result === 1`.
+ * `'default'` sentinel, resolved per-die against the natural face
+ * (`initialResult ?? result`) rather than the possibly-rewritten `result`.
  *
  * Renders `<targetExpr><codes>[<dice>]`, mirroring `evalSort`/`evalExplode`.
  */

--- a/src/evaluator/modifiers/crit-threshold.ts
+++ b/src/evaluator/modifiers/crit-threshold.ts
@@ -9,6 +9,20 @@
  * Meta dice (rolled to compute counts/sides/modifier args) are skipped so
  * their bookkeeping stays untouched.
  *
+ * The two threshold kinds deliberately read different values. `'default'`
+ * reads `initialResult ?? result`, the same source as the versus `natural`,
+ * so "rolled the maximum face" survives the two modifiers that overwrite
+ * `result` while recording the face they replaced — compound explode and
+ * `minN`/`maxN`. An explicit threshold (`cs>4`, `cf<=2`) reads the die's
+ * current `result`: it is a predicate over the die's value, and postfix
+ * modifiers are order-sensitive by design, so `4d6min5cs>4` is meant to
+ * see the clamped faces. The two can therefore disagree on one die —
+ * `4d6min5cs>4` flags a clamped natural 1 as both critical and fumble.
+ *
+ * ! Penetrating explode is not covered: it stores `raw - 1` in `result`
+ * ! without recording `initialResult`, so `1d6!pcs` still judges a natural
+ * ! 6 by its decremented 5.
+ *
  * Display-only: does not alter `total`, explosion triggers, success
  * counting, or any other modifier flag. Dropped dice still participate —
  * their `critical`/`fumble` metadata reflects what they rolled, not
@@ -23,9 +37,10 @@ import { isVersusDc } from './flags.js';
 
 /**
  * Applies success/fail threshold arrays to a dice pool, overriding each
- * die's `critical` and `fumble` flags in place. A die matches `'default'`
- * on the success side when `result === sides && sides > 1`, and on the
- * fail side when `result === 1`. Meta dice are skipped.
+ * die's `critical` and `fumble` flags in place. Writing `natural` for
+ * `initialResult ?? result`, a die matches `'default'` on the success side
+ * when `natural === sides && sides > 1`, and on the fail side when
+ * `natural === 1 && sides > 1`. Meta dice are skipped.
  */
 export function applyCritThresholds(
   dice: DieResult[],
@@ -44,7 +59,7 @@ export function applyCritThresholds(
 
 function matchesCrit(threshold: ResolvedCritThreshold, die: DieResult): boolean {
   if (threshold === 'default') {
-    return die.result === die.sides && die.sides > 1;
+    return (die.initialResult ?? die.result) === die.sides && die.sides > 1;
   }
   return matchesCondition(die.result, threshold.operator, threshold.value);
 }
@@ -52,7 +67,7 @@ function matchesCrit(threshold: ResolvedCritThreshold, die: DieResult): boolean 
 function matchesFumble(threshold: ResolvedCritThreshold, die: DieResult): boolean {
   if (threshold === 'default') {
     // Mirrors `createDieResult` — a d1 always rolls 1, never a fumble.
-    return die.result === 1 && die.sides > 1;
+    return (die.initialResult ?? die.result) === 1 && die.sides > 1;
   }
   return matchesCondition(die.result, threshold.operator, threshold.value);
 }

--- a/src/evaluator/modifiers/die-bound.ts
+++ b/src/evaluator/modifiers/die-bound.ts
@@ -10,6 +10,8 @@
  *
  * `critical` / `fumble` keep reflecting the natural face — a clamped 1 is
  * still a fumble, matching the raw-face crit semantics used everywhere else.
+ * A following bare `cs`/`cf` agrees; a following *explicit* threshold
+ * (`4d6min5cs>4`) is a predicate over the clamped value and overrides it.
  * Meta dice (rolled to compute counts/sides/modifier args) are skipped.
  * Dropped dice are clamped too — they are excluded from totals anyway, and
  * clamping them keeps the rendered pool consistent.

--- a/src/evaluator/modifiers/explode.ts
+++ b/src/evaluator/modifiers/explode.ts
@@ -194,8 +194,9 @@ export function applyCompoundExplode(
     if (!exploded) continue;
 
     // `critical` and `fumble` keep referring to the original triggering
-    // roll — after compounding the `result` is a sum.
-    original.initialResult = original.result;
+    // roll — after compounding the `result` is a sum. First writer wins, so
+    // a preceding `minN`/`maxN` clamp keeps its record of the raw face.
+    original.initialResult ??= original.result;
     original.result = accumulated;
     if (!original.modifiers.includes('exploded')) {
       original.modifiers = [...original.modifiers, 'exploded'];

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -314,9 +314,10 @@ export type SortNode = NodeSpan & {
 };
 
 /**
- * Sentinel for bare `cs` / `cf` without a ComparePoint. Resolved to
- * `result === sides` (for critical) or `result === 1` (for fumble) at
- * evaluation time, using each die's own `sides`.
+ * Sentinel for bare `cs` / `cf` without a ComparePoint. Resolved at
+ * evaluation time against each die's own `sides` and its natural face
+ * (`initialResult ?? result`): critical when that face equals `sides`,
+ * fumble when it equals 1.
  *
  * @category AST
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,9 +42,12 @@ export type ResolvedComparePoint = {
 };
 
 /**
- * A resolved crit threshold — `'default'` means the per-die default rule
- * (`result === sides` for critical, `result === 1` for fumble), which is what
- * bare `cs` / `cf` produce.
+ * A resolved crit threshold — `'default'` means the per-die default rule,
+ * which is what bare `cs` / `cf` produce. It reads the natural face
+ * (`initialResult ?? result`): critical when it equals `sides`, fumble when
+ * it equals 1, both only for `sides > 1`. An explicit ComparePoint instead
+ * reads the die's current `result`, so a preceding modifier that rewrote it
+ * is visible to the comparison.
  *
  * @category Results
  */


### PR DESCRIPTION
The `'default'` branch of `matchesCrit`/`matchesFumble` now reads `initialResult ?? result`, so bare `cs`/`cf` judge the natural face instead of a value a preceding modifier rewrote. Explicit thresholds keep reading `result` — order-sensitive by design, and now documented as such.

`applyCompoundExplode` set `initialResult` with `=` rather than `??=`, clobbering the raw face a preceding `minN`/`maxN` clamp had recorded. That was invisible until the default rule started reading `initialResult`; without the fix, `1d6min6!!cs` with `[2, 3]` reports `critical: true` on a die whose natural face was 2.

- `matchesCrit` / `matchesFumble` `'default'` branch reads `initialResult ?? result`
- `applyCompoundExplode` preserves an existing `initialResult` (`??=`, first writer wins)
- Refreshed the published TSDoc on `ResolvedCritThreshold`, `CritThreshold`, and `evalCritThreshold`, which still stated the old `result === sides` rule
- Recorded in `crit-threshold.ts` that the two threshold kinds read different values, that they can disagree on one die, and that penetrating explode is not covered
- Narrowed the `die-bound.ts` note: a following explicit threshold overrides the natural-face reading
- Nine regression tests covering compound explode, clamp-then-explode, explode-then-clamp, and the explicit/default asymmetry

Two pre-existing defects surfaced during review and are left for their own issues: penetrating explode rewrites `result` without recording a natural face (`1d6!pcs` judges a natural 6 by its decremented 5), and a `minN`/`maxN` after a standard explode sets `initialResult` on a continuation die, which makes `extractNatural` return `undefined` and drops the nat-20 upgrade.

Closes #288
