### PR TITLE
fix: site equation chip drops explode and reroll dice #313

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -11,7 +11,12 @@ coverageSkipTestFiles = true
 # `readme.test.ts` imports the built package in-process (the self-reference),
 # which would otherwise pull every `dist/` file into the coverage report and
 # double-count the library against the thresholds below.
-coveragePathIgnorePatterns = ["dist/**"]
+#
+# `site/**` is the demo app, not shipped surface — the thresholds below are the
+# library's gate, and holding a demo page's SVG rendering to 100% functions
+# would price site tests out entirely. Site suites still run; they just do not
+# count toward the floor.
+coveragePathIgnorePatterns = ["dist/**", "site/**"]
 
 # Enforced only when coverage runs (`bun test --coverage`, `test:ci`) — plain
 # `bun test` stays fast. This is the only place the numbers live; CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "workspaces": ["scripts/browser-smoke", "scripts/docs"],
   "scripts": {
     "prepare": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || exit 0",
-    "typecheck": "tsc --noEmit && bun run build && tsc --noEmit -p site/tsconfig.json && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p bench/tsconfig.json",
+    "typecheck": "tsc --noEmit && bun run build && tsc --noEmit -p site/tsconfig.json && tsc --noEmit -p site/tsconfig.test.json && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p bench/tsconfig.json",
     "check": "bun typecheck && biome check .",
     "check:fix": "bun typecheck && biome check --write .",
     "check:version": "bun scripts/check-version.ts",

--- a/site/src/render.test.ts
+++ b/site/src/render.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+import { roll } from 'roll-parser';
+import { createMockRng } from 'roll-parser/testing';
+import { renderResultPanel } from './render.js';
+
+/** The mini-die faces the equation chip renders, in order. */
+function chipDice(notation: string, sequence: number[]): string[] {
+  const html = renderResultPanel(roll(notation, { rng: createMockRng(sequence) }));
+  return [...html.matchAll(/<span class="mini-die[^"]*"[^>]*>([^<]*)</g)].map(
+    (match) => match[1] ?? '',
+  );
+}
+
+describe('equation chip pools', () => {
+  it('renders the appended explosion dice (#313)', () => {
+    expect(chipDice('2d6!', [6, 4, 2])).toEqual(['6', '2', '4']);
+  });
+
+  it('renders penetrating explosions with their penalty applied (#313)', () => {
+    expect(chipDice('2d6!p', [6, 4, 2])).toEqual(['6', '1', '4']);
+  });
+
+  it('renders both the discarded die and its replacement (#313)', () => {
+    expect(chipDice('2d6r<3', [1, 5, 4])).toEqual(['1', '4', '5']);
+  });
+
+  it('prefers the outermost pool when explode wraps sort (#313)', () => {
+    expect(chipDice('2d6s!', [3, 6, 5])).toEqual(['3', '6', '5']);
+  });
+
+  it('keeps compound explosions folded into the original dice', () => {
+    expect(chipDice('2d6!!', [6, 4, 2])).toEqual(['8', '4']);
+  });
+
+  it('keeps the sorted order for a bare sort', () => {
+    expect(chipDice('4d6s', [3, 1, 4, 2])).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('keeps the tallied pool for a success count', () => {
+    expect(chipDice('4d6>=4', [6, 2, 5, 1])).toEqual(['6', '2', '5', '1']);
+  });
+});

--- a/site/src/render.ts
+++ b/site/src/render.ts
@@ -162,12 +162,18 @@ function renderEquation(root: RollPart, notation: string): string {
     return `<span class="brace-grp" style="--i:${chipIndex++}"><span class="eq-paren">{</span>${items}<span class="eq-paren">}</span>${tail}</span>`;
   }
 
-  /** Renders a modifier-family part as one chip, unwrapping to the dice it decorates. */
+  /**
+   * Renders a modifier-family part as one chip, unwrapping to the dice it
+   * decorates. `sort`, `explode`, `reroll` and `successCount` each carry the
+   * pool they produced, which is what `rendered` shows — the outermost of them
+   * wins, and the `dice` pool underneath is only a fallback for the modifiers
+   * that rewrite dice in place.
+   */
   function modifierLike(part: RollPart, isOutermost: boolean): string {
     let core: RollPart = part;
-    let sortedRolls: DieResult[] | undefined;
+    let pool: DieResult[] | undefined;
     while ('target' in core) {
-      if (core.type === 'sort') sortedRolls ??= core.rolls;
+      if ('rolls' in core) pool ??= core.rolls;
       core = core.target;
     }
 
@@ -176,7 +182,7 @@ function renderEquation(root: RollPart, notation: string): string {
     if (core.type === 'dice' || core.type === 'fateDice') {
       return groupChip(
         label || fallbackDiceLabel(core),
-        sortedRolls ?? core.rolls,
+        pool ?? core.rolls,
         subtotalText(part),
         isOutermost,
       );

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -9,6 +9,8 @@
   },
   // Only the browser sources — the site build scripts are plain Bun programs and
   // belong to `scripts/tsconfig.json`, which checks all of `scripts/` at once.
+  // Co-located tests need `bun:test`, so they get their own program in
+  // `tsconfig.test.json` rather than `types: []` being relaxed for everything.
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/site/tsconfig.test.json
+++ b/site/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Tests run under Bun, so they need its ambient types. The browser sources
+    // they import stay guarded — `tsconfig.json` still checks every one of them
+    // with `types: []`, so a stray `Bun.*` in a site source fails there.
+    "types": ["@types/bun"]
+  },
+  "include": ["src/**/*.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
`modifierLike` now captures the outermost part carrying its own `rolls[]` rather than only `sort`, so the equation chip renders the pool the modifier produced instead of the one its target rolled. `2d6!` shows its explosions, `2d6r<3` shows the replacement alongside the discarded die, and `2d6s!` shows the expanded pool rather than the inner sorted one. The die tray and `rendered` were always correct — only the chip disagreed with the total printed above it.

`2d6!!`, `4d6s` and `4d6>=4` are unchanged: compound explode mutates dice in place and tally flags live on the shared `DieResult` objects, so the inner pool already held the right values.

Added `site/src/render.test.ts`, the first suite under `site/`. Four of its seven cases fail without the fix.

That suite needed two pieces of plumbing. `site/**` is excluded from the coverage report — the 100% functions / 98% lines thresholds gate the shipped library, and holding a demo page's SVG rendering to them would price site tests out entirely; the suite still runs, it just does not count toward the floor. And site tests get their own program in `site/tsconfig.test.json`, so `site/tsconfig.json` keeps `types: []` and a stray `Bun.*` in a browser source still fails to typecheck.

Closes #313
