### PR TITLE
fix: penetrating explosion overwrites result without setting initialResult #300

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,13 @@ specs applied independently to the same pool, with the dropped sets unioned —
 the Roll20 rule.
 
 `cs` / `cf` covers the whole pool, including dice that `!`, `!p`, `r`, and `ro`
-add after it — `1d6cs<2!` and `1d6!cs<2` flag the same dice. Two cases stay
-order-sensitive. Modifiers that rewrite a die's value rather than add one (`!!`,
-`minN`, `maxN`) are judged on whatever that value is when the threshold runs:
-with `[6, 6, 3]`, `1d6cs>10!!` reports no critical while `1d6!!cs>10` reports
-one, judging the compounded 15. And because `!p`'s added dice store one less
-than they rolled, the side you *don't* override moves with position —
-`1d6cf>5!p` keeps the critical that plain `1d6!p` gives the added 6, where
-`1d6!pcf>5` does not.
+add after it — `1d6cs<2!` and `1d6!cs<2` flag the same dice. One case stays
+order-sensitive: an explicit threshold reads a die's current value, so
+modifiers that rewrite it rather than add a die (`!!`, `minN`, `maxN`) are
+judged on whatever that value is when the threshold runs. With `[6, 6, 3]`,
+`1d6cs>10!!` reports no critical while `1d6!!cs>10` reports one, judging the
+compounded 15. The side you *don't* override always reads the natural face, so
+`1d6cf>5!p` and `1d6!pcf>5` agree with plain `1d6!p` on the added 6.
 
 ### Pools and checks
 

