### PR TITLE
fix: cs/cf thresholds never apply to dice created by explode or reroll #289

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ Chained keep/drop modifiers do **not** nest. `4d6kh3dl1` flattens into two
 specs applied independently to the same pool, with the dropped sets unioned —
 the Roll20 rule.
 
+`cs` / `cf` covers the whole pool, including dice that `!`, `!p`, `r`, and `ro`
+add after it — `1d6cs<2!` and `1d6!cs<2` flag the same dice. Two cases stay
+order-sensitive. Modifiers that rewrite a die's value rather than add one (`!!`,
+`minN`, `maxN`) are judged on whatever that value is when the threshold runs:
+with `[6, 6, 3]`, `1d6cs>10!!` reports no critical while `1d6!!cs>10` reports
+one, judging the compounded 15. And because `!p`'s added dice store one less
+than they rolled, the side you *don't* override moves with position —
+`1d6cf>5!p` keeps the critical that plain `1d6!p` gives the added 6, where
+`1d6!pcf>5` does not.
+
 ### Pools and checks
 
 | Notation | Meaning |

--- a/src/evaluator/env.ts
+++ b/src/evaluator/env.ts
@@ -10,6 +10,17 @@
 
 import { EvaluatorError } from '../errors.js';
 import type { ASTNode } from '../parser/ast.js';
+import type { DieResult, ResolvedCritThreshold } from '../types.js';
+
+/**
+ * A resolved `cs`/`cf` pair, recorded per die so that dice minted later by
+ * explode or reroll can be judged by the rule the user declared instead of
+ * the built-in default.
+ */
+export type CritRule = {
+  readonly success: readonly ResolvedCritThreshold[];
+  readonly fail: readonly ResolvedCritThreshold[];
+};
 
 /**
  * Per-evaluation shared environment (created once, shared across all branches).
@@ -46,6 +57,16 @@ export type EvalEnv = {
    * ! when the tagged DC dice become visible to the enclosing pool.
    */
   hasVersusDc: boolean;
