### PR TITLE
docs: add 3.0.0 to 3.1.0 migration notes #292

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `roll-parser/render`, a subpath export holding `renderBreakdown(result, marks?)`, `DieMarks`, and `MARKDOWN_MARKS`. It rebuilds the `RollResult.rendered` breakdown from `RollResult.parts` with markers the caller chooses, so consumers targeting anything other than Discord markdown no longer regex-parse the baked string. Six slots — `dropped`, `success`, `failure`, `critical`, `fumble`, and `droppedGroup` — compose in a fixed order; `critical`/`fumble` read the `DieResult` booleans, which `rendered` has no marker for. With no `marks` the output is byte-identical to `rendered`, pinned by a property test. Budgeted separately at 2 kB, leaving the `index.js` and `{ roll }` budgets to the library ([#292](https://github.com/edloidas/roll-parser/issues/292))
 
+- `MIGRATION.md` gains a 3.0.0 → 3.1.0 section covering the `RollPart` field, the three ways it can surface, and the new render subpath; the file is now ordered newest-first and `README.md` points at it for every upgrade path rather than only for 2.x ([#292](https://github.com/edloidas/roll-parser/issues/292))
+
 ### Changed
 
 - The `explode`, `reroll`, and `successCount` members of `RollPart` now carry `rolls: DieResult[]`, the pool the modifier produced — mirroring what `sort` already did. Standard and penetrating explosions and both reroll forms append dice that appear nowhere under `target`, so the part tree could not previously describe its own output ([#292](https://github.com/edloidas/roll-parser/issues/292))

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,76 @@
-# Migrating from v2 to v3
+# Migration notes
+
+Newest first. [Upgrading from 3.0.0 to 3.1.0](#upgrading-from-300-to-310) ·
+[Migrating from v2 to v3](#migrating-from-v2-to-v3) ·
+[Upgrading from a v3 pre-release](#upgrading-from-a-v3-pre-release)
+
+## Upgrading from 3.0.0 to 3.1.0
+
+Nothing was removed and no behaviour changed: `total`, `expression`, `rendered`,
+`rolls`, and `degree` are byte-identical to 3.0.0 for every expression. The
+whole of this section is about one added field.
+
+**`RollPart` gained `rolls` on three variants.** The `explode`, `reroll`, and
+`successCount` members now carry `rolls: DieResult[]` — the pool the modifier
+produced — joining `sort`, which always had it. They needed it: standard and
+penetrating explosions and both reroll forms *append* dice, and those dice
+appeared nowhere in the part tree, so a part could not describe its own output.
+
+<!-- readme-test: skip -->
+```typescript
+// 3.0.0 — the explosion die is missing from the tree
+roll('2d6!').parts.target.rolls.length; // 2, but `rendered` shows three dice
+
+// 3.1.0 — the modifier carries the pool it actually rendered
+roll('2d6!').parts.rolls.length; // 3
+```
+
+Per the [versioning policy](README.md#versioning), adding a field to a returned
+object is a minor. Reading `parts` is unaffected and needs no change. Three
+things can still bite:
+
+- **Constructing one of those parts stops compiling** — `TS2322: Property
+  'rolls' is missing in type … but required`. This is only reachable in test
+  fixtures and mocks, since no library function accepts a `RollPart`. Add the
+  pool, or widen the annotation.
+- **Deep-equality assertions against those parts fail.** Add `rolls` to the
+  expected object, or assert on the fields you care about instead of the whole
+  part.
+- **`--json` and `JSON.stringify(result)` payloads grow** for expressions using
+  explode, reroll, or success counting, because the pool is serialized on the
+  modifier as well as on its target — roughly +40% to +96% depending on pool
+  size. Expressions without those modifiers are unchanged. Budget for it if you
+  log, cache, or ship results over a wire.
+
+**The CLI renders nested dropped sub-rolls correctly.** `--verbose` on a dropped
+group sub-roll nested inside another one used to emit mismatched delimiters —
+`{{(1d6[1]), 1d8[4]}, ({)1d10[1](, 1d12[3]})}`. It now emits
+`{{(1d6[1]), 1d8[4]}, ({(1d10[1]), 1d12[3]})}`. Anything parsing that output
+should be reading `--json` instead.
+
+**New, optional: `roll-parser/render`.** A subpath export whose
+`renderBreakdown(result, marks?)` rebuilds the breakdown from `result.parts`
+with markers you choose, so you no longer have to regex the markdown out of
+`rendered`. With no marks its output is byte-identical to `rendered`, which
+makes it a drop-in starting point:
+
+```typescript
+import { roll } from 'roll-parser';
+import { renderBreakdown } from 'roll-parser/render';
+import { createMockRng } from 'roll-parser/testing';
+
+const result = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });
+
+renderBreakdown(result) === result.rendered; // true
+renderBreakdown(result, { dropped: (_die, text) => `(${text})` });
+// '4d6[3, 6, (2), 5] = 14'
+```
+
+See [Custom markers](README.md#custom-markers) for the six slots and the order
+they compose in. Nothing forces you to adopt it — `rendered` is unchanged and
+is not deprecated.
+
+## Migrating from v2 to v3
 
 v3 is a full rewrite. Nothing in the 2.x API carries over — the entry points,
 the result shape, the error behaviour, and parts of the notation all changed. To

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 - [Performance](#performance)
 - [Known limitations](#known-limitations)
 - [Versioning](#versioning)
-- [Upgrading from 2.x](#upgrading-from-2x)
+- [Upgrading](#upgrading)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -143,10 +143,11 @@ as one request:
 `https://esm.sh/roll-parser` works the same way. Raw file URLs
 (`unpkg.com/roll-parser`) also work but fetch each module separately.
 
-### Upgrading from 2.x
+### Upgrading
 
-v3 is a complete rewrite and the API is not compatible — see
-[MIGRATION.md](MIGRATION.md). To stay on the old line, pin `roll-parser@2.3.2`.
+[MIGRATION.md](MIGRATION.md) covers every upgrade path, newest first — 3.0.0 to
+3.1.0, v2 to v3, and the v3 pre-releases. v3 is a complete rewrite and the 2.x
+API is not compatible; to stay on the old line, pin `roll-parser@2.3.2`.
 
 ## Notation reference
 
@@ -353,9 +354,22 @@ describe(roll('4d6kh3 + 2', { rng: createMockRng([3, 6, 2, 5]) }).parts);
 
 Invariants worth relying on: `result.parts.total === result.total`,
 `successCount.total === successes - failures`, and every part's `rolls[]`
-sharing references with `result.rolls`. A `sort` part's `rolls[]` is its
-target's pool in sorted order — chained sorts (`4d6s sd`) nest, and the
-outermost one holds the order `rendered` shows.
+sharing references with `result.rolls`.
+
+Four variants carry a `rolls[]` of their own, holding the pool the modifier
+produced rather than the one its target rolled — read those instead of
+descending into `target` when you want what was rendered:
+
+- `sort` — the target's pool in sorted order. Chained sorts (`4d6s sd`) nest,
+  and the outermost one holds the order `rendered` shows.
+- `explode` — the expanded pool. Standard and penetrating explosions append
+  dice that exist nowhere under `target`.
+- `reroll` — discarded intermediates and their replacements, both appended
+  rather than substituted.
+- `successCount` — the tallied pool.
+
+Unlike the pool on a `dice` part, those four keep `'meta'` dice, so filter them
+before counting or displaying.
 
 Meta-expressions do **not** appear as nested parts. `(1d4)d6`, `4d6kh(1d2)`, and
 `1d6!>(1d2+3)` surface only their resolved numbers in the owning part; their


### PR DESCRIPTION
Adds a `3.0.0 → 3.1.0` section to `MIGRATION.md` for the `RollPart.rolls` field that shipped in #292, covering the three ways it can surface — constructing one of those parts, deep-equality assertions, and `--json` payload growth — plus the CLI nested-group fix and the new `roll-parser/render` subpath.

Reorders `MIGRATION.md` newest-first with an index, since it now covers three upgrade paths. Broadens the README pointer from "Upgrading from 2.x" to "Upgrading".

Also corrects the parts-tree invariants in the README, which still named `sort` as the only variant carrying its own pool.

Prep for the 3.1.0 release; no source changes.

Closes #292

<sub>[Claude Code session](https://claude.ai/code)</sub>