--- a/src/evaluator/env.ts
+++ b/src/evaluator/env.ts
@@ -68,6 +68,20 @@ export type EvalEnv = {
    */
   critRules: WeakMap<DieResult, CritRule> | undefined;
   /**
+   * Dice minted as explosion continuations by `!` / `!p`, keyed on the
+   * `DieResult` object itself. Read by `extractNatural`, which counts them out
+   * of the versus primaries — the `'exploded'` tag cannot say it alone, since
+   * a compound explode stamps it on the original die it accumulated into.
+   *
+   * Out of band for the same reason as {@link EvalEnv.critRules}: `DieResult`
+   * is public and serialized.
+   *
+   * ! Only populated while {@link EvalEnv.insideVersus} — nothing outside a
+   * ! `vs` reads it, and the `add` per appended die is not free. Any new
+   * ! reader must be on a versus path too.
+   */
+  explosionDice: WeakSet<DieResult> | undefined;
+  /**
    * User-supplied variable map for `@name` / `@{name}` references. Always
    * defined — `evaluate()` defaults to an empty object so lookups can be
    * branch-free on presence.

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1253,6 +1253,30 @@ describe('evaluate', () => {
         expect(getDie(result.rolls, 1).result).toBe(5);
         expect(getDie(result.rolls, 2).result).toBe(1);
       });
+
+      test('appended dice keep their raw face in initialResult (#300)', () => {
+        const result = evaluate(parse('1d20!p'), createMockRng([20, 20, 5]));
+
+        expect(result.rolls.map((d) => d.result)).toEqual([20, 19, 4]);
+        expect(result.rolls.map((d) => d.initialResult)).toEqual([undefined, 20, 5]);
+        expect(result.rolls.map((d) => d.initialResult ?? d.result)).toEqual([20, 20, 5]);
+        expect(result.rolls.map((d) => d.critical)).toEqual([true, true, false]);
+      });
+
+      test('a penetrating die that rolls 1 records it (#300)', () => {
+        const result = evaluate(parse('1d6!p'), createMockRng([6, 1]));
+
+        const die = getDie(result.rolls, 1);
+        expect(die.result).toBe(0);
+        expect(die.initialResult).toBe(1);
+        expect(die.fumble).toBe(true);
+      });
+
+      test('standard explode leaves initialResult unset (#300)', () => {
+        const result = evaluate(parse('1d6!'), createMockRng([6, 3]));
+
+        expect(result.rolls.map((d) => d.initialResult)).toEqual([undefined, undefined]);
+      });
     });
 
     describe('thresholds', () => {
@@ -2712,6 +2736,26 @@ describe('evaluate', () => {
       expect(result.total).toBe(24);
       expect(result.natural).toBe(20);
       expect(result.degree).toBe(DegreeOfSuccess.Failure);
+    });
+
+    test('Penetrating continuations carrying initialResult stay non-primary (#300)', () => {
+      // Both appended dice record a raw face, and must still not count as
+      // primaries alongside the original d20.
+      const result = evaluate(parse('1d20!p vs 35'), createMockRng([20, 20, 5]));
+
+      expect(result.total).toBe(43);
+      expect(result.natural).toBe(20);
+      expect(result.degree).toBe(DegreeOfSuccess.CriticalSuccess);
+    });
+
+    test('A clamped continuation die is still not a primary (#300)', () => {
+      // `min5` lifts the appended 2 and records its raw face — which must not
+      // make a continuation die a second primary and suppress the nat-20 step.
+      const result = evaluate(parse('1d20!min5 vs 30'), createMockRng([20, 2, 12]));
+
+      expect(result.rendered).toBe('1d20!min5[20, 5] vs 30 = Success');
+      expect(result.natural).toBe(20);
+      expect(result.degree).toBe(DegreeOfSuccess.Success);
     });
 
     test('Exploded pool plus separate d20 stays ambiguous: 1d20!+1d20 vs 50 → natural undefined', () => {
@@ -4334,6 +4378,16 @@ describe('evaluate', () => {
       // stored value on both sides of the chain.
       expect(before.rendered).toBe('1d6cs<2!p[6, 5, 2] = 13');
       expect(before.rolls.map((d) => d.critical)).toEqual(after.rolls.map((d) => d.critical));
+    });
+
+    test('cf is order-independent across penetrating explode (#300)', () => {
+      // The crit side keeps the `'default'` rule, which reads the raw face on
+      // both sides of the chain.
+      const before = evaluate(parse('1d6cf>5!p'), createMockRng([6, 6, 3]));
+      const after = evaluate(parse('1d6!pcf>5'), createMockRng([6, 6, 3]));
+
+      expect(before.rolls.map((d) => d.critical)).toEqual(after.rolls.map((d) => d.critical));
+      expect(after.rolls.map((d) => d.critical)).toEqual([true, true, false]);
     });
 
     test('cf before explode governs the appended dice (#289)', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1581,22 +1581,18 @@ function evalSuccessCount(
  * `undefined`.
  *
  * Excludes dropped (`kh`/`kl`/`dh`/`dl`/`r`/`ro`) dice — these aren't the
- * final kept result. Explosion continuation dice (appended by standard/
- * penetrating explode, tagged `'exploded'` with no `initialResult`) are not
- * primaries either — `1d20! vs DC` keeps the natural from the original d20.
- * Compound explode accumulates into the original die and sets
- * `initialResult`, so it stays a primary and the raw first face is used.
- * Multiple primary kept d20s (e.g., `1d20+1d20`) yield `undefined` so no
- * ambiguous upgrade/downgrade is applied.
+ * final kept result — and the continuation dice `env.explosionDice` marks, so
+ * `1d20! vs DC` keeps the natural from the original d20. A compound explode
+ * accumulates into that original instead of appending, so it stays a primary
+ * and its raw first face is used. Multiple primary kept d20s (e.g.,
+ * `1d20+1d20`) yield `undefined` so no ambiguous upgrade/downgrade is applied.
  */
-function extractNatural(rolls: DieResult[]): number | undefined {
+function extractNatural(rolls: DieResult[], env: EvalEnv): number | undefined {
   // Rerolled intermediates are always stamped `['rerolled', 'dropped']`
   // (see `modifiers/reroll.ts`), so filtering by `'dropped'` covers them.
+  const appended = env.explosionDice;
   const primaries = rolls.filter(
-    (d) =>
-      d.sides === 20 &&
-      !d.modifiers.includes('dropped') &&
-      !(d.modifiers.includes('exploded') && d.initialResult == null),
+    (d) => d.sides === 20 && !d.modifiers.includes('dropped') && !appended?.has(d),
   );
   if (primaries.length !== 1) return undefined;
   const die = primaries[0];
@@ -1642,7 +1638,7 @@ function evalVersus(node: VersusNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
   try {
     const rollCtx = createContext();
     const rollResult = evalNode(node.roll, rng, rollCtx, env);
-    const natural = extractNatural(rollCtx.rolls);
+    const natural = extractNatural(rollCtx.rolls, env);
 
     const dcCtx = createContext();
     const dcResult = evalNode(node.dc, rng, dcCtx, env);
@@ -1754,6 +1750,7 @@ export function evaluate(ast: ASTNode, rng: RNG, options: EvaluateOptions = {}):
     insideVersus: false,
     hasVersusDc: false,
     critRules: undefined,
+    explosionDice: undefined,
     context,
     onMissingVariable,
   };

--- a/src/evaluator/modifiers/crit-threshold.ts
+++ b/src/evaluator/modifiers/crit-threshold.ts
@@ -11,13 +11,13 @@
  *
  * The two threshold kinds deliberately read different values. `'default'`
  * reads `initialResult ?? result`, the same source as the versus `natural`,
- * so "rolled the maximum face" survives the two modifiers that overwrite
- * `result` while recording the face they replaced — compound explode and
- * `minN`/`maxN`. An explicit threshold (`cs>4`, `cf<=2`) reads the die's
- * current `result`: it is a predicate over the die's value, and postfix
- * modifiers are order-sensitive by design, so `4d6min5cs>4` is meant to
- * see the clamped faces. The two can therefore disagree on one die —
- * `4d6min5cs>4` flags a clamped natural 1 as both critical and fumble.
+ * so "rolled the maximum face" survives every modifier that overwrites
+ * `result` while recording the face it replaced — compound explode,
+ * penetrating explode, and `minN`/`maxN`. An explicit threshold (`cs>4`,
+ * `cf<=2`) reads the die's current `result`: it is a predicate over the die's
+ * value, and postfix modifiers are order-sensitive by design, so `4d6min5cs>4`
+ * is meant to see the clamped faces. The two can therefore disagree on one
+ * die — `4d6min5cs>4` flags a clamped natural 1 as both critical and fumble.
  *
  * They also diverge on Fate dice. `'default'` carries a `sides > 1` guard, so
  * it never fires on a `sides = 0` pool; an explicit threshold has none and
@@ -25,15 +25,6 @@
  * flags. The missing guard is deliberate — the parser rejects the bare
  * `cs`/`cf` forms instead, since they would resolve to `'default'` and
  * silently do nothing.
- *
- * ! Penetrating explode is not covered: it stores `raw - 1` in `result`
- * ! without recording `initialResult`, so `1d6!pcs` still judges a natural
- * ! 6 by its decremented 5. An *inherited* rule is handed the raw roll
- * ! instead, which keeps `1d6cf>5!p` agreeing with `1d6!p` on the side the
- * ! user never overrode — at the cost of `1d6cf>5!p` and `1d6!pcf>5`
- * ! disagreeing on it. Recording `initialResult` here would settle both, but
- * ! `extractNatural` reads that field to tell an appended explosion die from
- * ! a compounded one, and would start counting these as versus primaries.
  *
  * The rule is recorded per die on `env.critRules`, so dice that explode and
  * reroll mint *after* the crit node has run inherit it from the die they
@@ -102,26 +93,18 @@ function applyCritRule(die: DieResult, rule: CritRule, natural: number): void {
  * reroll inherits it in turn. No-op when no `cs`/`cf` governs `parent`, which
  * leaves the `createDieResult` default rule in place.
  *
- * `natural` is the face the `'default'` sentinel reads, defaulting to the
- * child's own. Penetrating explode passes its raw roll — see the module note.
- *
- * ! Call this only once the child's final `result` is stored — an explicit
- * ! threshold is a predicate over `result`, so a penetrating die is judged by
- * ! its decremented value, matching `1d6!pcs<2`.
+ * ! Call this only once the child's final `result` and `initialResult` are
+ * ! stored — an explicit threshold is a predicate over `result`, so a
+ * ! penetrating die is judged by its decremented value, matching `1d6!pcs<2`.
  */
-export function inheritCritRule(
-  env: EvalEnv,
-  parent: DieResult,
-  child: DieResult,
-  natural = child.initialResult ?? child.result,
-): void {
+export function inheritCritRule(env: EvalEnv, parent: DieResult, child: DieResult): void {
   const rules = env.critRules;
   if (rules === undefined) return;
 
   const rule = rules.get(parent);
   if (rule === undefined) return;
 
-  applyCritRule(child, rule, natural);
+  applyCritRule(child, rule, child.initialResult ?? child.result);
   rules.set(child, rule);
 }
 

--- a/src/evaluator/modifiers/explode.ts
+++ b/src/evaluator/modifiers/explode.ts
@@ -98,11 +98,14 @@ function canExplode(die: DieResult, hasVersusDc: boolean): boolean {
  * the value recorded on the appended die, which is the only thing standard
  * and penetrating explosions disagree about.
  *
+ * A die whose stored value differs from its raw roll records the raw face in
+ * `initialResult`, so `initialResult ?? result` recovers what was rolled.
+ *
  * `critical`/`fumble` are likewise derived from the raw roll — a penetrating
  * die that rolled its max face is still a crit even though it stores one less.
- * An inherited `cs`/`cf` keeps that: it is applied after `storeResult`, so an
- * explicit threshold reads the stored value, while the raw roll is handed over
- * for the `'default'` sentinel to read.
+ * A `cs`/`cf` rule keeps that: it is applied after `storeResult`, so an
+ * explicit threshold reads the stored value while the `'default'` sentinel
+ * reads `initialResult`.
  */
 function applyAppendingExplode(
   pool: DieResult[],
@@ -128,7 +131,13 @@ function applyAppendingExplode(
       const raw = rollExplosion(sides, rng, env);
       const die = createDieResult(sides, raw, ['exploded', 'kept']);
       die.result = storeResult(raw);
-      inheritCritRule(env, original, die, raw);
+      if (die.result !== raw) die.initialResult = raw;
+      // Only `extractNatural` reads this, and only inside a `vs`.
+      if (env.insideVersus) {
+        env.explosionDice ??= new WeakSet();
+        env.explosionDice.add(die);
+      }
+      inheritCritRule(env, original, die);
       result.push(die);
       lastRaw = raw;
       iterations += 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,8 +165,9 @@ export type DieResult = {
   /** The rolled value */
   result: number;
   /**
-   * Raw first roll before any mutation (e.g., compound-explode accumulation).
-   * Only populated when `result` has been overwritten with a computed value.
+   * Raw first roll before any mutation — compound-explode accumulation, the
+   * `!p` decrement, or a `minN`/`maxN` clamp. Only populated when `result` has
+   * been overwritten with a computed value.
    * Consumers that need the original face (nat-20 / nat-1 detection) should
    * read `initialResult ?? result`.
    */


### PR DESCRIPTION
Appended explosion dice now record their raw face in `initialResult` whenever the stored value differs from the roll, so `initialResult ?? result` recovers the natural face on a `!p` pool. Standard `!` is unaffected.

`extractNatural` no longer tells an appended continuation from a compounded original by `initialResult == null` — it reads a `WeakSet` on the eval env, populated inside a `vs` only. That also fixes a latent case: a clamped continuation (`1d20!min5 vs 30` on `[20, 2, 12]`) carried `initialResult` from the clamp and was counted as a second versus primary, suppressing the nat-20 step.

`inheritCritRule` loses its `natural` override parameter, which existed only to hand penetrating explode its raw roll. The `'default'` `cs`/`cf` sentinel now reads the natural face on both sides of a `!p` chain, so `1d6cf>5!p` and `1d6!pcf>5` agree; the README ordering paragraph is updated to match.

`result: 0` on a penetrating die that rolls a 1 is left as-is — the issue calls it a separate question.

Closes #300

<sub>[Claude Code session](https://claude.ai/code)</sub>
