### PR TITLE
feat: add roll-parser/render subpath for custom breakdown rendering #292

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,11 @@ jobs:
         run: |
           node --input-type=module -e "import { roll, VERSION } from 'roll-parser'; import { createMockRng, MockRNGExhaustedError } from 'roll-parser/testing'; const r = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }); if (r.total !== 14) throw new Error('pinned total ' + r.total); if (typeof MockRNGExhaustedError !== 'function') throw new Error('missing error export'); console.log('ESM OK:', VERSION, r.total)"
 
+      - name: Test render subpath
+        working-directory: ${{ runner.temp }}/smoke
+        run: |
+          node --input-type=module -e "import { roll } from 'roll-parser'; import { renderBreakdown } from 'roll-parser/render'; import { createMockRng } from 'roll-parser/testing'; const r = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }); const shown = renderBreakdown(r, { dropped: (die, text) => '(' + text + ')' }); if (shown !== '4d6[3, 6, (2), 5] = 14') throw new Error('render ' + shown); console.log('render OK:', shown)"
+
       - name: Test require(esm) import
         # ESM-only package — require() works on Node >=22.12 via require(esm).
         working-directory: ${{ runner.temp }}/smoke
@@ -390,7 +395,7 @@ jobs:
 
   # The published types on the TypeScript versions consumers actually run.
   # Typechecks `scripts/ts-compat/consumer.ts` against the packed tarball, so
-  # the `exports` map, both entry points, and the emitted `.d.ts` all take
+  # the `exports` map, all three entry points, and the emitted `.d.ts` all take
   # part — `tsc` resolves here exactly the way a consumer's does. Node-only:
   # no Bun setup and no root install, since the fixture depends on the tarball
   # and one matrix TypeScript, nothing else.
@@ -581,16 +586,19 @@ jobs:
           npm init -y > /dev/null
           npm install --no-audit --no-fund "$RUNNER_TEMP"/tarball/roll-parser-*.tgz
 
-      - name: Write browser fixture importing both entry points
+      - name: Write browser fixture importing every entry point
         working-directory: ${{ runner.temp }}/browser-smoke
         run: |
           printf '%s\n' \
             "import { roll, SeededRNG, VERSION } from 'roll-parser';" \
+            "import { renderBreakdown } from 'roll-parser/render';" \
             "import { createMockRng } from 'roll-parser/testing';" \
             "const pinned = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });" \
             "if (pinned.total !== 14) throw new Error('pinned total ' + pinned.total);" \
+            "const shown = renderBreakdown(pinned, { dropped: (die, text) => '(' + text + ')' });" \
+            "if (shown !== '4d6[3, 6, (2), 5] = 14') throw new Error('render ' + shown);" \
             "const seeded = roll('2d6', { rng: new SeededRNG('ci') });" \
-            "console.log('browser-smoke OK', VERSION, pinned.total, seeded.total);" \
+            "console.log('browser-smoke OK', VERSION, pinned.total, seeded.total, shown);" \
             > fixture.mjs
 
       - name: Bundle fixture for the browser
@@ -685,7 +693,7 @@ jobs:
         run: node scripts/browser-smoke/run.ts "$RUNNER_TEMP/browser-run/bundle.js"
 
   # Deno's npm compatibility layer resolves `exports` through its own
-  # implementation, so the dual entry points are the part most likely to break.
+  # implementation, so the three entry points are the part most likely to break.
   # Neutrality is not what this proves — Deno provides `node:` builtins — the
   # claim under test is that the published package resolves and runs there.
   deno-smoke:
@@ -723,18 +731,21 @@ jobs:
           npm init -y > /dev/null
           npm install --no-audit --no-fund "$RUNNER_TEMP"/tarball/roll-parser-*.tgz
 
-      - name: Write Deno fixture importing both entry points
+      - name: Write Deno fixture importing every entry point
         working-directory: ${{ runner.temp }}/deno-smoke
         run: |
           printf '%s\n' \
             "import { roll, SeededRNG, VERSION } from 'roll-parser';" \
+            "import { renderBreakdown } from 'roll-parser/render';" \
             "import { createMockRng } from 'roll-parser/testing';" \
             "const pinned = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });" \
             "if (pinned.total !== 14) throw new Error('pinned total ' + pinned.total);" \
+            "const shown = renderBreakdown(pinned, { dropped: (die, text) => '(' + text + ')' });" \
+            "if (shown !== '4d6[3, 6, (2), 5] = 14') throw new Error('render ' + shown);" \
             "const seeded = roll('2d6', { rng: new SeededRNG('ci') });" \
             "if (!Number.isInteger(seeded.total) || seeded.total < 2 || seeded.total > 12) throw new Error('seeded total ' + seeded.total);" \
             "if (typeof VERSION !== 'string' || VERSION.length === 0) throw new Error('missing VERSION');" \
-            "console.log('deno-smoke OK', VERSION, pinned.total, seeded.total);" \
+            "console.log('deno-smoke OK', VERSION, pinned.total, seeded.total, shown);" \
             > fixture.mjs
 
       # `manual` keeps Deno on the node_modules npm just wrote instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `roll-parser/render`, a subpath export holding `renderBreakdown(result, marks?)`, `DieMarks`, and `MARKDOWN_MARKS`. It rebuilds the `RollResult.rendered` breakdown from `RollResult.parts` with markers the caller chooses, so consumers targeting anything other than Discord markdown no longer regex-parse the baked string. Six slots — `dropped`, `success`, `failure`, `critical`, `fumble`, and `droppedGroup` — compose in a fixed order; `critical`/`fumble` read the `DieResult` booleans, which `rendered` has no marker for. With no `marks` the output is byte-identical to `rendered`, pinned by a property test. Budgeted separately at 2 kB, leaving the `index.js` and `{ roll }` budgets to the library ([#292](https://github.com/edloidas/roll-parser/issues/292))