+  /**
+   * Crit rule per die, keyed on the `DieResult` object itself. Populated by
+   * `applyCritThresholds`; read by explode and reroll so a die they mint
+   * inherits the rule of the die it descended from.
+   *
+   * Out of band rather than a `DieResult` field because `DieResult` is public
+   * and serialized. `undefined` until the first `cs`/`cf` node — declared here
+   * so the shape stays stable for notation that has none.
+   */
+  critRules: WeakMap<DieResult, CritRule> | undefined;
   /**
    * User-supplied variable map for `@name` / `@{name}` references. Always
    * defined — `evaluate()` defaults to an empty object so lookups can be

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -4185,6 +4185,108 @@ describe('evaluate', () => {
       expect(result.rolls.map((d) => d.fumble)).toEqual([true]);
       expect(result.expression).toBe('{1d6}kh1cf<2');
     });
+
+    test('cs before explode governs the appended dice (#289)', () => {
+      const result = evaluate(parse('1d6cs<2!'), createMockRng([6, 6, 3]));
+
+      expect(result.rendered).toBe('1d6cs<2![6, 6, 3] = 15');
+      // The appended 6 used to report the default-rule crit the `cs<2` overrode.
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, false, false]);
+    });
+
+    test('cs before reroll governs the kept replacement (#289)', () => {
+      const result = evaluate(parse('1d6cs<2r<4'), createMockRng([3, 6]));
+
+      expect(result.rendered).toBe('1d6cs<2r<4[~~3~~, 6] = 6');
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, false]);
+    });
+
+    test('cs before reroll-once governs the replacement (#289)', () => {
+      const result = evaluate(parse('1d6cs<2ro<4'), createMockRng([3, 6]));
+
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, false]);
+    });
+
+    test('cs reaches explode across an intervening sort (#289)', () => {
+      // The rule travels with the dice, not with the crit node's parent, so a
+      // pass-through modifier between `cs` and `!` changes nothing.
+      const result = evaluate(parse('1d6cs<2s!'), createMockRng([6, 6, 3]));
+
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, false, false]);
+    });
+
+    test('cs governs a reroll replacement of an exploded die (#289)', () => {
+      // The replacement descends from an exploded die that itself inherited.
+      const result = evaluate(parse('1d6cs<2!r<4'), createMockRng([6, 6, 3, 5]));
+
+      expect(result.rendered).toBe('1d6cs<2!r<4[6, 6, ~~3~~, 5] = 17');
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, false, false, false]);
+    });
+
+    test('cf before penetrating explode leaves the crit side where 1d6!p had it (#289)', () => {
+      // Only the fumble side is overridden, so the appended die's `critical`
+      // must still come from the raw 6 `createDieResult` judged — not from the
+      // 5 it stores.
+      const overridden = evaluate(parse('1d6cf>5!p'), createMockRng([6, 6, 3]));
+      const plain = evaluate(parse('1d6!p'), createMockRng([6, 6, 3]));
+
+      expect(overridden.rolls.map((d) => d.critical)).toEqual(plain.rolls.map((d) => d.critical));
+      expect(overridden.rolls.map((d) => d.critical)).toEqual([true, true, false]);
+    });
+
+    test('cs before penetrating explode leaves the fumble side alone (#289)', () => {
+      // Mirror of the above: overriding the success side must not invent a
+      // fumble on the appended die, whose stored 1 came from a raw 2.
+      const overridden = evaluate(parse('1d6cs<9!p'), createMockRng([6, 2]));
+      const plain = evaluate(parse('1d6!p'), createMockRng([6, 2]));
+
+      expect(overridden.rolls.map((d) => d.fumble)).toEqual(plain.rolls.map((d) => d.fumble));
+      expect(overridden.rolls.map((d) => d.fumble)).toEqual([false, false]);
+    });
+
+    test('cs is order-independent across penetrating explode (#289)', () => {
+      const before = evaluate(parse('1d6cs<2!p'), createMockRng([6, 6, 3]));
+      const after = evaluate(parse('1d6!pcs<2'), createMockRng([6, 6, 3]));
+
+      // Appended dice store `raw - 1`, and an explicit threshold reads the
+      // stored value on both sides of the chain.
+      expect(before.rendered).toBe('1d6cs<2!p[6, 5, 2] = 13');
+      expect(before.rolls.map((d) => d.critical)).toEqual(after.rolls.map((d) => d.critical));
+    });
+
+    test('cf before explode governs the appended dice (#289)', () => {
+      const result = evaluate(parse('1d6cf>5!'), createMockRng([6, 6, 3]));
+
+      expect(result.rolls.map((d) => d.fumble)).toEqual([true, true, false]);
+      // Untouched cs side keeps the default rule on both 6s.
+      expect(result.rolls.map((d) => d.critical)).toEqual([true, true, false]);
+    });
+
+    test('cs governs a Fate reroll replacement (#289)', () => {
+      const result = evaluate(parse('1dFcs<2r<0'), createMockRng([-1, 1]));
+
+      // `createFateDieResult` hard-codes both flags false; an explicit
+      // threshold still applies, as it does for `1dFcs<2`.
+      expect(result.rolls.map((d) => d.critical)).toEqual([true, true]);
+    });
+
+    test('a crit rule does not leak into an unrelated pool (#289)', () => {
+      const result = evaluate(parse('1d6cs<2 + 1d6!'), createMockRng([6, 6, 3]));
+
+      expect(result.rendered).toBe('1d6cs<2[6] + 1d6![6, 3] = 15');
+      // Only the first die is governed by `cs<2`; the second pool's exploded 6
+      // keeps the default rule.
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, true, false]);
+    });
+
+    test('compound explode keeps its pre-accumulation flags (#289)', () => {
+      // `!!` mints no die, so the rule stays applied where the crit node ran —
+      // the accumulated 15 keeps the crit its natural 6 earned under `cs=6`.
+      const result = evaluate(parse('1d6cs=6!!'), createMockRng([6, 6, 3]));
+
+      expect(result.rendered).toBe('1d6cs=6!![15] = 15');
+      expect(result.rolls.map((d) => d.critical)).toEqual([true]);
+    });
   });
 
   describe('cross-family modifier combinations (#134)', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1217,6 +1217,10 @@ function evalSort(node: SortNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eva
  * `'default'` sentinel, resolved per-die against the natural face
  * (`initialResult ?? result`) rather than the possibly-rewritten `result`.
  *
+ * The resolved rule is recorded per die, so an enclosing explode or reroll
+ * judges the dice it mints by it too — `1d6cs<2!` no longer reports the
+ * default-rule crit the user overrode.
+ *
  * Renders `<targetExpr><codes>[<dice>]`, mirroring `evalSort`/`evalExplode`.
  */
 function evalCritThreshold(
@@ -1237,7 +1241,7 @@ function evalCritThreshold(
     successResolved.length > 0 ? successResolved : ['default'];
   const failApplied: ResolvedCritThreshold[] = failResolved.length > 0 ? failResolved : ['default'];
 
-  applyCritThresholds(targetCtx.rolls, successApplied, failApplied, env.hasVersusDc);
+  applyCritThresholds(targetCtx.rolls, successApplied, failApplied, env);
 
   appendAll(ctx.rolls, targetCtx.rolls);
   propagateMetadata(ctx, targetCtx.versusMetadata);
@@ -1738,6 +1742,7 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
     hasSuccessCount: false,
     insideVersus: false,
     hasVersusDc: false,
+    critRules: undefined,
     context,
     onMissingVariable,
   };

--- a/src/evaluator/modifiers/crit-threshold.ts
+++ b/src/evaluator/modifiers/crit-threshold.ts
@@ -21,7 +21,20 @@
  *
  * ! Penetrating explode is not covered: it stores `raw - 1` in `result`
  * ! without recording `initialResult`, so `1d6!pcs` still judges a natural
- * ! 6 by its decremented 5.
+ * ! 6 by its decremented 5. An *inherited* rule is handed the raw roll
+ * ! instead, which keeps `1d6cf>5!p` agreeing with `1d6!p` on the side the
+ * ! user never overrode — at the cost of `1d6cf>5!p` and `1d6!pcf>5`
+ * ! disagreeing on it. Recording `initialResult` here would settle both, but
+ * ! `extractNatural` reads that field to tell an appended explosion die from
+ * ! a compounded one, and would start counting these as versus primaries.
+ *
+ * The rule is recorded per die on `env.critRules`, so dice that explode and
+ * reroll mint *after* the crit node has run inherit it from the die they
+ * descended from. `cs`/`cf` therefore covers the whole pool wherever it sits
+ * in the postfix chain — `1d6cs<2!` and `1d6!cs<2` agree. Two things stay
+ * outside that: compound explode, which mints no die and so keeps the flags
+ * its accumulated `result` had when the crit node ran, and `minN`/`maxN`,
+ * which rewrites `result` under an explicit threshold's feet.
  *
  * Display-only: does not alter `total`, explosion triggers, success
  * counting, or any other modifier flag. Dropped dice still participate —
@@ -32,6 +45,7 @@
  */
 
 import type { DieResult, ResolvedCritThreshold } from '../../types.js';
+import type { CritRule, EvalEnv } from '../env.js';
 import { matchesCondition } from './compare.js';
 import { isVersusDc } from './flags.js';
 
@@ -41,33 +55,80 @@ import { isVersusDc } from './flags.js';
  * `initialResult ?? result`, a die matches `'default'` on the success side
  * when `natural === sides && sides > 1`, and on the fail side when
  * `natural === 1 && sides > 1`. Meta dice are skipped.
+ *
+ * Also records the rule against every die it touched, so later explode and
+ * reroll dice can inherit it via {@link inheritCritRule}.
  */
 export function applyCritThresholds(
   dice: DieResult[],
   successThresholds: ResolvedCritThreshold[],
   failThresholds: ResolvedCritThreshold[],
-  hasVersusDc: boolean,
+  env: EvalEnv,
 ): void {
+  const rule: CritRule = { success: successThresholds, fail: failThresholds };
+  env.critRules ??= new WeakMap();
+  const rules = env.critRules;
+
   for (const die of dice) {
     if (die.modifiers.includes('meta')) continue;
-    if (hasVersusDc && isVersusDc(die)) continue;
+    if (env.hasVersusDc && isVersusDc(die)) continue;
 
-    die.critical = successThresholds.some((t) => matchesCrit(t, die));
-    die.fumble = failThresholds.some((t) => matchesFumble(t, die));
+    applyCritRule(die, rule, die.initialResult ?? die.result);
+    rules.set(die, rule);
   }
 }
 
-function matchesCrit(threshold: ResolvedCritThreshold, die: DieResult): boolean {
+/**
+ * Judges one die by a recorded rule, overwriting both flags. A side always
+ * carries at least `'default'` — `evalCritThreshold` fills the side the user
+ * left out — so neither flag is silently left untouched. `natural` is the face
+ * the `'default'` sentinel reads; an explicit threshold always reads `result`.
+ */
+function applyCritRule(die: DieResult, rule: CritRule, natural: number): void {
+  die.critical = rule.success.some((t) => matchesCrit(t, die, natural));
+  die.fumble = rule.fail.some((t) => matchesFumble(t, die, natural));
+}
+
+/**
+ * Passes the crit rule recorded for `parent` down to a die minted from it,
+ * judging the child by that rule and recording it so a further explode or
+ * reroll inherits it in turn. No-op when no `cs`/`cf` governs `parent`, which
+ * leaves the `createDieResult` default rule in place.
+ *
+ * `natural` is the face the `'default'` sentinel reads, defaulting to the
+ * child's own. Penetrating explode passes its raw roll — see the module note.
+ *
+ * ! Call this only once the child's final `result` is stored — an explicit
+ * ! threshold is a predicate over `result`, so a penetrating die is judged by
+ * ! its decremented value, matching `1d6!pcs<2`.
+ */
+export function inheritCritRule(
+  env: EvalEnv,
+  parent: DieResult,
+  child: DieResult,
+  natural = child.initialResult ?? child.result,
+): void {
+  const rules = env.critRules;
+  if (rules === undefined) return;
+
+  const rule = rules.get(parent);
+  if (rule === undefined) return;
+
+  applyCritRule(child, rule, natural);
+  rules.set(child, rule);
+}
+
+function matchesCrit(threshold: ResolvedCritThreshold, die: DieResult, natural: number): boolean {
   if (threshold === 'default') {
-    return (die.initialResult ?? die.result) === die.sides && die.sides > 1;
+    return natural === die.sides && die.sides > 1;
   }
   return matchesCondition(die.result, threshold.operator, threshold.value);
 }
 
-function matchesFumble(threshold: ResolvedCritThreshold, die: DieResult): boolean {
+function matchesFumble(threshold: ResolvedCritThreshold, die: DieResult, natural: number): boolean {
   if (threshold === 'default') {
     // Mirrors `createDieResult` — a d1 always rolls 1, never a fumble.
-    return (die.initialResult ?? die.result) === 1 && die.sides > 1;
+    return natural === 1 && die.sides > 1;
   }
   return matchesCondition(die.result, threshold.operator, threshold.value);
 }

--- a/src/evaluator/modifiers/explode.ts
+++ b/src/evaluator/modifiers/explode.ts
@@ -13,6 +13,7 @@ import type { RNG } from '../../rng/types.js';
 import type { CompareOp, DieResult } from '../../types.js';
 import { createDieResult } from '../die.js';
 import { chargeDie, type EvalEnv } from '../env.js';
+import { inheritCritRule } from './crit-threshold.js';
 import { isVersusDc } from './flags.js';
 
 /**
@@ -99,6 +100,9 @@ function canExplode(die: DieResult, hasVersusDc: boolean): boolean {
  *
  * `critical`/`fumble` are likewise derived from the raw roll — a penetrating
  * die that rolled its max face is still a crit even though it stores one less.
+ * An inherited `cs`/`cf` keeps that: it is applied after `storeResult`, so an
+ * explicit threshold reads the stored value, while the raw roll is handed over
+ * for the `'default'` sentinel to read.
  */
 function applyAppendingExplode(
   pool: DieResult[],
@@ -124,6 +128,7 @@ function applyAppendingExplode(
       const raw = rollExplosion(sides, rng, env);
       const die = createDieResult(sides, raw, ['exploded', 'kept']);
       die.result = storeResult(raw);
+      inheritCritRule(env, original, die, raw);
       result.push(die);
       lastRaw = raw;
       iterations += 1;

--- a/src/evaluator/modifiers/reroll.ts
+++ b/src/evaluator/modifiers/reroll.ts
@@ -15,6 +15,7 @@ import type { CompareOp, DieResult } from '../../types.js';
 import { createDieResult, createFateDieResult } from '../die.js';
 import { chargeDie, type EvalEnv } from '../env.js';
 import { matchesCondition } from './compare.js';
+import { inheritCritRule } from './crit-threshold.js';
 import { isVersusDc, REROLL_SLOT_FLAGS, rewriteFlags } from './flags.js';
 
 /**
@@ -31,15 +32,22 @@ import { isVersusDc, REROLL_SLOT_FLAGS, rewriteFlags } from './flags.js';
 export const DEFAULT_MAX_REROLL_ITERATIONS = 1_000;
 
 /**
- * Rolls a replacement die for the given sides, charging it against the global
- * dice limit. Fate dice (sides === 0) re-roll on the {-1, 0, +1} range.
+ * Rolls a replacement for `parent`, charging it against the global dice limit.
+ * Fate dice (sides === 0) re-roll on the {-1, 0, +1} range. Any `cs`/`cf`
+ * governing `parent` carries over, so a replacement is judged by the rule the
+ * user declared rather than the built-in default.
  */
-function rollReplacement(sides: number, rng: RNG, env: EvalEnv): DieResult {
+function rollReplacement(parent: DieResult, rng: RNG, env: EvalEnv): DieResult {
   chargeDie(env, 'Reroll');
 
-  if (sides === 0) return createFateDieResult(rng.nextInt(-1, 1), []);
+  const sides = parent.sides;
+  const die =
+    sides === 0
+      ? createFateDieResult(rng.nextInt(-1, 1), [])
+      : createDieResult(sides, rng.nextInt(1, sides), []);
 
-  return createDieResult(sides, rng.nextInt(1, sides), []);
+  inheritCritRule(env, parent, die);
+  return die;
 }
 
 function rerollLimitError(maxIterations: number): EvaluatorError {
@@ -95,7 +103,7 @@ export function applyRecursiveReroll(
       current.modifiers = rewriteFlags(current.modifiers, REROLL_SLOT_FLAGS, 'rerolled', 'dropped');
       result.push(current);
 
-      current = rollReplacement(current.sides, rng, env);
+      current = rollReplacement(current, rng, env);
       iterations += 1;
     }
 
@@ -136,7 +144,7 @@ export function applyRerollOnce(
     original.modifiers = rewriteFlags(original.modifiers, REROLL_SLOT_FLAGS, 'rerolled', 'dropped');
     result.push(original);
 
-    const replacement = rollReplacement(original.sides, rng, env);
+    const replacement = rollReplacement(original, rng, env);
     replacement.modifiers = rewriteFlags(replacement.modifiers, REROLL_SLOT_FLAGS, 'kept');
     result.push(replacement);
   }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -326,8 +326,9 @@ export type CritThreshold = ComparePoint | 'default';
 /**
  * Critical threshold modifier node (`cs`, `cf`).
  *
- * Overrides the default `critical`/`fumble` flag logic for the dice
- * produced by `target`. Bare `cs`/`cf` uses the `'default'` sentinel
+ * Overrides the default `critical`/`fumble` flag logic for `target`'s dice
+ * pool — including dice an enclosing `!` or `r` adds to it afterwards, which
+ * `target` never produced. Bare `cs`/`cf` uses the `'default'` sentinel
  * (max face / 1). Custom thresholds accept any ComparePoint. Chaining
  * collapses into a single node — `1d20cs=20cs=1cf>18` has two success
  * and one fail threshold. Display-only: does not change `total`,


### PR DESCRIPTION
Records each resolved `cs`/`cf` rule per die on a new `env.critRules` WeakMap, so explode and reroll judge the dice they mint by the declared threshold instead of the `createDieResult` default. `1d6cs<2!` and `1d6cs<2r<4` no longer report a `critical` the user overrode, and the rule survives an intervening `s`/`kh`/`min`.

Keyed off the die rather than the eval context: a context can hold dice from several pools with different rules, and every wrapper evaluator would have needed a propagation line.

- `inheritCritRule` applies and re-records the parent's rule on each minted die, hooked into `applyAppendingExplode` and `rollReplacement` — covers `!`, `!p`, `r`, `ro`, and Fate replacements
- `applyCritThresholds` takes `env` rather than `hasVersusDc`; the `'default'` sentinel's `natural` face is now an argument
- Penetrating explode passes its raw roll as that face, so overriding one side does not move the side left at default
- Corrects the published `CritThresholdNode` TSDoc, which scoped the override to "the dice produced by `target`"
- Documents the pool-scoped semantics and the `!!` / `minN` / `maxN` / `!p` carve-outs in the module TSDoc and README

Compound explode is unchanged — it mints no die, and which snapshot its flags read was settled by #288.

Closes #289
