### PR TITLE
docs: success counting is terminal only against direct wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,10 @@ than they rolled, the side you *don't* override moves with position —
 | `{a+b}khN` | Single-sub-roll group: keep/drop selects across the flattened pool |
 
 > [!IMPORTANT]
-> Success counting is **terminal** — nothing may wrap it, so `10d10>=6 + 2` is
-> a parse error. Put the arithmetic inside the threshold: `10d10>=(4+2)`.
+> Success counting is **terminal** — no modifier or arithmetic applies to it
+> directly, so `10d10>=6 + 2` is a parse error. Put the arithmetic inside the
+> threshold, `10d10>=(4+2)`, or wrap the count in group braces to operate on its
+> result: `{10d10>=6}+2`.
 
 > [!WARNING]
 > A bare `d` after a dice expression is rejected: `4d6d1` throws
@@ -960,7 +962,7 @@ any commit that regresses a case past 1.75x. Bundle size is gated in CI by
 - **Threshold comparisons bind tight.** `1d6!>=5+2` parses as `(1d6!>=5)+2`;
   parenthesize for a computed threshold, `1d6!>=(5+2)`. Success counts bind the
   same way but are terminal, so `1d6>=5+2` errors outright — write
-  `1d6>=(5+2)`.
+  `1d6>=(5+2)`, or `{1d6>=5}+2` to add to the count itself.
 - **`result.expression` substitutes meta-expressions with their resolved
   values,** so it does not round-trip through `parse` when they are present:
   `roll('(1d4)d6').expression` is `'4d6'` when the `1d4` rolled 4, and


### PR DESCRIPTION
`README.md` claimed nothing may wrap a success count, while `src/types.ts:423` documents group braces as the *required* wrapper. The two contradicted each other, and the README was the wrong one — `{5d6>=5}+2` has always parsed and evaluated.

Reworded the terminality callout to say no modifier or arithmetic applies *directly*, and named `{10d10>=6}+2` as the supported form. Added the same escape hatch to the matching Known-limitations entry, which gave the error without it.

Verified against the parser rather than assumed:

- throw `INVALID_SUCCESS_COUNT_TARGET` — `10d10>=6 + 2`, `5d6>=5 * 2`, `4d6>=5>=1`, `10d10>=6min2`, `10d10>=6kh2`, `10d10>=6s`, `10d10>=6cs`, `10d10>=6!`, `-(10d10>=6)`, `(10d10>=6) + 2`
- parse — `{5d6>=5}+2`, `{5d6>=5}*2`, `{5d6>=5}kh1`, `{5d6>=5}s`, `floor({5d6>=5}/2)`, `{{5d6>=5}+2}+3`

Docs only; no behavior change. Settles one acceptance criterion of #297 — that issue's semantics bug is untouched and it stays open.

<sub>Drafted with AI assistance</sub>