+
+### Changed
+
+- The `explode`, `reroll`, and `successCount` members of `RollPart` now carry `rolls: DieResult[]`, the pool the modifier produced — mirroring what `sort` already did. Standard and penetrating explosions and both reroll forms append dice that appear nowhere under `target`, so the part tree could not previously describe its own output ([#292](https://github.com/edloidas/roll-parser/issues/292))
+
+  Reading `parts` is unaffected. Three things do change:
+
+  - Code that **constructs** one of those three parts stops compiling — `TS2322: Property 'rolls' is missing in type … but required`. Add the pool, or widen the annotation.
+  - Deep-equality assertions against those parts need the new field.
+  - `--json` and `JSON.stringify(result)` payloads grow for expressions using explode, reroll, or success counting, since the pool is serialized on the modifier as well as its target — roughly +40% to +96% depending on pool size. Expressions without those modifiers are unchanged.
+
+### Fixed
+
+- CLI `--verbose` no longer mangles a dropped group sub-roll nested inside another dropped group sub-roll. `{{1d6, 1d8}kh1, {1d10, 1d12}kh1}kh1` rendered as `({)1d10[1](, 1d12[3]})`; the marker rewrite was a regex over the flat string and stopped at the first inner `~~`. It now reads the structure and emits `({(1d10[1]), 1d12[3]})` ([#292](https://github.com/edloidas/roll-parser/issues/292))
+
 ## [3.0.0] - 2026-08-06
 
 First stable release of the v3 rewrite. This section covers what changed since

--- a/README.md
+++ b/README.md
@@ -380,6 +380,36 @@ success-count modifiers, but **not** keep/drop — `4d6kh3` renders as `4d6[…]
 while `8d6!` renders as `8d6![…]`. Read `result.expression` when you need the
 modifier back.
 
+#### Custom markers
+
+Markdown is one dialect, and `rendered` bakes it in. `roll-parser/render` is a
+≈1.4 kB entry point that rebuilds the same breakdown from `result.parts` with
+markers you choose — no regex round-trip through the baked string.
+
+```typescript
+import { renderBreakdown } from 'roll-parser/render';
+
+const result = roll('4d6kh3', { seed: 'demo' });
+
+renderBreakdown(result); // '4d6[1, 6, ~~1~~, 3] = 10'
+renderBreakdown(result, {}); // '4d6[1, 6, 1, 3] = 10'
+renderBreakdown(result, {
+  dropped: (_die, text) => `<s>${text}</s>`,
+  critical: (_die, text) => `<b>${text}</b>`,
+}); // '4d6[1, <b>6</b>, <s>1</s>, 3] = 10'
+```
+
+Six slots are available — `dropped`, `success`, `failure`, `critical`,
+`fumble`, and `droppedGroup` for a whole sub-roll struck by `{…}kh1`. An
+omitted slot renders plain, so pass `{}` to strip markup entirely or spread
+`MARKDOWN_MARKS` to keep the rest. `critical` and `fumble` read the
+`DieResult` booleans, which `rendered` has no marker for at all.
+
+Marks compose in a fixed order: `critical` then `fumble` innermost, then
+exactly one of `dropped`, `success`, or `failure` — a dropped die is never
+also shown as a success. With no marks the output is byte-identical to
+`result.rendered`; a property test pins that.
+
 ## Randomness
 
 Every die is drawn through the `RNG` interface — no roll path bypasses the RNG

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./render": {
+      "types": "./dist/render.d.ts",
+      "default": "./dist/render.js"
+    },
     "./testing": {
       "types": "./dist/testing.d.ts",
       "default": "./dist/testing.js"
@@ -111,6 +115,12 @@
       "path": "dist/index.js",
       "import": "{ roll }",
       "limit": "12 kB"
+    },
+    {
+      "name": "render.js — { renderBreakdown }",
+      "path": "dist/render.js",
+      "import": "{ renderBreakdown }",
+      "limit": "2 kB"
     },
     {
       "name": "testing.js — { createMockRng }",

--- a/scripts/ts-compat/consumer.ts
+++ b/scripts/ts-compat/consumer.ts
@@ -19,6 +19,8 @@ import type {
   RollResult,
 } from 'roll-parser';
 import { DegreeOfSuccess, parse, RollParserError, roll, SeededRNG, VERSION } from 'roll-parser';
+import type { DieMarks } from 'roll-parser/render';
+import { MARKDOWN_MARKS, renderBreakdown } from 'roll-parser/render';
 import { createMockRng, MockRNGExhaustedError } from 'roll-parser/testing';
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
@@ -31,6 +33,7 @@ export type PartResolved = Assert<NotAny<RollPart>>;
 export type AstResolved = Assert<NotAny<ASTNode>>;
 export type DieResolved = Assert<NotAny<DieResult>>;
 export type SpecResolved = Assert<NotAny<KeepDropSpec>>;
+export type MarksResolved = Assert<NotAny<DieMarks>>;
 
 const rng: RNG = createMockRng([3, 6, 2, 5]);
 const result: RollResult = roll('4d6kh3', { rng });
@@ -39,6 +42,8 @@ const rendered: string = result.rendered;
 const version: string = VERSION;
 const seeded: RNG = new SeededRNG('ci');
 const ast: ASTNode = parse('2d6');
+const marks: DieMarks = { ...MARKDOWN_MARKS, critical: (die, text) => `${text}/${die.sides}` };
+const breakdown: string = renderBreakdown(result, marks);
 
 /** Narrowing on the discriminant must survive resolution, not collapse to `any`. */
 function describe(part: RollPart): string {
@@ -67,6 +72,7 @@ const unknownPartType: RollPartType = 'nope';
 export const checks = [
   total,
   rendered,
+  breakdown,
   version,
   describe(result.parts),
   ast.type,

--- a/scripts/worker-smoke/run.ts
+++ b/scripts/worker-smoke/run.ts
@@ -14,6 +14,7 @@ import { createServer } from 'node:net';
 import { join } from 'node:path';
 
 const EXPECTED_PINNED = 14;
+const EXPECTED_RENDERED = '4d6[3, 6, (2), 5] = 14';
 const BOOT_TIMEOUT_MS = 120_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 250;
@@ -104,7 +105,12 @@ if (!response.ok) {
   fail(`workerd returned ${response.status}: ${await response.text()}`);
 }
 
-const body = (await response.json()) as { version?: unknown; pinned?: unknown; seeded?: unknown };
+const body = (await response.json()) as {
+  version?: unknown;
+  pinned?: unknown;
+  seeded?: unknown;
+  rendered?: unknown;
+};
 
 if (typeof body.version !== 'string' || body.version.length === 0) {
   fail(`VERSION did not cross the Worker boundary: ${JSON.stringify(body.version)}`);
@@ -119,6 +125,10 @@ if (
   body.seeded > 12
 ) {
   fail(`seeded 2d6 total outside 2-12: ${JSON.stringify(body.seeded)}`);
+}
+
+if (body.rendered !== EXPECTED_RENDERED) {
+  fail(`rendered ${JSON.stringify(body.rendered)}, expected ${JSON.stringify(EXPECTED_RENDERED)}`);
 }
 
 stop();

--- a/scripts/worker-smoke/worker.mjs
+++ b/scripts/worker-smoke/worker.mjs
@@ -1,4 +1,5 @@
 import { SeededRNG, VERSION, roll } from 'roll-parser';
+import { renderBreakdown } from 'roll-parser/render';
 import { createMockRng } from 'roll-parser/testing';
 
 // ! Rolling per request, not at module scope: workerd evaluates the top level in
@@ -13,6 +14,7 @@ export default {
       version: VERSION,
       pinned: pinned.total,
       seeded: seeded.total,
+      rendered: renderBreakdown(pinned, { dropped: (die, text) => `(${text})` }),
     });
   },
 };

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -27,7 +27,7 @@ describe('formatResult', () => {
       expect(formatResult(result, { verbose: true })).toBe('2d6[3, 5] + 3 = 11');
     });
 
-    test('replaces markdown strikethrough with parentheses for dropped dice', () => {
+    test('parenthesizes dropped dice', () => {
       const result = roll('4d6kh3', { rng: createMockRng([3, 1, 5, 4]) });
       expect(formatResult(result, { verbose: true })).toContain('(1)');
       expect(formatResult(result, { verbose: true })).not.toContain('~~');
@@ -45,7 +45,7 @@ describe('formatResult', () => {
       expect(formatResult(result, { verbose: true })).toBe('1d20[15] = 15');
     });
 
-    test('replaces strikethrough around negative values (dropped fate dice)', () => {
+    test('parenthesizes dropped fate dice, negative faces included', () => {
       const result = roll('4dFkh2', { rng: createMockRng([-1, 0, 1, 1]) });
       const output = formatResult(result, { verbose: true });
 
@@ -55,7 +55,7 @@ describe('formatResult', () => {
       expect(output).toBe('4dF[(-1), (0), 1, 1] = 2');
     });
 
-    test('converts intermediate rerolled dice to terminal-friendly parentheses', () => {
+    test('parenthesizes intermediate rerolled dice', () => {
       // 2d6r<2 with RNG [1, 5, 3] — die 0 rerolls 1 → 3.
       const result = roll('2d6r<2', { rng: createMockRng([1, 5, 3]) });
       const output = formatResult(result, { verbose: true });
@@ -65,7 +65,7 @@ describe('formatResult', () => {
       expect(output).toContain('= 8');
     });
 
-    test('converts success/failure markers to brackets and braces', () => {
+    test('brackets successes and braces failures', () => {
       const result = roll('3d6>=5f1', { rng: createMockRng([1, 5, 3]) });
       const output = formatResult(result, { verbose: true });
 
@@ -75,13 +75,28 @@ describe('formatResult', () => {
       expect(output).not.toContain('__');
     });
 
-    test('converts compound dropped sub-roll spans from group keep', () => {
-      // The dropped sub-roll strikethrough wraps notation (`~~1d8[2]~~`), not just a number.
+    test('parenthesizes a whole sub-roll dropped by group keep', () => {
+      // The wrapper spans notation, not just a number — `(1d8[2])`.
       const result = roll('{1d8, 1d10}kh1', { rng: createMockRng([2, 7]) });
       const output = formatResult(result, { verbose: true });
 
       expect(output).toBe('{(1d8[2]), 1d10[7]} = 7');
       expect(output).not.toContain('~~');
+    });
+
+    test('nests a dropped sub-roll that itself contains a dropped sub-roll (#292)', () => {
+      // The marker span here is `~~{~~1d10[1]~~, 1d12[3]}~~` — nested, because
+      // `stripInnerMarkers` only unwraps markers around bare numbers. Reading
+      // it structurally is what makes the nesting come out paired; the regex
+      // this replaced stopped at the first inner `~~` and emitted `({)1d10[1](,
+      // 1d12[3]})`.
+      const result = roll('{{1d6, 1d8}kh1, {1d10, 1d12}kh1}kh1', {
+        rng: createMockRng([1, 4, 1, 3]),
+      });
+
+      expect(formatResult(result, { verbose: true })).toBe(
+        '{{(1d6[1]), 1d8[4]}, ({(1d10[1]), 1d12[3]})} = 4',
+      );
     });
   });
 

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -6,7 +6,21 @@
  * @module cli/format
  */
 
+import { type DieMarks, renderBreakdown } from '../render.js';
 import type { RollResult } from '../types.js';
+
+/**
+ * Terminal stand-ins for the markdown markers `RollResult.rendered` uses:
+ * dropped dice become `(value)`, successes `[value]`, failures `{value}`, so
+ * the per-die classification stays visible with no markup dependency. A
+ * dropped group sub-roll takes the same parentheses as a dropped die.
+ */
+const TERMINAL_MARKS: DieMarks = {
+  dropped: (_die, text) => `(${text})`,
+  success: (_die, text) => `[${text}]`,
+  failure: (_die, text) => `{${text}}`,
+  droppedGroup: (inner) => `(${inner})`,
+};
 
 /**
  * Output mode selectors for {@link formatResult}.
@@ -42,27 +56,5 @@ export function formatResult(result: RollResult, options: FormatOptions = {}): s
     return String(result.total);
   }
 
-  return formatRendered(result.rendered);
-}
-
-/**
- * Converts markdown-style dice markers to terminal-friendly forms.
- *
- * The evaluator uses markdown syntax in the rendered field:
- *   `~~value~~` — dropped dice or dropped group sub-rolls
- *   `**value**` — dice counted as success
- *   `__value__` — dice counted as failure
- *
- * For plain terminals these become `(value)`, `[value]`, and `{value}` so
- * the per-die classification stays visible without any markup dependency.
- * Dropped spans can wrap a whole sub-roll (e.g. `~~1d8[2]~~` from
- * `{1d8, 1d10}kh1`), so the strikethrough pattern accepts any tilde-free
- * content, not just a single number. The evaluator never nests `~~`
- * (see `stripInnerMarkers`), so the tilde-free span match is safe.
- */
-function formatRendered(rendered: string): string {
-  return rendered
-    .replace(/\*\*(-?\d+)\*\*/g, '[$1]')
-    .replace(/__(-?\d+)__/g, '{$1}')
-    .replace(/~~([^~]+)~~/g, '($1)');
+  return renderBreakdown(result, TERMINAL_MARKS);
 }

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1028,10 +1028,11 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
 
   const code = formatExplodeCode(node.variant, node.threshold, thresholdValue);
 
-  const buildPart = (total: number): RollPart => {
+  const buildPart = (total: number, rolls: DieResult[]): RollPart => {
     const part: RollPart = {
       type: 'explode',
       variant: node.variant,
+      rolls,
       target: target.part,
       total,
       ...partSpan(node),
@@ -1046,7 +1047,7 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   if (targetCtx.rolls.length === 0) {
     ctx.expressionParts.push(`${targetExpr}${code}`);
     ctx.renderedParts.push(`${targetExpr}${code}`);
-    return { total: target.total, part: buildPart(target.total) };
+    return { total: target.total, part: buildPart(target.total, targetCtx.rolls) };
   }
 
   const shouldExplode = buildShouldExplode(node.threshold?.operator, thresholdValue);
@@ -1060,7 +1061,7 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   ctx.renderedParts.push(`${targetExpr}${code}${renderDice(expanded)}`);
 
   const total = sumKeptDice(expanded, env.hasVersusDc);
-  return { total, part: buildPart(total) };
+  return { total, part: buildPart(total, expanded) };
 }
 
 function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv): EvalResult {
@@ -1087,6 +1088,7 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
         type: 'reroll',
         once: node.once,
         condition,
+        rolls: targetCtx.rolls,
         target: target.part,
         total,
         ...partSpan(node),
@@ -1109,6 +1111,7 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
       type: 'reroll',
       once: node.once,
       condition,
+      rolls: pool,
       target: target.part,
       total,
       ...partSpan(node),
@@ -1527,6 +1530,7 @@ function evalSuccessCount(
     const part: RollPart = {
       type: 'successCount',
       threshold: { operator: node.threshold.operator, value: thresholdValue },
+      rolls: targetCtx.rolls,
       target: target.part,
       successes,
       failures,

--- a/src/evaluator/parts.test.ts
+++ b/src/evaluator/parts.test.ts
@@ -188,27 +188,49 @@ describe('RollResult.parts', () => {
 
     test('1d6!! — compound explode mutation visible through shared refs', () => {
       const result = roll('1d6!!', { rng: createMockRng([6, 3]) });
+      const compoundDie = {
+        sides: 6,
+        result: 9,
+        initialResult: 6,
+        modifiers: ['kept', 'exploded'],
+        critical: true,
+        fumble: false,
+      };
       expect(stripSpans(result.parts)).toEqual({
         type: 'explode',
         variant: 'compound',
+        // Compound accumulates in place, so the expanded pool is the same die
+        // the target carries — unlike standard/penetrating, which append.
+        rolls: [compoundDie],
         target: {
           type: 'dice',
           count: 1,
           sides: 6,
-          rolls: [
-            {
-              sides: 6,
-              result: 9,
-              initialResult: 6,
-              modifiers: ['kept', 'exploded'],
-              critical: true,
-              fumble: false,
-            },
-          ],
+          rolls: [compoundDie],
           total: 6,
         },
         total: 9,
       });
+    });
+
+    test('1d6! — appended explosion die is only on the explode part (#292)', () => {
+      const result = roll('1d6!', { rng: createMockRng([6, 3]) });
+      const part = result.parts as Extract<RollPart, { type: 'explode' }>;
+      const target = part.target as Extract<RollPart, { type: 'dice' }>;
+
+      expect(part.rolls.map((die) => die.result)).toEqual([6, 3]);
+      expect(target.rolls.map((die) => die.result)).toEqual([6]);
+      expect(part.rolls[0]).toBe(target.rolls[0] as (typeof part.rolls)[number]);
+    });
+
+    test('1d6r<3 — discarded die and replacement are only on the reroll part (#292)', () => {
+      const result = roll('1d6r<3', { rng: createMockRng([1, 5]) });
+      const part = result.parts as Extract<RollPart, { type: 'reroll' }>;
+      const target = part.target as Extract<RollPart, { type: 'dice' }>;
+
+      expect(part.rolls.map((die) => die.result)).toEqual([1, 5]);
+      expect(part.rolls[0]?.modifiers).toEqual(['rerolled', 'dropped']);
+      expect(target.rolls.map((die) => die.result)).toEqual([1]);
     });
   });
 

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -18,10 +18,12 @@
  * shuffles test order; it does not configure fast-check.)
  */
 
-import { describe, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import fc from 'fast-check';
 import { isRollParserError } from './errors.js';
+import { renderBreakdown } from './render.js';
 import { roll } from './roll.js';
+import type { RollResult } from './types.js';
 
 /**
  * Seed generator for properties that compare two rolls on the same random
@@ -274,6 +276,152 @@ describe('property-based invariants', () => {
         ),
         { numRuns: 200 },
       );
+    });
+  });
+
+  describe('rendered breakdown round-trip', () => {
+    /**
+     * `renderBreakdown` is a second implementation of the same output as
+     * `RollResult.rendered`, so the two can drift apart silently. This is the
+     * gate that turns that drift into a CI failure — it is the reason two
+     * implementations are acceptable at all.
+     */
+    const notationCount = fc.integer({ min: 0, max: 4 });
+
+    // Slot order is the order the parser accepts a chain in.
+    const EXPLODE = ['!', '!!', '!p', '!>4'];
+    const REROLL = ['r<2', 'ro<2', 'r=1'];
+    const BOUND = ['min2', 'max5', 'min(-2)'];
+    const CRIT = ['cs>4', 'cf<2', 'cs', 'cf', 'cs>5cf<2'];
+    const SORT = ['s', 'sd'];
+    const KEEP_DROP = ['kh2', 'kl1', 'dh1', 'dl1', 'kh(1d2)'];
+
+    /**
+     * Joins modifiers with spaces. Several adjacent pairs are otherwise
+     * unlexable — `sd` followed by `kl1` reads as one identifier — and the
+     * evaluator drops the spaces when rebuilding the expression, so the
+     * rendered form is the same either way.
+     */
+    function chainModifiers(pool: string, modifiers: string[]): string {
+      return [pool, ...modifiers.filter((modifier) => modifier !== '')].join(' ');
+    }
+
+    function withModifiers(pool: fc.Arbitrary<string>, slots: string[][]): fc.Arbitrary<string> {
+      const slotArbs = slots.map((slot) => fc.option(fc.constantFrom(...slot), { nil: '' }));
+      return fc
+        .tuple(pool, fc.tuple(...slotArbs))
+        .map(([base, modifiers]) => chainModifiers(base, [...modifiers]));
+    }
+
+    /**
+     * A pool carrying exactly one modifier.
+     *
+     * ! Do not fold this into `withModifiers`. Only the outermost modifier of
+     * ! a chain renders its own pool — every inner one is re-rendered by its
+     * ! wrapper — so a generator that always stacks five optional slots leaves
+     * ! each individual modifier outermost about 0.03% of the time, and the
+     * ! explode and reroll pools go effectively untested.
+     */
+    function withOneModifier(pool: fc.Arbitrary<string>, slots: string[][]): fc.Arbitrary<string> {
+      return fc
+        .tuple(pool, fc.constantFrom(...slots.flat()))
+        .map(([base, modifier]) => chainModifiers(base, [modifier]));
+    }
+
+    const numericPool = fc
+      .tuple(notationCount, fc.constantFrom('4', '6', '8', '10', '20', '%'))
+      .map(([count, sides]) => `${count}d${sides}`);
+    const fatePool = notationCount.map((count) => `${count}dF`);
+
+    const NUMERIC_SLOTS = [EXPLODE, REROLL, BOUND, CRIT, SORT, KEEP_DROP];
+    // Fate dice reject explode, reroll and clamping, so they get a smaller
+    // slot list rather than generating notation that can only be discarded.
+    const FATE_SLOTS = [CRIT, SORT, KEEP_DROP];
+
+    const modifiedPool = fc.oneof(
+      { weight: 4, arbitrary: withOneModifier(numericPool, NUMERIC_SLOTS) },
+      { weight: 4, arbitrary: withModifiers(numericPool, NUMERIC_SLOTS) },
+      { weight: 1, arbitrary: withOneModifier(fatePool, FATE_SLOTS) },
+      { weight: 1, arbitrary: withModifiers(fatePool, FATE_SLOTS) },
+    );
+
+    const termArb = fc.letrec((tie) => ({
+      term: fc.oneof(
+        { maxDepth: 2, withCrossShrink: true },
+        modifiedPool,
+        fc.integer({ min: 0, max: 9 }).map(String),
+        fc.constantFrom('@str', '@{my stat}'),
+        tie('term').map((inner) => `(${inner})`),
+        fc
+          .tuple(fc.constantFrom('floor', 'ceil', 'round', 'abs', 'sqrt'), tie('term'))
+          .map(([name, inner]) => `${name}(${inner})`),
+        fc
+          .tuple(fc.constantFrom('min', 'max'), tie('term'), tie('term'))
+          .map(([name, left, right]) => `${name}(${left}, ${right})`),
+        fc.array(tie('term'), { minLength: 1, maxLength: 3 }).map((subs) => `{${subs.join(', ')}}`),
+        // Sub-roll selection — the only notation that produces a group part
+        // with `keptIndices`, and so the only one that strikes a whole
+        // sub-roll instead of a die. Two or more sub-rolls, or the evaluator
+        // takes the flat-pool path and no selection happens.
+        fc
+          .tuple(
+            fc.array(tie('term'), { minLength: 2, maxLength: 3 }),
+            fc.constantFrom('kh', 'kl', 'dh', 'dl'),
+            fc.integer({ min: 1, max: 2 }),
+          )
+          .map(([subs, code, count]) => `{${subs.join(', ')}}${code}${count}`),
+        fc
+          .tuple(tie('term'), fc.constantFrom('+', '-', '*', '/', '%', '**'), tie('term'))
+          .map(([left, operator, right]) => `${left} ${operator} ${right}`),
+      ),
+    })).term;
+
+    // Success counting is terminal, so it is generated at the top level (or
+    // braced) rather than as a term the arithmetic layer can wrap.
+    const successArb = fc
+      .tuple(
+        modifiedPool,
+        fc.constantFrom('>=4', '>3', '<3', '=4'),
+        fc.option(fc.constantFrom('f1', 'f<2', 'f>=5'), { nil: '' }),
+      )
+      .map(([pool, threshold, fail]) => `${pool}${threshold}${fail}`);
+
+    const notationArb = fc.oneof(
+      { weight: 6, arbitrary: termArb },
+      { weight: 2, arbitrary: successArb },
+      { weight: 2, arbitrary: successArb.map((counted) => `{${counted}} + 1`) },
+      { weight: 2, arbitrary: fc.tuple(termArb, termArb).map(([a, b]) => `${a} vs ${b}`) },
+    );
+
+    test('renderBreakdown with default marks reproduces result.rendered', () => {
+      const NUM_RUNS = 1000;
+      let evaluated = 0;
+
+      fc.assert(
+        fc.property(notationArb, seedArb, (notation, seed) => {
+          let result: RollResult;
+          try {
+            result = roll(notation, {
+              seed,
+              context: { str: 3, 'my stat': 4 },
+              maxDice: 200,
+            });
+          } catch (error) {
+            // Notation the grammar produced but the parser or evaluator
+            // rejects proves nothing about rendering — only an untyped
+            // escape would be a failure, and that is pinned separately.
+            return isRollParserError(error);
+          }
+
+          evaluated += 1;
+          return renderBreakdown(result) === result.rendered;
+        }),
+        { numRuns: NUM_RUNS },
+      );
+
+      // Without this the property would still pass if the grammar drifted
+      // into emitting notation nothing can evaluate.
+      expect(evaluated).toBeGreaterThan(NUM_RUNS / 2);
     });
   });
 

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -248,8 +248,13 @@ beforeAll(async () => {
   // ! on a fresh clone, where `dist/` (the self-reference target) does not exist yet.
   const packageName = 'roll-parser';
   const api = (await import(packageName)) as Record<string, unknown>;
+  const render = (await import(`${packageName}/render`)) as Record<string, unknown>;
   const testing = (await import(`${packageName}/testing`)) as Record<string, unknown>;
-  namespaces = { [packageName]: api, [`${packageName}/testing`]: testing };
+  namespaces = {
+    [packageName]: api,
+    [`${packageName}/render`]: render,
+    [`${packageName}/testing`]: testing,
+  };
 
   const roll = api.roll as (notation: string) => unknown;
   const notation = '2d6+1d0+3';
@@ -262,6 +267,7 @@ beforeAll(async () => {
 
   scope = {
     ...api,
+    ...render,
     ...testing,
     // Free variables the samples use without declaring.
     userInput: '2d20kh1+5',

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for `roll-parser/render`.
+ *
+ * The default-marks path is pinned twice: here against a table of concrete
+ * notations, chained without the spaces the property-test grammar inserts,
+ * and in `property.test.ts` against generated notation. This file also owns
+ * the custom-marks contract — composition order, plain slots, and the group
+ * wrapper.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { evaluate } from './evaluator/evaluator.js';
+import type { ASTNode } from './parser/ast.js';
+import { type DieMarks, MARKDOWN_MARKS, renderBreakdown } from './render.js';
+import { createMockRng } from './rng/mock.js';
+import { roll } from './roll.js';
+import { DegreeOfSuccess } from './types.js';
+
+/** Every notation in the table is rolled on this seed, not a mock RNG. */
+function seeded(notation: string) {
+  return roll(notation, {
+    seed: `render-${notation}`,
+    context: { str: 3, 'my stat': 4 },
+  });
+}
+
+describe('renderBreakdown', () => {
+  describe('default marks reproduce result.rendered', () => {
+    const NOTATIONS = [
+      '3d6',
+      '4d6kh3',
+      '4d6kh3dl1',
+      '2d6!',
+      '2d6!!',
+      '2d6!p',
+      '2d6!>4',
+      '2d6r<3',
+      '2d6ro<3',
+      '2d6min2',
+      '2d6max4',
+      '2d6min(-2)',
+      '4d6s',
+      '4d6sd',
+      '4d6>=4',
+      '4d6>=4f1',
+      '4d6>=4f<2',
+      '2d6cs>4',
+      '2d6cs',
+      '2d6cf<3',
+      '2d6cs>5cf<2',
+      '4dF',
+      '4dFcs>0',
+      '1d%',
+      '1d20+5 vs 15',
+      '1d20 vs 2d10',
+      '1d20 vs 2d10kh1',
+      '{1d6, 1d8}kh1',
+      '{1d6, 1d8, 1d10}kl1',
+      '{2d6, 3d6}',
+      '{1d6}kh1',
+      '{{1d6, 1d8}kh1, 1d10}kh1',
+      'floor(1d10/2)',
+      'max(1d6, 2)',
+      'min(1d6, 1d8)',
+      '-1d6',
+      '(1d6+2)*3',
+      '1d20+@str',
+      '1d20+@{my stat}',
+      '(1d2)d6',
+      '(1d2-1)d6',
+      '(1d2-1)d6!',
+      '(1d2-1)d6>=4',
+      '0d6',
+      '0d6!',
+      '0d6>=4',
+      '0d6min2',
+      '4d6kh(1d2)',
+      '1d6!>(1d2+3)',
+      '2d6!kh1',
+      '2d6!!kh1',
+      '4d6s dl1',
+      '4d6kh3!',
+      '4d6kh3 s',
+      '(2d6)!',
+      '(2d6)kh1',
+      '(2d6)min2',
+      '{2d6}kh1',
+      '{2d6}s',
+      '{2d6}>=4',
+      '-(2d6)kh1',
+      '{4d6kh3, 4d6kh3}kh1',
+      '10d20cs>=15',
+      '4d6cs>4>=4',
+      '2d6 + 3d8kh1 - 1',
+    ];
+
+    for (const notation of NOTATIONS) {
+      test(notation, () => {
+        const result = seeded(notation);
+        expect(renderBreakdown(result)).toBe(result.rendered);
+      });
+    }
+  });
+
+  describe('empty pools', () => {
+    // The bracket tracks whether the target rolled anything at all, including
+    // the meta dice that resolved its count — which never render themselves.
+    test('a pool that rolled nothing drops the bracket', () => {
+      const result = roll('0d6!', { rng: createMockRng([]) });
+      expect(renderBreakdown(result)).toBe('0d6! = 0');
+    });
+
+    test('a meta-resolved zero count keeps the empty bracket', () => {
+      const result = roll('(1d2-1)d6!', { rng: createMockRng([1]) });
+      expect(renderBreakdown(result)).toBe('0d6![] = 0');
+    });
+  });
+
+  // The parser refuses every one of these targets — `(1+2)!` is an
+  // INVALID_EXPLODE_TARGET — but `evaluate` accepts a hand-built AST, and the
+  // evaluator has explicit no-dice branches for exactly this. The renderer
+  // walks the same shapes, so it needs the same branches.
+  describe('dice-less modifier targets on hand-built ASTs', () => {
+    const literal: ASTNode = { type: 'Literal', value: 3 };
+    const variable: ASTNode = { type: 'Variable', name: 'str' };
+
+    const TARGETS: [label: string, target: ASTNode][] = [
+      ['literal', literal],
+      ['variable', variable],
+      ['binaryOp', { type: 'BinaryOp', operator: '+', left: literal, right: literal }],
+      ['unaryOp', { type: 'UnaryOp', operator: '-', operand: literal }],
+      ['functionCall', { type: 'FunctionCall', name: 'abs', args: [literal] }],
+      ['versus', { type: 'Versus', roll: literal, dc: literal }],
+    ];
+
+    const WRAPPERS: [label: string, wrap: (target: ASTNode) => ASTNode][] = [
+      ['explode', (target) => ({ type: 'Explode', variant: 'standard', target })],
+      [
+        'keepDrop',
+        (target) => ({
+          type: 'KeepDrop',
+          kind: 'keep',
+          selector: 'highest',
+          count: literal,
+          target,
+        }),
+      ],
+      ['dieBound', (target) => ({ type: 'DieBound', bound: 'min', value: literal, target })],
+      [
+        'critThreshold',
+        (target) => ({
+          type: 'CritThreshold',
+          successThresholds: ['default'],
+          failThresholds: [],
+          target,
+        }),
+      ],
+    ];
+
+    for (const [wrapperLabel, wrap] of WRAPPERS) {
+      for (const [targetLabel, target] of TARGETS) {
+        test(`${wrapperLabel} over ${targetLabel}`, () => {
+          const result = evaluate(wrap(target), createMockRng([]), { context: { str: 3 } });
+          expect(renderBreakdown(result)).toBe(result.rendered);
+        });
+      }
+    }
+  });
+
+  describe('degree labels', () => {
+    const DEGREES: [notation: string, draws: number[], label: string][] = [
+      ['1d20 vs 15', [18], 'Success'],
+      ['1d20 vs 15', [8], 'Failure'],
+      ['1d20+20 vs 15', [18], 'Critical Success'],
+      ['1d20 vs 15', [3], 'Critical Failure'],
+    ];
+
+    for (const [notation, draws, label] of DEGREES) {
+      test(`${notation} on ${draws[0]} renders ${label}`, () => {
+        const result = roll(notation, { rng: createMockRng(draws) });
+        expect(renderBreakdown(result).endsWith(` = ${label}`)).toBe(true);
+        expect(renderBreakdown(result)).toBe(result.rendered);
+      });
+    }
+
+    test('every DegreeOfSuccess member has a label', () => {
+      const labels = DEGREES.map(([, , label]) => label);
+      expect(new Set(labels).size).toBe(Object.keys(DegreeOfSuccess).length / 2);
+    });
+  });
+
+  describe('custom marks', () => {
+    const HTML: DieMarks = {
+      dropped: (_die, text) => `<s>${text}</s>`,
+      success: (_die, text) => `<b>${text}</b>`,
+      failure: (_die, text) => `<i>${text}</i>`,
+      critical: (_die, text) => `<crit>${text}</crit>`,
+      fumble: (_die, text) => `<fumble>${text}</fumble>`,
+      droppedGroup: (inner) => `<s>${inner}</s>`,
+    };
+
+    test('marks a dropped die', () => {
+      const result = roll('4d6kh3', { rng: createMockRng([3, 4, 2, 5]) });
+      expect(renderBreakdown(result, HTML)).toBe('4d6[3, 4, <s>2</s>, 5] = 12');
+    });
+
+    test('marks success and failure dice', () => {
+      const result = roll('4d6>=5f1', { rng: createMockRng([1, 4, 6, 2]) });
+      // The nat 1 and nat 6 also trip the default crit rules, which compose
+      // inside the tally marks rather than replacing them.
+      expect(renderBreakdown(result, HTML)).toBe(
+        '4d6>=5f1[<i><fumble>1</fumble></i>, 4, <b><crit>6</crit></b>, 2] = 0',
+      );
+    });
+
+    test('marks a critical die', () => {
+      const result = roll('2d6', { rng: createMockRng([6, 3]) });
+      expect(renderBreakdown(result, HTML)).toBe('2d6[<crit>6</crit>, 3] = 9');
+    });
+
+    test('a die that is both critical and fumble gets both, crit innermost', () => {
+      const result = roll('1d6cs>0cf<7', { rng: createMockRng([4]) });
+      const die = result.rolls[0];
+
+      expect(die?.critical).toBe(true);
+      expect(die?.fumble).toBe(true);
+      expect(renderBreakdown(result, HTML)).toBe(
+        '1d6cs>0cf<7[<fumble><crit>4</crit></fumble>] = 4',
+      );
+    });
+
+    test('a dropped critical die nests the state mark outermost', () => {
+      const result = roll('2d6kh1', { rng: createMockRng([6, 2]) });
+      expect(renderBreakdown(result, HTML)).toBe('2d6[<crit>6</crit>, <s>2</s>] = 6');
+    });
+
+    test('wraps a group-dropped sub-roll and leaves its dice unmarked', () => {
+      const result = roll('{2d6, 1d10}kh1', { rng: createMockRng([3, 4, 9]) });
+      expect(renderBreakdown(result, HTML)).toBe('{<s>2d6[3, 4]</s>, 1d10[9]} = 9');
+    });
+
+    test('crit and fumble survive inside a dropped sub-roll', () => {
+      const result = roll('{2d6, 1d10}kh1', { rng: createMockRng([1, 6, 9]) });
+      expect(renderBreakdown(result, HTML)).toBe(
+        '{<s>2d6[<fumble>1</fumble>, <crit>6</crit>]</s>, 1d10[9]} = 9',
+      );
+    });
+
+    test('marks the DC side of a versus roll', () => {
+      const result = roll('1d20 vs 2d10kh1', { rng: createMockRng([12, 4, 9]) });
+      expect(renderBreakdown(result, HTML)).toBe('1d20[12] vs 2d10[<s>4</s>, 9] = Success');
+    });
+
+    test('omitted slots render plain', () => {
+      const result = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });
+      expect(renderBreakdown(result, {})).toBe('4d6[3, 6, 2, 5] = 14');
+    });
+
+    test('MARKDOWN_MARKS spreads to override one slot', () => {
+      const result = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });
+      const marks: DieMarks = { ...MARKDOWN_MARKS, critical: (_die, text) => `!${text}!` };
+
+      expect(renderBreakdown(result, marks)).toBe('4d6[3, !6!, ~~2~~, 5] = 14');
+    });
+  });
+});

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,392 @@
+/**
+ * Breakdown rendering with consumer-supplied markers.
+ *
+ * `RollResult.rendered` bakes one markdown dialect into a string. This module
+ * rebuilds the same breakdown from `RollResult.parts`, letting the caller
+ * decide how each die is marked — HTML spans, ANSI codes, Telegram
+ * MarkdownV2, or nothing at all. Import it from `roll-parser/render`.
+ *
+ * @module render
+ */
+
+import type {
+  DieResult,
+  KeepDropSpec,
+  ResolvedComparePoint,
+  ResolvedCritThreshold,
+  RollPart,
+  RollResult,
+} from './types.js';
+import { DegreeOfSuccess } from './types.js';
+
+/**
+ * Per-die markers. Every slot is optional; an omitted slot leaves the die's
+ * text untouched, so `{}` renders a breakdown with no markup whatsoever.
+ *
+ * `text` arrives as the die's value already wrapped by any inner mark, and
+ * composition order is fixed: `critical` then `fumble` innermost, then
+ * exactly one of `dropped`, `success`, or `failure` outermost — matching the
+ * priority `RollResult.rendered` uses, where a dropped die is never also
+ * shown as a success.
+ *
+ * @example A die that is both critical and dropped
+ * ```typescript
+ * { critical: (_die, text) => `<b>${text}</b>`, dropped: (_die, text) => `<s>${text}</s>` }
+ * // renders <s><b>20</b></s>
+ * ```
+ *
+ * @category Rendering
+ */
+export type DieMarks = {
+  /** Excluded from the total by `kh`/`kl`/`dh`/`dl`, a reroll, or group selection. */
+  dropped?: (die: DieResult, text: string) => string;
+  /** Met a success-count threshold. */
+  success?: (die: DieResult, text: string) => string;
+  /** Met a failure threshold. */
+  failure?: (die: DieResult, text: string) => string;
+  /** `DieResult.critical` — the default rule or an explicit `cs` threshold. */
+  critical?: (die: DieResult, text: string) => string;
+  /** `DieResult.fumble` — the default rule or an explicit `cf` threshold. */
+  fumble?: (die: DieResult, text: string) => string;
+  /**
+   * Wraps a whole sub-roll dropped by group selection (`{1d8, 1d10}kh1`).
+   *
+   * Inside it, `dropped`, `success`, and `failure` are suppressed — the
+   * wrapper already carries the verdict, and marking a dropped die inside a
+   * dropped sub-roll says nothing extra. `critical` and `fumble` still apply:
+   * they describe the face, not the selection. A nested `droppedGroup` also
+   * survives, so `{{1d6, 1d8}kh1, 1d10}kh1` can wrap twice.
+   */
+  droppedGroup?: (inner: string) => string;
+};
+
+/**
+ * The marks `RollResult.rendered` itself uses. Applied when
+ * {@link renderBreakdown} is called without a `marks` argument; spread it to
+ * override one slot while keeping the rest markdown.
+ *
+ * @category Rendering
+ */
+export const MARKDOWN_MARKS: DieMarks = {
+  dropped: (_die, text) => `~~${text}~~`,
+  success: (_die, text) => `**${text}**`,
+  failure: (_die, text) => `__${text}__`,
+  droppedGroup: (inner) => `~~${inner}~~`,
+};
+
+const KEEP_DROP_CODES = {
+  keep: { highest: 'kh', lowest: 'kl' },
+  drop: { highest: 'dh', lowest: 'dl' },
+} as const;
+
+const EXPLODE_MARKERS = {
+  standard: '!',
+  compound: '!!',
+  penetrating: '!p',
+} as const;
+
+const DEGREE_LABELS: Record<DegreeOfSuccess, string> = {
+  [DegreeOfSuccess.CriticalFailure]: 'Critical Failure',
+  [DegreeOfSuccess.Failure]: 'Failure',
+  [DegreeOfSuccess.Success]: 'Success',
+  [DegreeOfSuccess.CriticalSuccess]: 'Critical Success',
+};
+
+/** Bare identifier grammar; anything else was written `@{like this}`. */
+const BARE_VARIABLE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function comparePointCode(point: ResolvedComparePoint): string {
+  return `${point.operator}${point.value}`;
+}
+
+function critCode(prefix: 'cs' | 'cf', threshold: ResolvedCritThreshold): string {
+  return threshold === 'default' ? prefix : `${prefix}${comparePointCode(threshold)}`;
+}
+
+function keepDropCode(spec: KeepDropSpec): string {
+  return `${KEEP_DROP_CODES[spec.kind][spec.selector]}${spec.count}`;
+}
+
+/** `'='` is elided because bare `fN` parses back to it — `f3`, `f<3`, `f>=3`. */
+function failCode(point: ResolvedComparePoint): string {
+  return point.operator === '=' ? `f${point.value}` : `f${comparePointCode(point)}`;
+}
+
+/**
+ * Rebuilds the normalized expression a part contributes to
+ * `RollResult.expression` — the prefix every dice bracket hangs off.
+ *
+ * Meta-expressions are already resolved to numbers here, so `4d6kh(1d2)`
+ * comes back as `4d6kh1`, exactly as the evaluator spells it.
+ */
+function expr(part: RollPart): string {
+  switch (part.type) {
+    case 'literal':
+      return String(part.value);
+    case 'variable':
+      return String(part.value);
+    case 'dice':
+      return `${part.count}d${part.sides}`;
+    case 'fateDice':
+      return `${part.count}dF`;
+    case 'grouped':
+      return `(${expr(part.inner)})`;
+    case 'binaryOp':
+      return `${expr(part.left)} ${part.operator} ${expr(part.right)}`;
+    case 'unaryOp':
+      return `-${expr(part.operand)}`;
+    case 'group':
+      return `{${part.parts.map(expr).join(', ')}}`;
+    case 'functionCall':
+      return `${part.name}(${part.args.map(expr).join(', ')})`;
+    case 'keepDrop':
+      return `${expr(part.target)}${part.specs.map(keepDropCode).join('')}`;
+    case 'explode':
+      return `${expr(part.target)}${explodeCode(part)}`;
+    case 'reroll':
+      return `${expr(part.target)}${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`;
+    case 'dieBound':
+      return `${expr(part.target)}${dieBoundCode(part)}`;
+    case 'sort':
+      return `${expr(part.target)}${part.order === 'ascending' ? 's' : 'sd'}`;
+    case 'critThreshold':
+      return `${expr(part.target)}${critThresholdCode(part)}`;
+    case 'successCount':
+      return `${expr(part.target)}${successCountCode(part)}`;
+    case 'versus':
+      return `${expr(part.roll)} vs ${expr(part.dc)}`;
+  }
+}
+
+function explodeCode(part: Extract<RollPart, { type: 'explode' }>): string {
+  const marker = EXPLODE_MARKERS[part.variant];
+  return part.threshold == null ? marker : `${marker}${comparePointCode(part.threshold)}`;
+}
+
+/** Negative bounds are parenthesized so the expression re-parses. */
+function dieBoundCode(part: Extract<RollPart, { type: 'dieBound' }>): string {
+  return part.value < 0 ? `${part.bound}(${part.value})` : `${part.bound}${part.value}`;
+}
+
+function critThresholdCode(part: Extract<RollPart, { type: 'critThreshold' }>): string {
+  return [
+    ...part.successThresholds.map((threshold) => critCode('cs', threshold)),
+    ...part.failThresholds.map((threshold) => critCode('cf', threshold)),
+  ].join('');
+}
+
+function successCountCode(part: Extract<RollPart, { type: 'successCount' }>): string {
+  const fail = part.failThreshold == null ? '' : failCode(part.failThreshold);
+  return `${comparePointCode(part.threshold)}${fail}`;
+}
+
+/**
+ * Collects the dice a part's subtree produced, in evaluation order.
+ *
+ * `sort`, `explode`, `reroll`, and `successCount` carry their own pool and
+ * stop the descent: a sorted pool is reordered, and an exploded or rerolled
+ * one holds dice that exist nowhere under `target`.
+ */
+function collectDice(part: RollPart, out: DieResult[]): void {
+  switch (part.type) {
+    case 'dice':
+    case 'fateDice':
+    case 'sort':
+    case 'explode':
+    case 'reroll':
+    case 'successCount':
+      for (const die of part.rolls) out.push(die);
+      return;
+    case 'grouped':
+      collectDice(part.inner, out);
+      return;
+    case 'unaryOp':
+      collectDice(part.operand, out);
+      return;
+    case 'binaryOp':
+      collectDice(part.left, out);
+      collectDice(part.right, out);
+      return;
+    case 'keepDrop':
+    case 'dieBound':
+    case 'critThreshold':
+      collectDice(part.target, out);
+      return;
+    case 'group':
+      for (const sub of part.parts) collectDice(sub, out);
+      return;
+    case 'functionCall':
+      for (const arg of part.args) collectDice(arg, out);
+      return;
+    case 'versus':
+      collectDice(part.roll, out);
+      collectDice(part.dc, out);
+      return;
+    case 'literal':
+    case 'variable':
+      return;
+  }
+}
+
+function poolOf(part: RollPart): DieResult[] {
+  const dice: DieResult[] = [];
+  collectDice(part, dice);
+  return dice;
+}
+
+/**
+ * Marks one die. `plain` suppresses the three state marks for dice inside a
+ * dropped sub-roll, where the group wrapper already carries the verdict —
+ * crit and fumble survive, since they describe the face, not the selection.
+ */
+function markDie(die: DieResult, marks: DieMarks, plain: boolean): string {
+  let text = String(die.result);
+
+  if (die.critical) text = marks.critical?.(die, text) ?? text;
+  if (die.fumble) text = marks.fumble?.(die, text) ?? text;
+  if (plain) return text;
+
+  const { modifiers } = die;
+  if (modifiers.includes('dropped')) return marks.dropped?.(die, text) ?? text;
+  if (modifiers.includes('success')) return marks.success?.(die, text) ?? text;
+  if (modifiers.includes('failure')) return marks.failure?.(die, text) ?? text;
+
+  return text;
+}
+
+/** `'meta'` dice were rolled to resolve a parameter — they are never shown. */
+function renderPool(dice: readonly DieResult[], marks: DieMarks, plain: boolean): string {
+  const shown: string[] = [];
+
+  for (const die of dice) {
+    if (die.modifiers.includes('meta')) continue;
+    shown.push(markDie(die, marks, plain));
+  }
+
+  return `[${shown.join(', ')}]`;
+}
+
+/**
+ * A modifier renders as `<target expression><code><pool>`, replacing whatever
+ * bracket the target would have shown on its own. An empty pool means the
+ * target rolled nothing at all, and the bracket is dropped with it.
+ */
+function renderModifier(
+  target: RollPart,
+  code: string,
+  dice: readonly DieResult[],
+  marks: DieMarks,
+  plain: boolean,
+): string {
+  const pool = dice.length === 0 ? '' : renderPool(dice, marks, plain);
+  return `${expr(target)}${code}${pool}`;
+}
+
+function renderPart(part: RollPart, marks: DieMarks, plain: boolean): string {
+  switch (part.type) {
+    case 'literal':
+      return String(part.value);
+    case 'variable': {
+      const display = BARE_VARIABLE.test(part.name) ? `@${part.name}` : `@{${part.name}}`;
+      return `${display}[${part.value}]`;
+    }
+    case 'dice':
+    case 'fateDice':
+      return `${expr(part)}${renderPool(part.rolls, marks, plain)}`;
+    case 'grouped':
+      return `(${renderPart(part.inner, marks, plain)})`;
+    case 'binaryOp':
+      return `${renderPart(part.left, marks, plain)} ${part.operator} ${renderPart(part.right, marks, plain)}`;
+    case 'unaryOp':
+      return `-${renderPart(part.operand, marks, plain)}`;
+    case 'functionCall': {
+      const args = part.args.map((arg) => renderPart(arg, marks, plain)).join(', ');
+      return `${part.name}(${args})`;
+    }
+    case 'versus':
+      return `${renderPart(part.roll, marks, plain)} vs ${renderPart(part.dc, marks, plain)}`;
+    case 'group':
+      return renderGroup(part, marks, plain);
+    case 'keepDrop':
+      // Sub-roll selection renders through the group, which strikes whole
+      // sub-rolls; only the flat-pool form collapses into one bracket.
+      return part.target.type === 'group' && part.target.keptIndices != null
+        ? renderPart(part.target, marks, plain)
+        : `${expr(part.target)}${renderPool(poolOf(part.target), marks, plain)}`;
+    case 'explode':
+      return renderModifier(part.target, explodeCode(part), part.rolls, marks, plain);
+    case 'reroll':
+      return renderModifier(
+        part.target,
+        `${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`,
+        part.rolls,
+        marks,
+        plain,
+      );
+    case 'successCount':
+      return renderModifier(part.target, successCountCode(part), part.rolls, marks, plain);
+    case 'dieBound':
+      return `${expr(part.target)}${dieBoundCode(part)}${renderPool(poolOf(part.target), marks, plain)}`;
+    case 'sort':
+      return `${expr(part.target)}${part.order === 'ascending' ? 's' : 'sd'}${renderPool(part.rolls, marks, plain)}`;
+    case 'critThreshold':
+      return `${expr(part.target)}${critThresholdCode(part)}${renderPool(poolOf(part.target), marks, plain)}`;
+  }
+}
+
+function renderGroup(
+  part: Extract<RollPart, { type: 'group' }>,
+  marks: DieMarks,
+  plain: boolean,
+): string {
+  const { keptIndices } = part;
+  const subRolls = part.parts.map((sub, index) => {
+    if (keptIndices == null || keptIndices.includes(index)) {
+      return renderPart(sub, marks, plain);
+    }
+    const inner = renderPart(sub, marks, true);
+    return marks.droppedGroup?.(inner) ?? inner;
+  });
+
+  return `{${subRolls.join(', ')}}`;
+}
+
+/**
+ * Rebuilds a roll's breakdown from `RollResult.parts`, applying `marks` to
+ * every die.
+ *
+ * With no `marks` the output is byte-identical to `RollResult.rendered` — a
+ * property test pins that over generated notation. Pass any object to take
+ * over: omitted slots render plain, so `{}` strips markup entirely and
+ * `{ ...MARKDOWN_MARKS, critical: … }` keeps the rest of the markdown.
+ *
+ * The trailing `= <total>` is included, and becomes the degree label for a
+ * `vs` roll, exactly as `rendered` does.
+ *
+ * @param result - A finished result from `roll` or `evaluate`
+ * @param marks - Per-die markers; defaults to {@link MARKDOWN_MARKS}
+ * @returns The rendered breakdown
+ *
+ * @example
+ * ```typescript
+ * import { roll } from 'roll-parser';
+ * import { renderBreakdown } from 'roll-parser/render';
+ * import { createMockRng } from 'roll-parser/testing';
+ *
+ * const result = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });
+ *
+ * renderBreakdown(result); // '4d6[3, 6, ~~2~~, 5] = 14'
+ * renderBreakdown(result, {}); // '4d6[3, 6, 2, 5] = 14'
+ * renderBreakdown(result, {
+ *   dropped: (_die, text) => `<s>${text}</s>`,
+ *   critical: (_die, text) => `<b>${text}</b>`,
+ * }); // '4d6[3, <b>6</b>, <s>2</s>, 5] = 14'
+ * ```
+ *
+ * @category Rendering
+ */
+export function renderBreakdown(result: RollResult, marks: DieMarks = MARKDOWN_MARKS): string {
+  const trailing = result.degree == null ? String(result.total) : DEGREE_LABELS[result.degree];
+
+  return `${renderPart(result.parts, marks, false)} = ${trailing}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,10 +73,14 @@ export type ResolvedCritThreshold = ResolvedComparePoint | 'default';
  *
  * `'meta'` is the one tag with no counterpart in the notation. Dice counts,
  * sides, modifier counts and computed thresholds may themselves be dice
- * (`(1d4)d6`, `4d6kh(1d2)`, `1d6!>(1d2+3)`). Those inner dice are not part of
- * any pool, so they never appear in a {@link RollPart}; they are appended to
- * `RollResult.rolls` tagged `'meta'` so an audit log can still show what the
- * meta-expression rolled. Filter them out when summing or displaying a pool.
+ * (`(1d4)d6`, `4d6kh(1d2)`, `1d6!>(1d2+3)`). Those inner dice belong to no
+ * pool: they never appear on a `dice` or `fateDice` part, and they are
+ * appended to `RollResult.rolls` tagged `'meta'` so an audit log can still
+ * show what the meta-expression rolled.
+ *
+ * The four whole-pool views — `sort`, `explode`, `reroll`, and `successCount`
+ * `rolls` — are snapshots of an evaluation context rather than of a pool, so
+ * they do carry meta dice. Filter them out when summing or displaying a pool.
  *
  * `'dc'` marks the DC side of a `vs` comparison. Unlike `'meta'` these dice do
  * render — `1d20[3] vs 2d10[5, 6]` shows both sides — but they are not part of
@@ -312,12 +316,30 @@ export type RollPart =
       type: 'explode';
       variant: 'standard' | 'compound' | 'penetrating';
       threshold?: ResolvedComparePoint;
+      /**
+       * The expanded pool. Standard and penetrating explosions append dice
+       * that exist nowhere under `target`, so this is the only view of the
+       * pool the modifier actually produced. Compound explosions accumulate
+       * in place, making it the same dice as `target` carries.
+       *
+       * Like `RollResult.rolls` — and unlike the pool under `target` — this
+       * keeps `'meta'` dice. Filter them out before counting or displaying.
+       */
+      rolls: DieResult[];
       target: RollPart;
     })
   | (RollPartBase & {
       type: 'reroll';
       once: boolean;
       condition: ResolvedComparePoint;
+      /**
+       * The post-reroll pool: discarded intermediates (`'rerolled'` +
+       * `'dropped'`) alongside their replacements. Both are appended rather
+       * than substituted, so neither appears under `target`.
+       *
+       * Keeps `'meta'` dice, as `RollResult.rolls` does.
+       */
+      rolls: DieResult[];
       target: RollPart;
     })
   | (RollPartBase & { type: 'dieBound'; bound: 'min' | 'max'; value: number; target: RollPart })
@@ -325,6 +347,11 @@ export type RollPart =
       type: 'successCount';
       threshold: ResolvedComparePoint;
       failThreshold?: ResolvedComparePoint;
+      /**
+       * The tallied pool, sharing `DieResult` references with `target`.
+       * Keeps `'meta'` dice, as `RollResult.rolls` does.
+       */
+      rolls: DieResult[];
       target: RollPart;
       successes: number;
       failures: number;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/index.ts", "src/testing.ts"],
+  "entryPoints": ["src/index.ts", "src/render.ts", "src/testing.ts"],
   "tsconfig": "tsconfig.json",
   "out": "site/dist/docs",
   "name": "roll-parser",
@@ -13,7 +13,7 @@
     "inherited": true
   },
   "categorizeByGroup": false,
-  "categoryOrder": ["Core", "Results", "AST", "Errors", "RNG", "Limits", "Testing", "*"],
+  "categoryOrder": ["Core", "Results", "Rendering", "AST", "Errors", "RNG", "Limits", "Testing", "*"],
   "defaultCategory": "Other",
   "navigation": {
     "includeCategories": true,


### PR DESCRIPTION
Adds `roll-parser/render`, a subpath export holding `renderBreakdown(result, marks?)`, `DieMarks`, and `MARKDOWN_MARKS`. It rebuilds the breakdown from `RollResult.parts` with markers the caller picks, so consumers targeting anything other than Discord markdown stop regex-parsing `rendered`. With no marks the output is byte-identical to `result.rendered`.

`dist/render.js` gets its own 2 kB `size-limit` line. That is a budget for a new artifact, not a raise of an existing one — `index.js` and `{ roll }` keep their limits.

Adds `rolls` to the `explode`, `reroll`, and `successCount` members of `RollPart`, mirroring what `sort` already carried. The issue assumed `parts` already held everything a renderer needs; it does not. Standard and penetrating explosions and both reroll forms append dice that appear nowhere under `target`:

```
roll('2d6!')   // rendered "2d6![6, 2, 3]"       parts.target.rolls = [6, 3]
roll('2d6r<3') // rendered "2d6r<3[~~1~~, 4, 5]" parts.target.rolls = [1, 5]
```

Reading `parts` is unaffected; constructing one of those three parts, deep-comparing them, or snapshotting `--json` is. Shipping as a minor is a deliberate call — see the CHANGELOG entry, which names the `TS2322` a constructor will hit and the `--json` payload growth.

Migrates `src/cli/format.ts` onto `renderBreakdown` and deletes its three marker regexes. That fixes a dropped group sub-roll nested inside another one rendering as `({)1d10[1](, 1d12[3])}` — the old `~~([^~]+)~~` pattern stopped at the first inner `~~`, which `stripInnerMarkers` leaves behind because it only unwraps markers around bare numbers.

Adds a fast-check notation grammar and the anti-drift property asserting `renderBreakdown(result) === result.rendered`. The grammar emits each modifier alone as well as chained — only the outermost modifier of a chain renders its own pool, so a generator that always stacks slots leaves the explode and reroll pools untested — and emits group keep/drop, the only notation producing a group part with `keptIndices`.

Extends the node, browser, Deno, and Workers smoke fixtures and the ts-compat consumer to import the new subpath, and adds it to the TypeDoc entry points.

Closes #292