### PR TITLE
fix: nested success counts append tags instead of reconciling them #297

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,8 +9,9 @@ Newest first. [Upgrading from 3.1.0 to 3.2.0](#upgrading-from-310-to-320) ·
 
 Nothing was removed and no type changed, and the seed → dice mapping is
 untouched — the same seed and notation roll the same faces they did in 3.1.0.
-Two fixes: penetrating explode and the three places its output is visible, and
-a success-count target that never rolled anything.
+Three fixes: penetrating explode and the three places its output is visible, a
+success-count target that never rolled anything, and a success count wrapped in
+another one.
 
 **`!p` continuation dice now carry `initialResult`.** A penetrating explosion
 stores `raw - 1` on each die it appends, and used to record the face it
@@ -92,6 +93,32 @@ Groups holding at least one pool are untouched — `{3, 1d6}>=4` counts the `1d6
 exactly as it did. `0d6>=4` also still parses and totals 0; only targets that
 can never roll a die are rejected. One related total moved: a group whose pool
 turns out empty at run time, `{3, 0d6}>=4`, now totals 0 rather than 3.
+
+**A second success count re-scores the pool instead of adding to it.** Group
+braces let one count wrap another (`{4d6>=5f1}<=2f6`), which the parse-time
+reject on a direct `4d6>=5>=1` never reached. The inner pass used to leave its
+tags behind, so a die could come back both `'success'` and `'failure'` and the
+top-level counts stopped describing the total. The outermost count now owns the
+tags outright.
+
+```typescript
+import { roll } from 'roll-parser';
+import { createMockRng } from 'roll-parser/testing';
+
+const result = roll('{4d6>=5f1}<=2f6', { rng: createMockRng([6, 5, 2, 1]) });
+
+result.total; // 1
+result.successes; // 2 — was 4
+result.failures; // 1 — was 0
+result.rendered; // '{4d6>=5f1}<=2f6[__6__, 5, **2**, **1**] = 1'
+```
+
+`total` never moved — it always came from the outermost count. What changed is
+`successes`, `failures`, `rolls[].modifiers`, and `rendered`, which now agree
+with it, so `successCount.total === successes - failures` holds again. A lone
+count is untouched, and so is a nested pair whose thresholds agree
+(`{4d6>=5}>=5`). Dropped dice come out untagged; only the DC side of a `vs`
+keeps tags from an inner count, since no pool pass may tally it.
 
 ## Upgrading from 3.0.0 to 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ compounded 15. The side you *don't* override always reads the natural face, so
 > directly, so `10d10>=6 + 2` is a parse error. Put the arithmetic inside the
 > threshold, `10d10>=(4+2)`, or wrap the count in group braces to operate on its
 > result: `{10d10>=6}+2`.
+>
+> Braces also let a second count re-score the same pool — `{4d6>=5}<=2f5`. The
+> outermost count wins outright: every die is judged against its thresholds
+> alone, so `successes`, `failures`, and the rendered markers agree with it, and
+> dice it does not count come out untagged. The one exception is the DC side of
+> a `vs`, which sits outside every pool pass and keeps whatever tagged it.
 
 > [!WARNING]
 > A bare `d` after a dice expression is rejected: `4d6d1` throws

--- a/src/evaluator/env.ts
+++ b/src/evaluator/env.ts
@@ -37,6 +37,10 @@ export type EvalEnv = {
    * Set to `true` by `evalSuccessCount`. Propagates through the shared env
    * so `evaluate()` can include `successes`/`failures` fields even when no
    * die was tagged (impossible threshold).
+   *
+   * ! Set *after* the target is evaluated, not before. `evalSuccessCount` reads
+   * ! the pre-set value to learn whether an inner count already tagged its pool
+   * ! — moving the assignment back to the top makes it read its own write.
    */
   hasSuccessCount: boolean;
   /**

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -1783,6 +1783,48 @@ describe('evaluate', () => {
       expect(getDie(result.rolls, 3).modifiers).toEqual(['kept', 'success']);
     });
 
+    test('the outer count re-scores the pool: {4d6>=5f1}<=2f6 (#297)', () => {
+      // Differing thresholds — the inner pass tags 6 and 5 as successes and 1 as
+      // a failure, the outer one scores every die the other way round.
+      const ast = parse('{4d6>=5f1}<=2f6');
+      const result = evaluate(ast, createMockRng([6, 5, 2, 1]));
+
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['kept', 'failure']);
+      expect(getDie(result.rolls, 1).modifiers).toEqual(['kept']);
+      expect(getDie(result.rolls, 2).modifiers).toEqual(['kept', 'success']);
+      expect(getDie(result.rolls, 3).modifiers).toEqual(['kept', 'success']);
+
+      expect(result.successes).toBe(2);
+      expect(result.failures).toBe(1);
+      expect(result.total).toBe(1);
+      expect(result.rendered).toBe('{4d6>=5f1}<=2f6[__6__, 5, **2**, **1**] = 1');
+    });
+
+    test('a re-scored die loses the inner success tag: {4d6>=5}<=2f5 (#297)', () => {
+      const ast = parse('{4d6>=5}<=2f5');
+      const result = evaluate(ast, createMockRng([5, 2, 3, 6]));
+
+      expect(getDie(result.rolls, 0).modifiers).toEqual(['kept', 'failure']);
+      expect(result.rendered).toContain('__5__');
+
+      expect(result.successes).toBe(1);
+      expect(result.failures).toBe(1);
+      expect(result.total).toBe(0);
+    });
+
+    test('no die carries both tally tags after a nested count (#297)', () => {
+      for (const notation of ['{4d6>=5f1}<=2f6', '{4d6>=5}<=2f5', '{4d6>=5f1}>=5f1']) {
+        const result = evaluate(parse(notation), createMockRng([6, 5, 2, 1]));
+
+        for (const die of result.rolls) {
+          expect(die.modifiers.includes('success') && die.modifiers.includes('failure')).toBe(
+            false,
+          );
+        }
+        expect(result.total).toBe((result.successes ?? 0) - (result.failures ?? 0));
+      }
+    });
+
     test('rendered output uses ** and __ markers', () => {
       const ast = parse('3d6>=5f1');
       const rng = createMockRng([1, 5, 3]);

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1505,13 +1505,17 @@ function evalSuccessCount(
   ctx: EvalContext,
   env: EvalEnv,
 ): EvalResult {
-  // Flag tracks syntactic presence of success-count notation, not pool size —
-  // set before any early return so empty pools still populate successes/failures.
-  env.hasSuccessCount = true;
-
   const targetCtx = createContext();
   const target = evalNode(node.target, rng, targetCtx, env);
   const targetExpr = targetCtx.expressionParts.join('');
+
+  // True once any count has run: an inner one that tagged this very pool (only
+  // a group can arrange that — `{4d6>=5}<=2f5`), or an unrelated earlier one,
+  // which costs a redundant strip over dice nothing tagged. The flag otherwise
+  // tracks syntactic presence of success-count notation, not pool size — set
+  // before any early return so empty pools still populate successes/failures.
+  const poolAlreadyCounted = env.hasSuccessCount;
+  env.hasSuccessCount = true;
 
   const thresholdValue = resolveThreshold(node.threshold.value, rng, ctx, env, 'threshold');
   const failValue =
@@ -1561,6 +1565,7 @@ function evalSuccessCount(
       ? { operator: node.failThreshold.operator, value: failValue }
       : undefined,
     env.hasVersusDc,
+    poolAlreadyCounted,
   );
 
   appendAll(ctx.rolls, targetCtx.rolls);

--- a/src/evaluator/modifiers/flags.ts
+++ b/src/evaluator/modifiers/flags.ts
@@ -33,15 +33,21 @@ export function isVersusDc(die: DieResult): boolean {
 export const SELECTION_FLAGS: readonly DieModifier[] = ['kept', 'dropped'];
 
 /**
+ * Success-count tally flags — rebuilt by every counting pass. A group lets a
+ * second count reach a pool the first one already tagged (`{4d6>=5}<=2f5`);
+ * stripping these first is what keeps the outermost count the only one the
+ * tags describe.
+ */
+export const TALLY_FLAGS: readonly DieModifier[] = ['success', 'failure'];
+
+/**
  * Selection flags plus the success-count tally flags. Stripped when a die
  * leaves the pool that tagged it (meta sub-expressions, dropped group
  * sub-rolls) so the top-level successes/failures scan cannot count it.
  */
 export const SELECTION_AND_TALLY_FLAGS: readonly DieModifier[] = [
-  'kept',
-  'dropped',
-  'success',
-  'failure',
+  ...SELECTION_FLAGS,
+  ...TALLY_FLAGS,
 ];
 
 /**
@@ -49,13 +55,7 @@ export const SELECTION_AND_TALLY_FLAGS: readonly DieModifier[] = [
  * into a parent. Meta operands nest (`((1d2)d4)d6`), so a die passes through
  * the merge once per level and the tag must be rebuilt, not appended.
  */
-export const META_MERGE_FLAGS: readonly DieModifier[] = [
-  'kept',
-  'dropped',
-  'success',
-  'failure',
-  'meta',
-];
+export const META_MERGE_FLAGS: readonly DieModifier[] = [...SELECTION_AND_TALLY_FLAGS, 'meta'];
 
 /** Selection flags plus `rerolled` — reassigned on every reroll pass. */
 export const REROLL_SLOT_FLAGS: readonly DieModifier[] = ['kept', 'dropped', 'rerolled'];

--- a/src/evaluator/modifiers/success-count.ts
+++ b/src/evaluator/modifiers/success-count.ts
@@ -10,17 +10,18 @@
  * excluded from counting and are never tagged.
  *
  * Mutates the input pool in place to add `'success'` / `'failure'` modifier
- * flags — mirrors the mutation pattern of explode and reroll modifiers. Each
- * tag is written at most once per die: a group counted after its members
- * (`{4d6>=5}>=1`) runs this pass twice over the same dice, and the parse-time
- * reject that blocks a direct `4d6>=5>=4` does not reach through a group.
+ * flags — mirrors the mutation pattern of explode and reroll modifiers. The
+ * tags are rebuilt, not appended: a group counted after its members
+ * (`{4d6>=5}<=2f5`) runs this pass twice over the same dice, and the outermost
+ * pass is the one whose arithmetic `RollResult.successes` / `failures` and the
+ * rendered markers report.
  *
  * @module evaluator/modifiers/success-count
  */
 
 import type { DieResult, ResolvedComparePoint } from '../../types.js';
 import { matchesCondition } from './compare.js';
-import { isVersusDc } from './flags.js';
+import { isVersusDc, stripFlags, TALLY_FLAGS } from './flags.js';
 
 export type SuccessCountResult = {
   total: number;
@@ -33,6 +34,7 @@ export function countSuccesses(
   threshold: ResolvedComparePoint,
   failThreshold: ResolvedComparePoint | undefined,
   hasVersusDc: boolean,
+  poolAlreadyCounted: boolean,
 ): SuccessCountResult {
   let successes = 0;
   let failures = 0;
@@ -45,15 +47,20 @@ export function countSuccesses(
   // ! `'success'` / `'failure'` tags written below still land on the pool.
   const pool = hasVersusDc ? dice.filter((die) => !isVersusDc(die)) : dice;
 
-  // ! The guards below only stop the *same* tag being written twice. A nested
-  // ! count with a different threshold still appends to the first pass's tags,
-  // ! so a die can end up both `'success'` and `'failure'`, and the returned
-  // ! counts then disagree with the tags in `rolls`.
+  // ! Dropped dice are stripped too, not just the ones re-tagged below. This
+  // ! pass skips them, so an inner count's tag would otherwise survive into the
+  // ! top-level successes/failures scan and break `total === successes - failures`.
+  if (poolAlreadyCounted) {
+    for (const die of pool) {
+      die.modifiers = stripFlags(die.modifiers, TALLY_FLAGS);
+    }
+  }
+
   for (const die of pool) {
     if (die.modifiers.includes('dropped')) continue;
 
     if (matchesCondition(die.result, threshold.operator, threshold.value)) {
-      if (!die.modifiers.includes('success')) die.modifiers.push('success');
+      die.modifiers.push('success');
       successes += 1;
       continue;
     }
@@ -62,7 +69,7 @@ export function countSuccesses(
       failThreshold != null &&
       matchesCondition(die.result, failThreshold.operator, failThreshold.value)
     ) {
-      if (!die.modifiers.includes('failure')) die.modifiers.push('failure');
+      die.modifiers.push('failure');
       failures += 1;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,7 +235,10 @@ export type RollPartBase = {
  * - `literal.total === value` and `variable.total === value`.
  * - Each part's `rolls[]` shares `DieResult` references with
  *   `RollResult.rolls[]`; both reflect post-evaluation state (explode
- *   accumulation, reroll flags, keep/drop flags). No deep clone.
+ *   accumulation, reroll flags, keep/drop flags, success/failure tags). No deep
+ *   clone. A part's own numbers record what that part computed, so an inner
+ *   `successCount` re-scored by an outer one (`{4d6>=5}<=2f5`) keeps its
+ *   tally while the dice it shares show the outer count's tags.
  *
  * Meta-expression sub-trees (`4d6kh(1d2)`, `(1+1)d6` counts/sides, computed
  * thresholds) are not surfaced as nested parts — their resolved numbers
@@ -450,6 +453,13 @@ export type RollResult = Readonly<{
    * arithmetic on top of a success count (e.g. `{5d6>=5}+2`) affects `total`
    * but not `successes`. Success counts are terminal, so the group braces are
    * required: `5d6>=5 * 2` is an `INVALID_SUCCESS_COUNT_TARGET` parse error.
+   *
+   * Braces also let a second count re-count the same pool (`{4d6>=5}<=2f5`).
+   * The outermost count owns the outcome: it re-scores the pool against its own
+   * thresholds, so no die is ever both a success and a failure, and dice it
+   * does not count come out untagged rather than keeping the inner count's
+   * tags. The one exception is the DC side of a `vs`, which sits outside every
+   * pool pass and so keeps whatever tagged it.
    */
   successes?: number;
   /**


### PR DESCRIPTION
`countSuccesses` now rebuilds the `'success'` / `'failure'` tags rather than appending them, so a second count reaching a pool through group braces (`{4d6>=5f1}<=2f6`) re-scores it outright. No die carries both tags, `RollResult.failures` counts every die tagged `'failure'`, `rendered` stops marking a die a success the outermost count scored a failure, and `successCount.total === successes - failures` holds again.

The strip is gated on `env.hasSuccessCount`, read before this pass sets it, so the single-count hot path is unchanged — a per-die branch in that loop measured ~9% on `10d10>=6f1` under #281. Dropped dice are stripped too: this pass skips them, so a stale tag would otherwise reach the top-level tally.

`total` is unchanged for every expression — it always came from the outermost count. `{ roll }` stays at 12.04 kB against the 12.25 kB budget.

Acceptance criterion 6 rested on a stale premise: `README.md` already sanctioned `{10d10>=6}+2`, and the cited `src/types.ts:411-414` anchors now point into a JSON example. There was no doc disagreement to settle, so the nested-count case is documented instead.

Closes #297
