### PR TITLE
fix: dice-less group success count no-ops and breaks its own invariant #304

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,8 +9,8 @@ Newest first. [Upgrading from 3.1.0 to 3.2.0](#upgrading-from-310-to-320) ·
 
 Nothing was removed and no type changed, and the seed → dice mapping is
 untouched — the same seed and notation roll the same faces they did in 3.1.0.
-The whole of this section is one fix to penetrating explode and the three
-places its output is visible.
+Two fixes: penetrating explode and the three places its output is visible, and
+a success-count target that never rolled anything.
 
 **`!p` continuation dice now carry `initialResult`.** A penetrating explosion
 stores `raw - 1` on each die it appends, and used to record the face it
@@ -74,6 +74,24 @@ result.degree === DegreeOfSuccess.Success; // true — was `Failure`
 This needs a `vs` whose roll side both appends explosion dice and clamps them.
 Without the clamp — `1d20! vs 30` — the continuation never looked like a
 primary, and those degrees are unchanged.
+
+**Success counting a dice-less group is now a parse error.** `{3, 5, 7}>=4`
+used to return the group's sum with `successes: 0`, so the
+`successCount.total === successes - failures` invariant the README offers read
+`15 === 0`. There are no dice to tally, and whether a group's units should be
+its subtotals is undecided, so the form is refused instead.
+
+```typescript
+import { roll } from 'roll-parser';
+
+roll('{3, 5, 7}>=4'); // throws 'INVALID_SUCCESS_COUNT_TARGET' — was 15
+roll('{3, 5, 7}kh1>=4'); // throws 'INVALID_SUCCESS_COUNT_TARGET' — was 7
+```
+
+Groups holding at least one pool are untouched — `{3, 1d6}>=4` counts the `1d6`
+exactly as it did. `0d6>=4` also still parses and totals 0; only targets that
+can never roll a die are rejected. One related total moved: a group whose pool
+turns out empty at run time, `{3, 0d6}>=4`, now totals 0 rather than 3.
 
 ## Upgrading from 3.0.0 to 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,12 @@ any commit that regresses a case past 1.75x. Bundle size is gated in CI by
   within each sub-roll, then sub-rolls by total — and the evaluator only
   flat-sorts, so the syntax is refused rather than shipped wrong. Single
   sub-roll groups (`{2d6+1d8}s`) still work as the flat-pool escape hatch.
+- **Success counting a group that rolls no dice is rejected.** `{3, 5, 7}>=4`
+  throws `INVALID_SUCCESS_COUNT_TARGET`. A success count tallies dice, and a
+  literal-only group has none — whether its units should be the subtotals is
+  undecided, so the syntax is refused rather than answered wrongly. Groups with
+  at least one pool (`{3, 1d6}>=4`) count as before, and a pool that is merely
+  empty at run time (`0d6>=4`) still totals 0.
 - **Division does not floor.** `7/2` totals `3.5`, not `3` — arithmetic is plain
   IEEE-754 throughout. Wrap it when you need an integer: `floor(7/2)` totals `3`.
 - **The power operator has no overflow guard.** `2**999` totals `5.357…e+300`.

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1840,6 +1840,14 @@ describe('evaluate', () => {
       expect(result.failures).toBe(0);
     });
 
+    test('a group whose pool rolls nothing scores 0, not its sum — {3, 0d6}>=4 (#304)', () => {
+      const result = evaluate(parse('{3, 0d6}>=4'), createMockRng([]));
+
+      expect(result.total).toBe(0);
+      expect(result.successes).toBe(0);
+      expect(result.failures).toBe(0);
+    });
+
     test('empty pool success is numeric — 0d10>=6 arithmetic does not NaN', () => {
       const ast = parse('0d10>=6');
       const rng = createMockRng([]);

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1543,13 +1543,15 @@ function evalSuccessCount(
     return part;
   };
 
-  // No-op when the target produced no dice (`0d6>=4`); `containsDicePool`
-  // should already reject dice-less targets at parse time. `target.total` is 0
-  // for an empty pool, so `total === successes - failures` still holds.
+  // An empty pool (`0d6>=4`, `{3, 0d6}>=4`) scores zero of both, so its total
+  // is 0 — never `target.total`, which for a group is the sum of its
+  // sub-rolls and would break `total === successes - failures`. Reachable only
+  // through a zero-count pool — a target holding no dice node at all is
+  // rejected at parse time.
   if (targetCtx.rolls.length === 0) {
     ctx.expressionParts.push(`${targetExpr}${code}`);
     ctx.renderedParts.push(`${targetExpr}${code}`);
-    return { total: target.total, part: buildPart(target.total, 0, 0) };
+    return { total: 0, part: buildPart(0, 0, 0) };
   }
 
   const result = countSuccesses(

--- a/src/parser/guards.ts
+++ b/src/parser/guards.ts
@@ -112,6 +112,9 @@ const isDicePoolHit = (current: ASTNode): boolean =>
 
 const isFateDiceHit = (current: ASTNode): boolean => current.type === 'FateDice';
 
+const isDiceHit = (current: ASTNode): boolean =>
+  current.type === 'Dice' || current.type === 'FateDice';
+
 const isMultiSubGroupHit = (current: ASTNode): boolean =>
   current.type === 'Group' && current.expressions.length >= 2;
 
@@ -166,6 +169,19 @@ export function containsDicePool(node: ASTNode): boolean {
  */
 export function deepContainsDicePool(node: ASTNode): boolean {
   return someDescendant(node, isDicePoolHit);
+}
+
+/**
+ * Deep-walks a node to find any descendant `Dice` or `FateDice`. Unlike
+ * `deepContainsDicePool`, a multi-sub-roll `Group` is not a hit in its own
+ * right — only real dice are.
+ *
+ * Used by the success-count parser guard, which tallies individual dice rather
+ * than subtotals: a literal-only group satisfies `containsDicePool` yet rolls
+ * nothing to tally.
+ */
+export function containsDice(node: ASTNode): boolean {
+  return someDescendant(node, isDiceHit);
 }
 
 /**

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1192,6 +1192,30 @@ describe('Parser', () => {
       expectRollError(() => parseAst('(1d6*2)>=10'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
     });
 
+    it('rejects a literal-only group target: {3, 5, 7}>=4 (#304)', () => {
+      expectRollError(() => parseAst('{3, 5, 7}>=4'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+    });
+
+    it('rejects a literal-only group with a fail threshold: {3, 5, 7}>=4f1 (#304)', () => {
+      expectRollError(() => parseAst('{3, 5, 7}>=4f1'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+    });
+
+    it('rejects a kept literal-only group: {3, 5, 7}kh1>=4 (#304)', () => {
+      expectRollError(
+        () => parseAst('{3, 5, 7}kh1>=4'),
+        ParseError,
+        'INVALID_SUCCESS_COUNT_TARGET',
+      );
+    });
+
+    it('rejects a single-expression literal group: {3}>=4 (#304)', () => {
+      expectRollError(() => parseAst('{3}>=4'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+    });
+
+    it('accepts a group with one real pool among literals: {3, 1d6}>=4 (#304)', () => {
+      expect(parseAst('{3, 1d6}>=4').type).toBe('SuccessCount');
+    });
+
     it('should reject versus inside success-count target: (1d20 vs 15)>=1', () => {
       expectRollError(
         () => parseAst('(1d20 vs 15)>=1'),

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -32,6 +32,7 @@ import type {
 } from './ast.js';
 import { isCritThreshold, isSuccessCount } from './ast.js';
 import {
+  containsDice,
   containsDicePool,
   containsFatePool,
   containsMultiSubGroup,
@@ -1087,7 +1088,12 @@ export class Parser {
     // Success counting reads a raw pool, so arithmetic or composition wrappers
     // (`1>=3`, `(1+2)>=3`, `(1d6*2)>=10`, `(1d20 vs 15)>=1`) would be silently
     // ignored.
-    if (!containsDicePool(target)) {
+    //
+    // ! Both checks are load-bearing. `containsDicePool` rejects those wrappers
+    // ! despite the dice; `containsDice` rejects a group holding none
+    // ! (`{3, 5, 7}>=4`), which the multi-sub-roll rule accepts — that rule is
+    // ! written for keep/drop, whose units are subtotals, not dice.
+    if (!containsDicePool(target) || !containsDice(target)) {
       throw new ParseError(
         `Success counting requires a dice pool target`,
         'INVALID_SUCCESS_COUNT_TARGET',


### PR DESCRIPTION
Added `containsDice`, a deep walk for a real `Dice`/`FateDice` descendant, and required it alongside `containsDicePool` on a success-count target, so a group that rolls nothing (`{3, 5, 7}>=4`, `{3, 5, 7}kh1>=4`) throws `INVALID_SUCCESS_COUNT_TARGET` instead of returning the group's sum.

Changed the evaluator's empty-pool early return to total 0 rather than `target.total`, which a group whose pool is empty only at run time (`{3, 0d6}>=4`) would otherwise report as a success count. Corrected the guard comment that asserted the opposite.

`{3, 1d6}>=4` and `0d6>=4` are unchanged. Documented in `README.md` and `MIGRATION.md`.

Closes #304
