### PR TITLE
fix: chained cs/cf normalizes to an expression that does not re-parse #299

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,11 @@ any commit that regresses a case past 1.75x. Bundle size is gated in CI by
   values,** so it does not round-trip through `parse` when they are present:
   `roll('(1d4)d6').expression` is `'4d6'` when the `1d4` rolled 4, and
   `roll('1d6!>(1d2+3)').expression` is `'1d6!>5'`.
+- **Adjacent bare modifiers keep a space.** `cs`, `cf`, `s`, and `sd` without a
+  threshold or count end an identifier the lexer would extend into whatever
+  follows, so `expression` and `rendered` separate them the way the input had
+  to: `roll('1d20cs cf').expression` is `'1d20cs cf'`, and `4d6 s kh2` comes
+  back as `'4d6s kh2'`. Everything else stays flush — `4d6cs>4cf<2`.
 - **Sort flattens additive pools.** `(2d6+1d8)s` renders as one combined sorted
   list, `(2d6 + 1d8)s[2, 3, 6] = 11`, rather than `2d6[2, 6] + 1d8[3]`. Totals
   are unaffected; only the breakdown loses pool boundaries.

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -4089,25 +4089,27 @@ describe('evaluate', () => {
       expect(result.rendered).toBe('0d6cs>3[] = 0');
     });
 
