### PR TITLE
fix: chained minN/maxN push duplicate min/max modifiers #290

### DIFF
--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -11,7 +11,7 @@ import { parse } from '../parser/parser.js';
 import { createMockRng } from '../rng/mock.js';
 import { SeededRNG } from '../rng/seeded.js';
 import { expectRollError } from '../test-helpers.js';
-import type { DieResult } from '../types.js';
+import type { DieModifier, DieResult } from '../types.js';
 import { DegreeOfSuccess } from '../types.js';
 import type { EvalContext } from './evaluator.js';
 import {
@@ -1738,6 +1738,27 @@ describe('evaluate', () => {
       }
     });
 
+    test('a group counted after its members tags each die once: {4d6>=5}>=1 (#290)', () => {
+      // A group bypasses the parse-time reject that blocks a direct `4d6>=5>=4`,
+      // so `countSuccesses` runs twice over the same dice.
+      const ast = parse('{4d6>=5}>=1');
+      const result = evaluate(ast, createMockRng([1, 2, 5, 6]));
+
+      for (const die of result.rolls) {
+        expect(die.modifiers).toEqual(['kept', 'success']);
+      }
+      expect(result.successes).toBe(4);
+    });
+
+    test('a group counted after its members tags failures once: {4d6>=5f1}>=5f1 (#290)', () => {
+      const ast = parse('{4d6>=5f1}>=5f1');
+      const result = evaluate(ast, createMockRng([1, 2, 5, 6]));
+
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['kept', 'failure']);
+      expect(getDie(result.rolls, 2).modifiers).toEqual(['kept', 'success']);
+      expect(getDie(result.rolls, 3).modifiers).toEqual(['kept', 'success']);
+    });
+
     test('rendered output uses ** and __ markers', () => {
       const ast = parse('3d6>=5f1');
       const rng = createMockRng([1, 5, 3]);
@@ -3076,6 +3097,21 @@ describe('evaluate', () => {
         expect(die.modifiers).not.toContain('kept');
       }
     });
+
+    test('nested meta operands tag a die once: ((1d2)d4)d6 (#290)', () => {
+      // The innermost die merges upward once per level, so an append-only
+      // rewrite left it carrying `'meta'` twice.
+      const ast = parse('((1d2)d4)d6');
+      const result = evaluate(ast, createMockRng([2, 1, 2, 3, 4, 5]));
+
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['meta', 'dropped']);
+      const meta = result.rolls.filter((die) => die.modifiers.includes('meta'));
+      expect(meta).toHaveLength(3);
+      for (const die of meta) {
+        expect(die.modifiers).toEqual(['meta', 'dropped']);
+      }
+      expect(result.total).toBe(12);
+    });
   });
 
   describe('variables', () => {
@@ -3672,6 +3708,40 @@ describe('evaluate', () => {
       const result = evaluate(ast, createMockRng([1, 3, 6, 2]));
 
       expect(result.rolls.map((die) => die.result)).toEqual([2, 3, 5, 2]);
+    });
+
+    test('chained min bounds tag a die once: 4d6min3min4 (#290)', () => {
+      const ast = parse('4d6min3min4');
+      const result = evaluate(ast, createMockRng([1, 2, 5, 6]));
+
+      expect(result.rendered).toBe('4d6min3min4[4, 4, 5, 6] = 19');
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['kept', 'min']);
+      expect(getDie(result.rolls, 1).modifiers).toEqual(['kept', 'min']);
+      // The first bound that moved the die owns `initialResult`, not the last.
+      expect(getDie(result.rolls, 0).initialResult).toBe(1);
+      expect(getDie(result.rolls, 1).initialResult).toBe(2);
+    });
+
+    test('chained max bounds tag a die once: 4d6max4max3 (#290)', () => {
+      const ast = parse('4d6max4max3');
+      const result = evaluate(ast, createMockRng([1, 2, 5, 6]));
+
+      expect(result.rendered).toBe('4d6max4max3[1, 2, 3, 3] = 9');
+      expect(getDie(result.rolls, 2).modifiers).toEqual(['kept', 'max']);
+      expect(getDie(result.rolls, 3).modifiers).toEqual(['kept', 'max']);
+      expect(getDie(result.rolls, 2).initialResult).toBe(5);
+      expect(getDie(result.rolls, 3).initialResult).toBe(6);
+    });
+
+    test('mixed-kind chains still carry both tags: 4d6min2max5 (#290)', () => {
+      const ast = parse('4d6min2max5');
+      const result = evaluate(ast, createMockRng([1, 3, 6, 2]));
+
+      expect(result.rendered).toBe('4d6min2max5[2, 3, 5, 2] = 12');
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['kept', 'min']);
+      expect(getDie(result.rolls, 2).modifiers).toEqual(['kept', 'max']);
+      expect(getDie(result.rolls, 0).initialResult).toBe(1);
+      expect(getDie(result.rolls, 2).initialResult).toBe(6);
     });
 
     test('a min bound above the die size lifts every face: 2d6min7', () => {
@@ -4517,5 +4587,37 @@ describe('evaluate', () => {
       expect(isRollParserError(error)).toBe(true);
       expect((error as EvaluatorError).code).toBe('NON_FINITE_RESULT');
     });
+  });
+
+  describe('die modifier tags', () => {
+    // The `Record<DieModifier, …>` annotation is the completeness gate: adding a
+    // tag to the union without a provoking case is a type error. Where a tag can
+    // be written by more than one pass, the notation chains those passes so a
+    // non-idempotent write shows up as a duplicate.
+    const TAG_CASES: Record<DieModifier, { notation: string; rolls: number[] }> = {
+      kept: { notation: '4d6', rolls: [1, 2, 5, 6] },
+      dropped: { notation: '4d6kh2', rolls: [1, 2, 5, 6] },
+      exploded: { notation: '1d6!', rolls: [6, 6, 3] },
+      rerolled: { notation: '1d6r<3', rolls: [1, 2, 5] },
+      min: { notation: '4d6min3min4', rolls: [1, 2, 5, 6] },
+      max: { notation: '4d6max4max3', rolls: [1, 2, 5, 6] },
+      success: { notation: '{4d6>=5}>=1', rolls: [1, 2, 5, 6] },
+      failure: { notation: '{4d6>=5f1}>=5f1', rolls: [1, 2, 5, 6] },
+      meta: { notation: '((1d2)d4)d6', rolls: [2, 1, 2, 3, 4, 5] },
+      dc: { notation: '1d20 vs 2d10', rolls: [15, 5, 6] },
+    };
+
+    for (const tag of Object.keys(TAG_CASES) as DieModifier[]) {
+      const { notation, rolls } = TAG_CASES[tag];
+
+      test(`${tag} is reachable and written at most once: ${notation}`, () => {
+        const result = evaluate(parse(notation), createMockRng(rolls));
+
+        expect(result.rolls.some((die) => die.modifiers.includes(tag))).toBe(true);
+        for (const die of result.rolls) {
+          expect(die.modifiers).toHaveLength(new Set(die.modifiers).size);
+        }
+      });
+    }
   });
 });

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -55,6 +55,7 @@ import {
 } from './modifiers/explode.js';
 import {
   isVersusDc,
+  META_MERGE_FLAGS,
   rewriteFlags,
   SELECTION_AND_TALLY_FLAGS,
   SELECTION_FLAGS,
@@ -263,6 +264,10 @@ function renderDie(result: number, modifiers: readonly DieModifier[]): string {
  * `sumKeptDice`; `'meta'` lets renderers hide them and lets callers
  * distinguish them from ordinary pool dice.
  *
+ * `'meta'` is stripped before being re-added: meta operands nest
+ * (`((1d2)d4)d6`), so the innermost dice pass through here once per level and
+ * an append-only rewrite would leave them carrying the tag once per level.
+ *
  * `'success'`/`'failure'` tags are stripped here as defense-in-depth against
  * a SuccessCount leaking into a meta sub-expression (parser rejects all such
  * wrappings; this strip ensures a future parse regression cannot leak tags
@@ -279,7 +284,7 @@ export function mergeMetaRolls(parent: EvalContext, source: EvalContext): void {
   for (const die of source.rolls) {
     parent.rolls.push({
       ...die,
-      modifiers: rewriteFlags(die.modifiers, SELECTION_AND_TALLY_FLAGS, 'meta', 'dropped'),
+      modifiers: rewriteFlags(die.modifiers, META_MERGE_FLAGS, 'meta', 'dropped'),
     });
   }
 }
@@ -1643,6 +1648,8 @@ function evalVersus(node: VersusNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
     appendAll(ctx.rolls, rollCtx.rolls);
     // ! Tag before merging: past this point the DC dice are indistinguishable
     // ! from the roll side, and every pool modifier walks the merged array.
+    // ! Bare push, deliberately: `insideVersus` above rejects every nesting, so
+    // ! each die reaches exactly one `dcCtx` and cannot be tagged twice.
     for (const die of dcCtx.rolls) {
       die.modifiers.push('dc');
     }

--- a/src/evaluator/modifiers/die-bound.ts
+++ b/src/evaluator/modifiers/die-bound.ts
@@ -6,7 +6,8 @@
  * `initialResult` (first writer wins, so a compound-explode accumulation
  * that was clamped afterwards still reports its original first roll), and
  * the die is tagged `'min'` / `'max'` so parts consumers can tell a clamped
- * value from a natural one.
+ * value from a natural one. The tag is written at most once, so a chain of
+ * same-kind bounds (`4d6min3min4`) leaves a die carrying a single `'min'`.
  *
  * `critical` / `fumble` keep reflecting the natural face — a clamped 1 is
  * still a fumble, matching the raw-face crit semantics used everywhere else.
@@ -42,6 +43,6 @@ export function applyDieBound(
 
     die.initialResult ??= die.result;
     die.result = clamped;
-    die.modifiers.push(bound);
+    if (!die.modifiers.includes(bound)) die.modifiers.push(bound);
   }
 }

--- a/src/evaluator/modifiers/flags.ts
+++ b/src/evaluator/modifiers/flags.ts
@@ -44,6 +44,19 @@ export const SELECTION_AND_TALLY_FLAGS: readonly DieModifier[] = [
   'failure',
 ];
 
+/**
+ * {@link SELECTION_AND_TALLY_FLAGS} plus `'meta'`, for a meta context merging
+ * into a parent. Meta operands nest (`((1d2)d4)d6`), so a die passes through
+ * the merge once per level and the tag must be rebuilt, not appended.
+ */
+export const META_MERGE_FLAGS: readonly DieModifier[] = [
+  'kept',
+  'dropped',
+  'success',
+  'failure',
+  'meta',
+];
+
 /** Selection flags plus `rerolled` — reassigned on every reroll pass. */
 export const REROLL_SLOT_FLAGS: readonly DieModifier[] = ['kept', 'dropped', 'rerolled'];
 

--- a/src/evaluator/modifiers/success-count.ts
+++ b/src/evaluator/modifiers/success-count.ts
@@ -10,7 +10,10 @@
  * excluded from counting and are never tagged.
  *
  * Mutates the input pool in place to add `'success'` / `'failure'` modifier
- * flags — mirrors the mutation pattern of explode and reroll modifiers.
+ * flags — mirrors the mutation pattern of explode and reroll modifiers. Each
+ * tag is written at most once per die: a group counted after its members
+ * (`{4d6>=5}>=1`) runs this pass twice over the same dice, and the parse-time
+ * reject that blocks a direct `4d6>=5>=4` does not reach through a group.
  *
  * @module evaluator/modifiers/success-count
  */
@@ -42,11 +45,15 @@ export function countSuccesses(
   // ! `'success'` / `'failure'` tags written below still land on the pool.
   const pool = hasVersusDc ? dice.filter((die) => !isVersusDc(die)) : dice;
 
+  // ! The guards below only stop the *same* tag being written twice. A nested
+  // ! count with a different threshold still appends to the first pass's tags,
+  // ! so a die can end up both `'success'` and `'failure'`, and the returned
+  // ! counts then disagree with the tags in `rolls`.
   for (const die of pool) {
     if (die.modifiers.includes('dropped')) continue;
 
     if (matchesCondition(die.result, threshold.operator, threshold.value)) {
-      die.modifiers.push('success');
+      if (!die.modifiers.includes('success')) die.modifiers.push('success');
       successes += 1;
       continue;
     }
@@ -55,7 +62,7 @@ export function countSuccesses(
       failThreshold != null &&
       matchesCondition(die.result, failThreshold.operator, failThreshold.value)
     ) {
-      die.modifiers.push('failure');
+      if (!die.modifiers.includes('failure')) die.modifiers.push('failure');
       failures += 1;
     }
   }

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1706,6 +1706,14 @@ describe('Parser', () => {
       it('should reject bound after success counting: 10d10>=6min2', () => {
         expectRollError(() => parseAst('10d10>=6min2'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
       });
+
+      it('should reject success counting after success counting: 4d6>=5>=4 (#290)', () => {
+        expectRollError(() => parseAst('4d6>=5>=4'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+      });
+
+      it('should reject success counting after a fail threshold: 4d6>=5f1>=4 (#290)', () => {
+        expectRollError(() => parseAst('4d6>=5f1>=4'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+      });
     });
   });
 


### PR DESCRIPTION
Guarded the `'min'` / `'max'` write in `applyDieBound`, so a chain of same-kind bounds tags a die once and `initialResult` still comes from the first bound that moved it.

Two further duplicate sites turned up during the audit the issue asked for, both reachable through the public API:

- `countSuccesses` — a group counted after its members (`{4d6>=5}>=1`) reaches the pass twice, because the outer `>=` targets a `GroupNode` and so escapes the parse-time reject that blocks a direct `4d6>=5>=4`.
- `mergeMetaRolls` — meta operands nest (`((1d2)d4)d6`), so a die passed through the merge once per level and collected `'meta'` each time. Added `META_MERGE_FLAGS` to rebuild the tag; the shared `SELECTION_AND_TALLY_FLAGS` could not take `'meta'` without stripping it from dropped group sub-rolls at the other call site.

The third site, `die.modifiers.push('dc')`, is genuinely unguarded but unreachable — `insideVersus` rejects every nesting, so a die reaches exactly one DC context. Documented in place rather than guarded with dead code.

Added a `Record<DieModifier, …>` completeness gate that provokes every tag and asserts no die carries a duplicate, plus regression tests for each chain and parser tests pinning the `4d6>=5>=4` / `4d6>=5f1>=4` rejects.

Used a membership check rather than `rewriteFlags` on the bound path: it runs only for dice a bound actually moved, while the rewrite allocates per die (#132). Measured the guard end-to-end on `10d10>=6f1` — within noise.

Known gap, left for a separate issue: nested counts with *different* thresholds append to the first pass's tags rather than rebuilding them, so `{4d6>=5f1}>=1` leaves a die tagged both `'success'` and `'failure'` and the returned counts disagree with `rolls`. That is contradictory tags rather than duplicate tags, it predates this change, and reconciling it alters user-visible output. Flagged in place at the guards.

Closes #290
