### PR TITLE
fix: keep/drop on a single-sub group discards non-dice arithmetic #302

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,9 +9,9 @@ Newest first. [Upgrading from 3.1.0 to 3.2.0](#upgrading-from-310-to-320) ·
 
 Nothing was removed and no type changed, and the seed → dice mapping is
 untouched — the same seed and notation roll the same faces they did in 3.1.0.
-Three fixes: penetrating explode and the three places its output is visible, a
-success-count target that never rolled anything, and a success count wrapped in
-another one.
+Four fixes: penetrating explode and the three places its output is visible, a
+success-count target that never rolled anything, a success count wrapped in
+another one, and keep/drop on a single-sub-roll group.
 
 **`!p` continuation dice now carry `initialResult`.** A penetrating explosion
 stores `raw - 1` on each die it appends, and used to record the face it
@@ -119,6 +119,40 @@ with it, so `successCount.total === successes - failures` holds again. A lone
 count is untouched, and so is a nested pair whose thresholds agree
 (`{4d6>=5}>=5`). Dropped dice come out untagged; only the DC side of a `vs`
 keeps tags from an inner count, since no pool pass may tally it.
+
+**Keep/drop on a single-sub-roll group now takes added dice terms only.** The
+flat-pool form totals the faces it kept, so any term in the sub-roll that is not
+an added die face was discarded from the total with no error and no marker.
+`{2d6+3}kh2` lost the `+3`, and `{2d6-1d4}kh3` — which drops nothing — flipped
+the `1d4` from `-3` to `+3`. The parser already refused `(2d6+3)kh2` for exactly
+this reason; the brace form now does too.
+
+```typescript
+import { roll } from 'roll-parser';
+import { createMockRng } from 'roll-parser/testing';
+
+roll('{2d6+3}kh2', { rng: createMockRng([4, 5]) }); // throws 'INVALID_KEEP_DROP_TARGET' — was 9
+roll('{2d6-1d4}kh3', { rng: createMockRng([4, 5, 3]) }); // throws 'INVALID_KEEP_DROP_TARGET' — was 12
+roll('{4d6+2d8}kh3', { rng: createMockRng([6, 6, 6, 1, 8, 1]) }).total; // 20 — unchanged
+```
+
+Also newly rejected, same cause: a scaled or function-wrapped pool (`{2d6*2}kh2`,
+`{abs(1d6-1d8)}kh1`), and a success count, which returned the face sum rather
+than the tally. `{4d6>=5}kh1` throws `INVALID_SUCCESS_COUNT_TARGET`, not the
+keep/drop code — a single-sub-roll group used to hide the count from the reject
+that `(4d6>=5)kh1` has always hit, and both spellings now report the same thing.
+
+The check is structural rather than arithmetic, so a term that happened to be an
+identity is refused along with the rest even though its total was already right:
+`{2d6+0}kh2`, `{2d6*1}kh2`, and `{2d6+1d8-0}kh3` all throw now. Widening the rule
+to evaluate the term first would accept `{2d6+0}kh2` and still reject
+`{2d6+3}kh2`, which is a worse contract to build notation against.
+
+Additive pools are the form this syntax exists for and are untouched —
+`{4d6+2d8}kh3`, `{2d6kh1+1d8}kh2`, `{{1d6, 1d8}+2d6}kh2`. Multi-sub-roll groups
+never had the bug, since keep/drop compares subtotals there: `{2d6+3, 1d8}kh1`
+still works. To keep a rejected expression, move the arithmetic outside the
+selection (`{2d6}kh2+3`) or give each term its own sub-roll.
 
 ## Upgrading from 3.0.0 to 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ compounded 15. The side you *don't* override always reads the natural face, so
 | `fT` / `f<cmp>T` | Subtract dice meeting the failure threshold — `10d10>=6f1`, `10d10>=6f<=2` |
 | `<roll> vs <dc>` | PF2e degree of success, with nat-20/nat-1 upgrade and downgrade |
 | `{a, b}khN` | Grouped roll: each sub-roll's subtotal competes as one compound die |
-| `{a+b}khN` | Single-sub-roll group: keep/drop selects across the flattened pool |
+| `{a+b}khN` | Single-sub-roll group: keep/drop selects across the flattened pool — added dice terms only |
 
 > [!IMPORTANT]
 > Success counting is **terminal** — no modifier or arithmetic applies to it
@@ -1032,6 +1032,18 @@ any commit that regresses a case past 1.75x. Bundle size is gated in CI by
   within each sub-roll, then sub-rolls by total — and the evaluator only
   flat-sorts, so the syntax is refused rather than shipped wrong. Single
   sub-roll groups (`{2d6+1d8}s`) still work as the flat-pool escape hatch.
+- **Keep/drop on a single-sub-roll group takes added dice terms only.**
+  `{4d6+2d8}kh3` selects across the six faces and totals them, which is the
+  whole point of the form. A term that contributes to the group's total without
+  contributing a face — a literal, a subtracted or scaled pool, a function call —
+  has nowhere to go in that sum, so `{2d6+3}kh2`, `{2d6-1d4}kh3`, and
+  `{2d6*2}kh2` throw `INVALID_KEEP_DROP_TARGET` instead of quietly returning the
+  face sum, and `{4d6>=5}kh1` throws `INVALID_SUCCESS_COUNT_TARGET` like the
+  `(4d6>=5)kh1` it brackets. The check is structural, not arithmetic, so an
+  identity term is refused with the rest — `{2d6+0}kh2` reads the same as
+  `{2d6+3}kh2` here. Put the arithmetic outside the selection (`{2d6}kh2+3`) or
+  give each term its own sub-roll (`{2d6+3, 1d8}kh1`), where keep/drop compares
+  subtotals.
 - **Success counting a group that rolls no dice is rejected.** `{3, 5, 7}>=4`
   throws `INVALID_SUCCESS_COUNT_TARGET`. A success count tallies dice, and a
   literal-only group has none — whether its units should be the subtotals is

--- a/bench/_cases.ts
+++ b/bench/_cases.ts
@@ -57,7 +57,7 @@ export const BENCH_CASES: BenchCase[] = [
   { id: '4dF', notation: '4dF', tier: 'simple' },
 
   { id: '4d6kh3', notation: '4d6kh3', tier: 'common' },
-  { id: '{1d6+2}kh1', notation: '{1d6+2}kh1', tier: 'common' },
+  { id: '{1d6+1d8}kh1', notation: '{1d6+1d8}kh1', tier: 'common' },
   { id: '2d20kh1 vs 15', notation: '2d20kh1 vs 15', tier: 'common' },
   { id: '10d10>=6f1', notation: '10d10>=6f1', tier: 'common' },
   { id: '4d6sd', notation: '4d6sd', tier: 'common' },

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -3463,6 +3463,37 @@ describe('evaluate', () => {
         const kept = result.rolls.filter((d) => !d.modifiers.includes('dropped'));
         expect(kept).toHaveLength(2);
       });
+
+      // The forms that survive the `sumsToKeptFaces` reject must actually hold
+      // the property it asserts — otherwise the guard's accept set is wrong.
+      const FLAT_POOL_CASES: [string, number[]][] = [
+        ['{4d6+2d8}kh3', [6, 6, 6, 1, 8, 1]],
+        ['{2d6kh1+1d8}kh2', [4, 5, 3]],
+        ['{2d6!+1d8}kh2', [6, 4, 5, 3]],
+        ['{{1d6, 1d8}+2d6}kh2', [4, 5, 3, 2]],
+      ];
+
+      test.each(FLAT_POOL_CASES)(
+        '%s totals the sum of its kept faces (#302)',
+        (notation, faces) => {
+          const result = evaluate(parse(notation), createMockRng(faces));
+          const kept = result.rolls.filter((d) => !d.modifiers.includes('dropped'));
+
+          expect(result.total).toBe(kept.reduce((sum, die) => sum + die.result, 0));
+        },
+      );
+
+      test('a keep-everything selection agrees with the bare group (#302)', () => {
+        const faces = [6, 6, 6, 1, 8, 1];
+        const bare = evaluate(parse('{4d6+2d8}'), createMockRng(faces));
+        const keptAll = evaluate(parse('{4d6+2d8}kh6'), createMockRng(faces));
+
+        expect(keptAll.total).toBe(bare.total);
+        expect(keptAll.parts.type).toBe('keepDrop');
+        if (keptAll.parts.type === 'keepDrop') {
+          expect(keptAll.parts.target.total).toBe(keptAll.parts.total);
+        }
+      });
     });
 
     describe('sub-roll mode (multi sub-roll with keep/drop)', () => {

--- a/src/parser/guards.ts
+++ b/src/parser/guards.ts
@@ -172,6 +172,42 @@ export function deepContainsDicePool(node: ASTNode): boolean {
 }
 
 /**
+ * Returns `true` when this node's total provably equals the sum of its kept
+ * dice faces: a pool, a chain of pool modifiers over one, or an addition of
+ * those. A multi-sub-roll `Group` qualifies when every sub-roll does, since its
+ * total is their sum and `evalGroupKeepDrop` re-flags dropped sub-rolls' dice.
+ *
+ * Guards the single-sub-roll `Group` keep/drop target, whose flat-pool path
+ * totals `sumKeptDice`. Anything else in there — a literal, a subtracted or
+ * scaled dice term, a function call, a success count — contributes to the
+ * group's own total but not to that face sum, so `{2d6+3}kh2` would lose the
+ * `+3` and `{2d6-1d4}kh3` would flip the `1d4` from `-3` to `+3` while dropping
+ * nothing.
+ */
+export function sumsToKeptFaces(node: ASTNode): boolean {
+  switch (node.type) {
+    case 'Dice':
+    case 'FateDice':
+      return true;
+    case 'KeepDrop':
+    case 'Explode':
+    case 'Reroll':
+    case 'DieBound':
+    case 'Sort':
+    case 'CritThreshold':
+      return sumsToKeptFaces(node.target);
+    case 'Grouped':
+      return sumsToKeptFaces(node.expression);
+    case 'Group':
+      return node.expressions.every(sumsToKeptFaces);
+    case 'BinaryOp':
+      return node.operator === '+' && sumsToKeptFaces(node.left) && sumsToKeptFaces(node.right);
+    default:
+      return false;
+  }
+}
+
+/**
  * Deep-walks a node to find any descendant `Dice` or `FateDice`. Unlike
  * `deepContainsDicePool`, a multi-sub-roll `Group` is not a hit in its own
  * right — only real dice are.

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1451,6 +1451,89 @@ describe('Parser', () => {
       });
     });
 
+    describe('keep/drop rejects single-sub groups that do not sum to their faces', () => {
+      // The flat-pool path totals `sumKeptDice`, so a sub-roll term that is not
+      // an added die face is discarded from the total without a marker.
+
+      it('rejects {2d6+3}kh2 (#302)', () => {
+        expectRollError(() => parseAst('{2d6+3}kh2'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      it('rejects {2d6-1d4}kh3 (#302)', () => {
+        expectRollError(() => parseAst('{2d6-1d4}kh3'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      it('rejects {2d6*2}kh2 (#302)', () => {
+        expectRollError(() => parseAst('{2d6*2}kh2'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      it('rejects {floor(2d6/2)}kh2 (#302)', () => {
+        expectRollError(
+          () => parseAst('{floor(2d6/2)}kh2'),
+          ParseError,
+          'INVALID_KEEP_DROP_TARGET',
+        );
+      });
+
+      it('rejects {-1d6+2d6}kh2 (#302)', () => {
+        expectRollError(() => parseAst('{-1d6+2d6}kh2'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      it('rejects {2d6+0}kh2 — an added literal counts even at zero (#302)', () => {
+        expectRollError(() => parseAst('{2d6+0}kh2'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      // Routed to the success-count code, not the keep/drop one, so the brace form
+      // reports what `(4d6>=5)kh1` has always reported for the same condition.
+      it('rejects {4d6>=5}kh1 — a success count is a tally, not a face sum (#302)', () => {
+        expectRollError(() => parseAst('{4d6>=5}kh1'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+      });
+
+      it.each(['{(4d6>=5)}kh1', '{{4d6>=5}}kh1', '{({4d6>=5})}kh1'])(
+        'rejects %s with the same code at any brace depth (#302)',
+        (notation) => {
+          expectRollError(() => parseAst(notation), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
+        },
+      );
+
+      it('rejects {{1d6, 1d8}+3}kh2 — the literal survives the nested group (#302)', () => {
+        expectRollError(
+          () => parseAst('{{1d6, 1d8}+3}kh2'),
+          ParseError,
+          'INVALID_KEEP_DROP_TARGET',
+        );
+      });
+
+      it('rejects ({2d6+3})kh2 through the Grouped wrapper (#302)', () => {
+        expectRollError(() => parseAst('({2d6+3})kh2'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      it('rejects {2d6+3}sd kh2 through the Sort wrapper (#302)', () => {
+        expectRollError(() => parseAst('{2d6+3}sd kh2'), ParseError, 'INVALID_KEEP_DROP_TARGET');
+      });
+
+      it.each([
+        '{4d6}kh2',
+        '{4d6+2d8}kh3',
+        '{4d10+5d6}kh2',
+        '{2d6kh1+1d8}kh2',
+        '{2d6!+1d8}kh2',
+        '{{1d6, 1d8}+2d6}kh2',
+        '{1d20}kh1cs>18',
+        '{4dF+2d6}kh2',
+      ])('still accepts %s — added dice terms only (#302)', (notation) => {
+        expect(() => parseAst(notation)).not.toThrow();
+      });
+
+      it('still accepts {2d6+3, 1d8}kh1 — multi-sub groups keep/drop subtotals (#302)', () => {
+        expect(() => parseAst('{2d6+3, 1d8}kh1')).not.toThrow();
+      });
+
+      it('still accepts {3, 5, 7}kh1 — literal-only multi-sub group (#302)', () => {
+        expect(() => parseAst('{3, 5, 7}kh1')).not.toThrow();
+      });
+    });
+
     describe('explode rejects non-pool targets', () => {
       it('should reject (1d6+5)!', () => {
         expectRollError(() => parseAst('(1d6+5)!'), ParseError, 'INVALID_EXPLODE_TARGET');

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -38,6 +38,7 @@ import {
   containsMultiSubGroup,
   containsVersus,
   deepContainsDicePool,
+  sumsToKeptFaces,
   unwrapAllTransparent,
   unwrapGrouped,
 } from './guards.js';
@@ -766,6 +767,39 @@ export class Parser {
         token.position,
         token,
       );
+    }
+
+    // ! A single-sub-roll Group is the flat-pool escape hatch, so `containsDicePool`
+    // ! deep-walks the arithmetic that `(1d6+5)kh1` rejects outright — but the flat
+    // ! path totals `sumKeptDice`, faces only. `{2d6+3}kh2` and `{2d6-1d4}kh3` are
+    // ! exactly the drop that reject exists to prevent.
+    const base = unwrapAllTransparent(target);
+    if (base.type === 'Group' && base.expressions.length === 1) {
+      const inner = base.expressions[0];
+      if (inner != null) {
+        // Single-sub Groups hide a count from the shallow reject at the top of this
+        // method, so peel them to any depth and `{4d6>=5}kh1`, `{{4d6>=5}}kh1`, and
+        // `(4d6>=5)kh1` all report one code. Peeling only picks which error the
+        // caller sees — `sumsToKeptFaces` below refuses a count either way.
+        let innermost = inner;
+        while (true) {
+          const peeled = unwrapGrouped(innermost);
+          if (peeled.type !== 'Group' || peeled.expressions.length !== 1) break;
+          const next = peeled.expressions[0];
+          if (next == null) break;
+          innermost = next;
+        }
+        this.rejectSuccessCountTarget(innermost, token);
+
+        if (!sumsToKeptFaces(inner)) {
+          throw new ParseError(
+            `Keep/drop on a single-sub-roll group requires added dice terms only`,
+            'INVALID_KEEP_DROP_TARGET',
+            token.position,
+            token,
+          );
+        }
+      }
     }
 
     const kind =


### PR DESCRIPTION
Added `sumsToKeptFaces` to `parser/guards.ts` — true only when a node's total provably equals the sum of its kept dice faces

Rejected single-sub-roll group keep/drop targets that fail it, so `{2d6+3}kh2` and `{2d6-1d4}kh3` throw `INVALID_KEEP_DROP_TARGET` instead of returning a face sum that contradicts the same group unmodified

Routed a brace-wrapped success count to `INVALID_SUCCESS_COUNT_TARGET` at any nesting depth, matching what `(4d6>=5)kh1` already reported

Replaced the `{1d6+2}kh1` bench case with `{1d6+1d8}kh1`, since the old notation no longer parses

Documented the restriction in `README.md` and `MIGRATION.md`

Additive pools are untouched — `{4d6+2d8}kh3`, `{2d6kh1+1d8}kh2`, `{{1d6, 1d8}+2d6}kh2`. Multi-sub-roll groups keep/drop subtotals and never had the bug. The check is structural, so an identity term (`{2d6+0}kh2`) is refused with the rest even though its total was already right. `{ roll }` moves from 12.04 kB to 12.17 kB against the 12.25 kB budget.

Closes #302