-    test('renders expression with default-sentinel codes', () => {
+    test('keeps the space between default-sentinel codes (#299)', () => {
       // `cscf` would lex as one unknown identifier — whitespace is what separates
-      // the two bare modifiers.
+      // the two bare modifiers, in the emitted form as much as in the input.
       const ast = parse('1d20cs cf');
       const rng = createMockRng([10]);
       const result = evaluate(ast, rng);
 
-      expect(result.expression).toBe('1d20cscf');
-      expect(result.rendered).toBe('1d20cscf[10] = 10');
+      expect(result.expression).toBe('1d20cs cf');
+      expect(result.rendered).toBe('1d20cs cf[10] = 10');
+      expect(evaluate(parse(result.expression), createMockRng([10])).expression).toBe('1d20cs cf');
     });
 
     test('renders expression with mixed defaults and compare points', () => {
       // Rendered order is all success thresholds first, then all fail thresholds —
-      // input `cs` + `cf<3` + `cs=10` comes back as `cscs=10cf<3`.
+      // input `cs` + `cf<3` + `cs=10` comes back as `cs cs=10cf<3`; only the bare
+      // `cs` needs the separator.
       const ast = parse('1d20cs cf<3cs=10');
       const rng = createMockRng([10]);
       const result = evaluate(ast, rng);
 
-      expect(result.expression).toBe('1d20cscs=10cf<3');
+      expect(result.expression).toBe('1d20cs cs=10cf<3');
     });
 
     test('computed threshold via parens evaluates correctly', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -5,6 +5,7 @@
  */
 
 import { describeValue, EvaluatorError, RollParserError, stampEvaluatorSpan } from '../errors.js';
+import { joinModifierCode } from '../notation.js';
 import type {
   ASTNode,
   BinaryOpNode,
@@ -1067,11 +1068,11 @@ function evalExplode(node: ExplodeNode, rng: RNG, ctx: EvalContext, env: EvalEnv
 function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv): EvalResult {
   const targetCtx = createContext();
   const target = evalNode(node.target, rng, targetCtx, env);
-  const targetExpr = targetCtx.expressionParts.join('');
 
   const thresholdValue = evalMetaOperand(node.condition.value, rng, ctx, env);
 
   const code = `${node.once ? 'ro' : 'r'}${node.condition.operator}${thresholdValue}`;
+  const modifierExpr = joinModifierCode(targetCtx.expressionParts.join(''), code);
   const condition: ResolvedComparePoint = {
     operator: node.condition.operator,
     value: thresholdValue,
@@ -1079,8 +1080,8 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
 
   // No-op when the target produced no dice (e.g., `(1+2)r<5`).
   if (targetCtx.rolls.length === 0) {
-    ctx.expressionParts.push(`${targetExpr}${code}`);
-    ctx.renderedParts.push(`${targetExpr}${code}`);
+    ctx.expressionParts.push(modifierExpr);
+    ctx.renderedParts.push(modifierExpr);
     const total = sumKeptDice(targetCtx.rolls, env.hasVersusDc);
     return {
       total,
@@ -1101,8 +1102,8 @@ function evalReroll(node: RerollNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
     : applyRecursiveReroll(targetCtx.rolls, node.condition.operator, thresholdValue, rng, env);
 
   appendAll(ctx.rolls, pool);
-  ctx.expressionParts.push(`${targetExpr}${code}`);
-  ctx.renderedParts.push(`${targetExpr}${code}${renderDice(pool)}`);
+  ctx.expressionParts.push(modifierExpr);
+  ctx.renderedParts.push(`${modifierExpr}${renderDice(pool)}`);
 
   const total = sumKeptDice(pool, env.hasVersusDc);
   return {
@@ -1145,13 +1146,13 @@ function evalDieBound(node: DieBoundNode, rng: RNG, ctx: EvalContext, env: EvalE
   // ! would have been resolved against a total this node just replaced.
   // ! See the rule on `propagateMetadata`.
 
-  const targetExpr = targetCtx.expressionParts.join('');
   // Negative bounds render parenthesized so `result.expression` re-parses
   // (`4d6min-2` is a syntax error; `4d6min(-2)` is not).
   const code = boundValue < 0 ? `${node.bound}(${boundValue})` : `${node.bound}${boundValue}`;
+  const modifierExpr = joinModifierCode(targetCtx.expressionParts.join(''), code);
 
-  ctx.expressionParts.push(`${targetExpr}${code}`);
-  ctx.renderedParts.push(`${targetExpr}${code}${renderDice(targetCtx.rolls)}`);
+  ctx.expressionParts.push(modifierExpr);
+  ctx.renderedParts.push(`${modifierExpr}${renderDice(targetCtx.rolls)}`);
 
   const total = sumKeptDice(targetCtx.rolls, env.hasVersusDc);
   return {
@@ -1193,10 +1194,10 @@ function evalSort(node: SortNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eva
   propagateMetadata(ctx, targetCtx.versusMetadata);
 
   const code = node.order === 'ascending' ? 's' : 'sd';
-  const targetExpr = targetCtx.expressionParts.join('');
+  const modifierExpr = joinModifierCode(targetCtx.expressionParts.join(''), code);
 
-  ctx.expressionParts.push(`${targetExpr}${code}`);
-  ctx.renderedParts.push(`${targetExpr}${code}${renderDice(sortedRolls)}`);
+  ctx.expressionParts.push(modifierExpr);
+  ctx.renderedParts.push(`${modifierExpr}${renderDice(sortedRolls)}`);
 
   return {
     total: target.total,
@@ -1254,14 +1255,13 @@ function evalCritThreshold(
   appendAll(ctx.rolls, targetCtx.rolls);
   propagateMetadata(ctx, targetCtx.versusMetadata);
 
-  const targetExpr = targetCtx.expressionParts.join('');
-  const codes = [
+  const modifierExpr = [
     ...successResolved.map((t) => (t === 'default' ? 'cs' : `cs${t.operator}${t.value}`)),
     ...failResolved.map((t) => (t === 'default' ? 'cf' : `cf${t.operator}${t.value}`)),
-  ].join('');
+  ].reduce(joinModifierCode, targetCtx.expressionParts.join(''));
 
-  ctx.expressionParts.push(`${targetExpr}${codes}`);
-  ctx.renderedParts.push(`${targetExpr}${codes}${renderDice(targetCtx.rolls)}`);
+  ctx.expressionParts.push(modifierExpr);
+  ctx.renderedParts.push(`${modifierExpr}${renderDice(targetCtx.rolls)}`);
 
   return {
     total: target.total,
@@ -1321,7 +1321,7 @@ function evalKeepDrop(node: KeepDropNode, rng: RNG, ctx: EvalContext, env: EvalE
   const targetExpr = targetCtx.expressionParts.join('');
   const keepDropCodes = specs.map((s) => `${s.code}${s.count}`).join('');
 
-  ctx.expressionParts.push(`${targetExpr}${keepDropCodes}`);
+  ctx.expressionParts.push(joinModifierCode(targetExpr, keepDropCodes));
   ctx.renderedParts.push(`${targetExpr}${renderDice(mergedDice)}`);
 
   return {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -871,4 +871,41 @@ describe('roll() integration', () => {
       expect(() => roll('{1d6, 2d8}cs>5', { rng: createMockRng([]) })).toThrow(ParseError);
     });
   });
+
+  describe('re-parseable normalized expressions (#299)', () => {
+    // Bare `cs`, `cf`, `s`, and `sd` end an identifier the lexer would extend
+    // into the next code, so the emitted form keeps the separator.
+    const separated: [notation: string, expression: string][] = [
+      ['1d20cs cf', '1d20cs cf'],
+      ['4d6 s kh2', '4d6s kh2'],
+      ['4d6 s dh1', '4d6s dh1'],
+      ['4d6 sd kh2', '4d6sd kh2'],
+      ['4d6 s s', '4d6s s'],
+      ['4d6 cs cf s', '4d6cs cf s'],
+      ['4dF s kh2', '4dFs kh2'],
+      ['4d6 s min2', '4d6s min2'],
+      ['4d6 s r<2', '4d6s r<2'],
+    ];
+
+    for (const [notation, expression] of separated) {
+      test(`separates the modifiers ${notation} normalizes to`, () => {
+        const result = roll(notation, { seed: 'reparse' });
+
+        expect(result.expression).toBe(expression);
+        expect(roll(result.expression, { seed: 'reparse' }).expression).toBe(expression);
+      });
+    }
+
+    // `dF` and `!p` end in letters but are scanned as their own tokens, so
+    // gluing the next code to them still re-parses.
+    const glued = ['4dFcs>2', '4d6!pkh2', '4d6kh2s', '4d6cs>4cf<2'];
+
+    for (const notation of glued) {
+      test(`leaves ${notation} unseparated`, () => {
+        const result = roll(notation, { seed: 'reparse' });
+
+        expect(result.expression).toBe(notation);
+      });
+    }
+  });
 });

--- a/src/notation.test.ts
+++ b/src/notation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { joinModifierCode } from './notation.js';
+
+describe('joinModifierCode', () => {
+  test.each([
+    ['1d20cs', 'cf', '1d20cs cf'],
+    ['4d6s', 'kh2', '4d6s kh2'],
+    ['4d6sd', 'kh2', '4d6sd kh2'],
+    ['4d6cf', 'sd', '4d6cf sd'],
+    ['4dFs', 'dh1', '4dFs dh1'],
+  ])('separates %s from %s', (expression, code, expected) => {
+    expect(joinModifierCode(expression, code)).toBe(expected);
+  });
+
+  test.each([
+    // A threshold ends the code with a digit, so nothing can merge into it.
+    ['1d20cs>4', 'cf<2', '1d20cs>4cf<2'],
+    ['4d6kh2', 's', '4d6kh2s'],
+    // `dF` and `!p` end in letters but lex as their own tokens.
+    ['4dF', 'cs', '4dFcs'],
+    ['4d6!p', 'kh2', '4d6!pkh2'],
+    // Codes that open with a symbol are unambiguous wherever they land.
+    ['4d6s', '>=4', '4d6s>=4'],
+    ['4d6cs', '!', '4d6cs!'],
+  ])('leaves %s and %s joined', (expression, code, expected) => {
+    expect(joinModifierCode(expression, code)).toBe(expected);
+  });
+});
+
+describe('folding a code list', () => {
+  test('separates only where needed', () => {
+    expect(['cs', 'cs=10', 'cf<3'].reduce(joinModifierCode, '')).toBe('cs cs=10cf<3');
+  });
+
+  test('yields an empty string for no codes', () => {
+    expect([].reduce(joinModifierCode, '')).toBe('');
+  });
+});

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -1,0 +1,24 @@
+/**
+ * Notation serialization shared by the two breakdown builders — the
+ * evaluator's `expression`/`rendered` strings and `render.ts`.
+ *
+ * @module notation
+ */
+
+// ! `cs`, `cf`, `s`, and `sd` are the only codes ending in a letter the lexer
+// ! scans as an identifier — maximal munch then swallows what follows, so
+// ! `cs` + `cf` re-lexes as `cscf`. `4dF` and `!p` are their own tokens.
+const BARE_MODIFIER_END = /(?:cs|cf|sd|s)$/;
+
+const STARTS_WITH_LETTER = /^[A-Za-z]/;
+
+/**
+ * Appends a modifier code to the expression built so far, separating the two
+ * with a space when concatenating them would re-lex as a single identifier.
+ * The space is the same separator the input used to make them parse.
+ */
+export function joinModifierCode(expression: string, code: string): string {
+  return BARE_MODIFIER_END.test(expression) && STARTS_WITH_LETTER.test(code)
+    ? `${expression} ${code}`
+    : `${expression}${code}`;
+}

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -21,6 +21,7 @@
 import { describe, expect, test } from 'bun:test';
 import fc from 'fast-check';
 import { isRollParserError } from './errors.js';
+import { parse } from './parser/parser.js';
 import { renderBreakdown } from './render.js';
 import { roll } from './roll.js';
 import type { RollResult } from './types.js';
@@ -299,8 +300,8 @@ describe('property-based invariants', () => {
     /**
      * Joins modifiers with spaces. Several adjacent pairs are otherwise
      * unlexable — `sd` followed by `kl1` reads as one identifier — and the
-     * evaluator drops the spaces when rebuilding the expression, so the
-     * rendered form is the same either way.
+     * evaluator keeps a space exactly where one is needed, so the emitted
+     * form differs from the input only in the redundant separators.
      */
     function chainModifiers(pool: string, modifiers: string[]): string {
       return [pool, ...modifiers.filter((modifier) => modifier !== '')].join(' ');
@@ -421,6 +422,37 @@ describe('property-based invariants', () => {
 
       // Without this the property would still pass if the grammar drifted
       // into emitting notation nothing can evaluate.
+      expect(evaluated).toBeGreaterThan(NUM_RUNS / 2);
+    });
+
+    /**
+     * Reuses the breakdown grammar above — it is the one generator that covers
+     * every modifier adjacency the serializer can emit.
+     */
+    test('result.expression parses (#299)', () => {
+      const NUM_RUNS = 1000;
+      let evaluated = 0;
+
+      fc.assert(
+        fc.property(notationArb, seedArb, (notation, seed) => {
+          const options = { seed, context: { str: 3, 'my stat': 4 }, maxDice: 200 };
+
+          let result: RollResult;
+          try {
+            result = roll(notation, options);
+          } catch (error) {
+            return isRollParserError(error);
+          }
+
+          evaluated += 1;
+          // Meta-expressions are substituted with their resolved values, so
+          // only re-parseability holds — not an identical total.
+          parse(result.expression);
+          return true;
+        }),
+        { numRuns: NUM_RUNS },
+      );
+
       expect(evaluated).toBeGreaterThan(NUM_RUNS / 2);
     });
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -9,6 +9,7 @@
  * @module render
  */
 
+import { joinModifierCode } from './notation.js';
 import type {
   DieResult,
   KeepDropSpec,
@@ -140,17 +141,20 @@ function expr(part: RollPart): string {
     case 'functionCall':
       return `${part.name}(${part.args.map(expr).join(', ')})`;
     case 'keepDrop':
-      return `${expr(part.target)}${part.specs.map(keepDropCode).join('')}`;
+      return joinModifierCode(expr(part.target), part.specs.map(keepDropCode).join(''));
     case 'explode':
       return `${expr(part.target)}${explodeCode(part)}`;
     case 'reroll':
-      return `${expr(part.target)}${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`;
+      return joinModifierCode(
+        expr(part.target),
+        `${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`,
+      );
     case 'dieBound':
-      return `${expr(part.target)}${dieBoundCode(part)}`;
+      return joinModifierCode(expr(part.target), dieBoundCode(part));
     case 'sort':
-      return `${expr(part.target)}${part.order === 'ascending' ? 's' : 'sd'}`;
+      return joinModifierCode(expr(part.target), part.order === 'ascending' ? 's' : 'sd');
     case 'critThreshold':
-      return `${expr(part.target)}${critThresholdCode(part)}`;
+      return joinModifierCode(expr(part.target), critThresholdCode(part));
     case 'successCount':
       return `${expr(part.target)}${successCountCode(part)}`;
     case 'versus':
@@ -172,7 +176,7 @@ function critThresholdCode(part: Extract<RollPart, { type: 'critThreshold' }>): 
   return [
     ...part.successThresholds.map((threshold) => critCode('cs', threshold)),
     ...part.failThresholds.map((threshold) => critCode('cf', threshold)),
-  ].join('');
+  ].reduce(joinModifierCode, '');
 }
 
 function successCountCode(part: Extract<RollPart, { type: 'successCount' }>): string {
@@ -279,7 +283,7 @@ function renderModifier(
   plain: boolean,
 ): string {
   const pool = dice.length === 0 ? '' : renderPool(dice, marks, plain);
-  return `${expr(target)}${code}${pool}`;
+  return `${joinModifierCode(expr(target), code)}${pool}`;
 }
 
 function renderPart(part: RollPart, marks: DieMarks, plain: boolean): string {
@@ -326,11 +330,11 @@ function renderPart(part: RollPart, marks: DieMarks, plain: boolean): string {
     case 'successCount':
       return renderModifier(part.target, successCountCode(part), part.rolls, marks, plain);
     case 'dieBound':
-      return `${expr(part.target)}${dieBoundCode(part)}${renderPool(poolOf(part.target), marks, plain)}`;
+      return `${joinModifierCode(expr(part.target), dieBoundCode(part))}${renderPool(poolOf(part.target), marks, plain)}`;
     case 'sort':
-      return `${expr(part.target)}${part.order === 'ascending' ? 's' : 'sd'}${renderPool(part.rolls, marks, plain)}`;
+      return `${joinModifierCode(expr(part.target), part.order === 'ascending' ? 's' : 'sd')}${renderPool(part.rolls, marks, plain)}`;
     case 'critThreshold':
-      return `${expr(part.target)}${critThresholdCode(part)}${renderPool(poolOf(part.target), marks, plain)}`;
+      return `${joinModifierCode(expr(part.target), critThresholdCode(part))}${renderPool(poolOf(part.target), marks, plain)}`;
   }
 }
 


### PR DESCRIPTION
Added `joinModifierCode`, shared by the evaluator and `render.ts`, and routed every modifier append site through it.

Adjacent modifier codes in `expression` and `rendered` are now separated by a space whenever concatenating them would re-lex as one identifier. `cs`, `cf`, `s`, and `sd` are the only codes ending in a letter the lexer scans as an identifier, so maximal munch swallowed whatever followed — `4d6 s kh2` normalized to `4d6skh2` for the same reason `1d20cs cf` normalized to `1d20cscf`. `4dF` and `!p` end in letters but are their own tokens, so they stay flush.

Pinned with unit, integration, and property coverage; the property parses `result.expression` over the breakdown grammar, the one generator that reaches every adjacency.

Closes #299
