### PR TITLE
docs: critical/fumble TSDoc contradicts explicit cs/cf on Fate dice #291

### DIFF
--- a/src/evaluator/die.ts
+++ b/src/evaluator/die.ts
@@ -37,7 +37,8 @@ export function createDieResult(
 
 /**
  * Creates a Fate/Fudge die result. Uses `sides = 0` as a sentinel — Fate dice
- * have no max-face concept, so `critical` and `fumble` are always `false`.
+ * have no max-face concept, so `critical` and `fumble` start `false` and the
+ * default rule never sets them. An explicit `cs`/`cf` threshold still can.
  */
 export function createFateDieResult(result: number, modifiers: DieModifier[]): DieResult {
   return {

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -4193,6 +4193,16 @@ describe('evaluate', () => {
       expect(result.rolls.map((d) => d.fumble)).toEqual([false, false, false, false]);
     });
 
+    test('cf on Fate dice flags a -1 the default rule never reaches', () => {
+      const ast = parse('4dFcf=-1');
+      const rng = createMockRng([1, -1, 0, 1]);
+      const result = evaluate(ast, rng);
+
+      expect(result.total).toBe(1);
+      expect(result.rolls.map((d) => d.fumble)).toEqual([false, true, false, false]);
+      expect(result.rolls.map((d) => d.critical)).toEqual([false, false, false, false]);
+    });
+
     test('SuccessCount wrapping CritThreshold leaves success tags independent of crit flags', () => {
       const ast = parse('10d10cs>8>=6');
       const rng = createMockRng([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);

--- a/src/evaluator/modifiers/crit-threshold.ts
+++ b/src/evaluator/modifiers/crit-threshold.ts
@@ -19,6 +19,13 @@
  * see the clamped faces. The two can therefore disagree on one die —
  * `4d6min5cs>4` flags a clamped natural 1 as both critical and fumble.
  *
+ * They also diverge on Fate dice. `'default'` carries a `sides > 1` guard, so
+ * it never fires on a `sides = 0` pool; an explicit threshold has none and
+ * compares the raw {-1, 0, +1} face, so `4dFcs>0` and `4dFcf=-1` do set the
+ * flags. The missing guard is deliberate — the parser rejects the bare
+ * `cs`/`cf` forms instead, since they would resolve to `'default'` and
+ * silently do nothing.
+ *
  * ! Penetrating explode is not covered: it stores `raw - 1` in `result`
  * ! without recording `initialResult`, so `1d6!pcs` still judges a natural
  * ! 6 by its decremented 5. An *inherited* rule is handed the raw roll

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -61,8 +61,11 @@ export type DiceNode = NodeSpan & {
  * Fate/Fudge dice node (`dF`).
  * Each die produces a result in {-1, 0, +1}. No configurable sides.
  *
- * Fate dice carry `sides: 0` as a sentinel in their `DieResult`, and are
- * never `critical` or `fumble` — there is no maximum face to hit.
+ * Fate dice carry `sides: 0` as a sentinel in their `DieResult`, so the
+ * default `critical`/`fumble` rule never fires — it is guarded on `sides > 1`,
+ * which also stops a `+1` face from reading as a fumbled 1. An explicit
+ * threshold still applies: `4dFcs>0` and `4dFcf=-1` set the flags, while the
+ * bare `cs`/`cf` forms are rejected at parse time.
  *
  * @category AST
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,9 +169,19 @@ export type DieResult = {
   initialResult?: number;
   /** Modifiers applied to this die */
   modifiers: DieModifier[];
-  /** True if rolled the maximum value (always false for Fate dice) */
+  /**
+   * True if the die met its critical criteria — by default, rolling the
+   * maximum face on a die with more than one side. That default never fires
+   * on `d1` or on Fate dice (`sides = 0` has no maximum face), but an
+   * explicit `cs` threshold does: `4dFcs>0` flags every `+1`.
+   */
   critical: boolean;
-  /** True if rolled 1 (always false for Fate dice) */
+  /**
+   * True if the die met its fumble criteria — by default, rolling a 1 on a
+   * die with more than one side. As with {@link DieResult.critical}, the
+   * default never fires on `d1` or Fate dice, while an explicit `cf`
+   * threshold does: `4dFcf=-1` flags every `-1`.
+   */
   fumble: boolean;
 };
 


### PR DESCRIPTION
Rewords the four TSDoc sites that claimed `critical` and `fumble` are unconditionally `false` on Fate dice. The shipped behavior is the intended one — #93 rejected only the bare `cs`/`cf` forms on Fate pools and kept explicit thresholds — so only the prose moved.

- `DieResult.critical` / `DieResult.fumble` now scope the default max-face / 1 rule to `sides > 1`, so it claims neither `d1` nor Fate dice, and name the explicit-threshold exception (`4dFcs>0`, `4dFcf=-1`)
- `FateDiceNode` attributes the miss to the `sides > 1` guard rather than to a missing maximum face — a Fate die does roll `+1`, so `natural === 1` is satisfiable and only the guard stops the fumble
- `createFateDieResult` says the flags start `false`, not that they stay that way
- `crit-threshold` module TSDoc records the asymmetry: the explicit branch omits the `sides > 1` guard deliberately, and the parser rejects the bare forms instead, since those resolve to `'default'` and would silently do nothing

Added an evaluator test pinning `4dFcf=-1`, alongside the `4dFcs>0` one that already existed.

README needed no change — its `cs`/`cf` section never repeated the claim.

Closes #291
