### PR TITLE
docs: document reading crit/fumble and rendering custom markers #293

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,17 +77,14 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `bui
 - **Title**: `<type>: <description> #<number>`
 - **Body**: concise, no emojis, separate all sections with one blank line
 - Multiple issues go on one `Closes` line: `Closes #1 #23 #456`
-- The session link is informational: one `<sub>`-wrapped line, last in the body
-- Never append a second generated footer, `---` rule, or promotional line — the
-  `<sub>` session line is the only attribution. Applies to PRs created from the
-  web too, where these instructions are the only source of truth.
+- Never append a generated footer, `---` rule, session link, `<sub>` attribution,
+  or promotional line. Applies to PRs created from the web too, where these
+  instructions are the only source of truth.
 
   ```
   <summary of changes>
 
   Closes #<issue1> #<issue2>
-
-  <sub>[Claude Code session](<link>)</sub>
   ```
 
 `master` merges through a PR, must be up to date with it, and must pass the eight

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,18 +1,22 @@
 # Migration notes
 
-Newest first. [Upgrading from 3.1.0 to 3.2.0](#upgrading-from-310-to-320) ·
-[Upgrading from 3.0.0 to 3.1.0](#upgrading-from-300-to-310) ·
-[Migrating from v2 to v3](#migrating-from-v2-to-v3) ·
-[Upgrading from a v3 pre-release](#upgrading-from-a-v3-pre-release)
+Newest first.
+
+- [Upgrading from 3.1.0 to 3.2.0](#upgrading-from-310-to-320)
+- [Upgrading from 3.0.0 to 3.1.0](#upgrading-from-300-to-310)
+- [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+- [Upgrading from a v3 pre-release](#upgrading-from-a-v3-pre-release)
 
 ## Upgrading from 3.1.0 to 3.2.0
 
-Nothing was removed and no type changed, and the seed → dice mapping is
-untouched — the same seed and notation roll the same faces they did in 3.1.0.
-Five fixes: penetrating explode and the three places its output is visible, a
-success-count target that never rolled anything, a success count wrapped in
-another one, keep/drop on a single-sub-roll group, and success counting on a
-grouped roll.
+Nothing was removed from the API, no type changed, and the seed → dice mapping
+is untouched — the same seed and notation roll the same faces they did in
+3.1.0. What moves falls in two buckets. Several group forms that used to
+evaluate now throw a parse error — `{3, 5, 7}>=4`, `{2d6+3}kh2`, `{2d6*2}kh2`,
+`{3d20+5}>=21`, and `{2d6, 2d8}kh1>=4` — each listed below with a rewrite. The
+rest are values that moved: `initialResult` on `!p` dice, one `vs` degree, the
+`expression` and `rendered` strings, and the totals and tags of nested and
+grouped success counts.
 
 **`!p` continuation dice now carry `initialResult`.** A penetrating explosion
 stores `raw - 1` on each die it appends, and used to record the face it
@@ -45,27 +49,43 @@ continuation that rolled its maximum is critical even though it displays one
 less, matching the flags plain `1d6!p` already set.
 
 ```typescript
-import { roll } from 'roll-parser';
-import { createMockRng } from 'roll-parser/testing';
-
 const result = roll('1d6!pcf>5', { rng: createMockRng([6, 6, 3]) });
 
 result.rendered; // '1d6!pcf>5[6, 5, 2] = 13'
 result.rolls[1].critical; // true — was `false`, judged by the stored 5
 ```
 
-`1d6cf>5!p` and `1d6!pcf>5` now agree. 3.1.0's README documented them as
-disagreeing, and [Modifiers](README.md#modifiers) is rewritten to match: an
+If you assert `critical` or `fumble` on `!p` continuation dice, re-derive the
+expected flag from `initialResult ?? result`. Order stops mattering here:
+`1d6cf>5!p` and `1d6!pcf>5` now agree, where 3.1.0's README documented them as
+disagreeing, and [Modifiers](README.md#modifiers) is rewritten to match. An
 explicit threshold is still a predicate over a die's current `result`, so `!!`,
 `minN`, and `maxN` remain order-sensitive.
 
-**One `vs` case stops discarding its natural face.** A clamped explosion
-continuation used to be counted as a second primary d20, and two primaries
-suppress the natural 20 / natural 1 step.
+**Adjacent bare modifiers keep a space in `expression` and `rendered`.** `cs`,
+`cf`, `s`, and `sd` with no threshold or count end in a letter the lexer scans
+as an identifier, so the normalized form used to re-lex as one token and no
+longer round-tripped through `parse`.
 
 ```typescript
-import { DegreeOfSuccess, roll } from 'roll-parser';
-import { createMockRng } from 'roll-parser/testing';
+roll('1d20cs cf', { rng: createMockRng([20]) }).expression; // '1d20cs cf' — was '1d20cscf'
+roll('4d6 s kh2', { rng: createMockRng([1, 2, 3, 4]) }).rendered;
+// '4d6s[~~1~~, ~~2~~, 3, 4] = 7' — the prefix was '4d6skh2'
+```
+
+Only those four codes are affected; `4dF` and `!p` end in letters but are their
+own tokens, so they stay flush. Snapshot assertions over `expression` or
+`rendered` for an affected expression need re-recording.
+
+**One `vs` case stops discarding its natural face.** Only `vs` expressions
+whose roll side both appends explosion dice and clamps them — `!` or `!!`
+combined with `minN`/`maxN` — are affected: a clamped continuation used to be
+counted as a second primary d20, and two primaries suppress the natural 20 /
+natural 1 step. Without the clamp (`1d20! vs 30`) the continuation never looked
+like a primary, and those degrees are unchanged.
+
+```typescript
+import { DegreeOfSuccess } from 'roll-parser';
 
 const result = roll('1d20!min5 vs 30', { rng: createMockRng([20, 2, 12]) });
 
@@ -73,9 +93,7 @@ result.natural; // 20 — was `undefined`
 result.degree === DegreeOfSuccess.Success; // true — was `Failure`
 ```
 
-This needs a `vs` whose roll side both appends explosion dice and clamps them.
-Without the clamp — `1d20! vs 30` — the continuation never looked like a
-primary, and those degrees are unchanged.
+If you pinned `natural` or `degree` on such a roll, re-record it.
 
 **Success counting a dice-less group is now a parse error.** `{3, 5, 7}>=4`
 used to return the group's sum with `successes: 0`, so the
@@ -84,16 +102,16 @@ used to return the group's sum with `successes: 0`, so the
 its subtotals is undecided, so the form is refused instead.
 
 ```typescript
-import { roll } from 'roll-parser';
-
 roll('{3, 5, 7}>=4'); // throws 'INVALID_SUCCESS_COUNT_TARGET' — was 15
 roll('{3, 5, 7}kh1>=4'); // throws 'INVALID_SUCCESS_COUNT_TARGET' — was 7
+roll('{3, 0d6}>=4').total; // 0 — was 3
 ```
 
 Groups holding at least one pool are untouched — `{3, 1d6}>=4` counts the `1d6`
 exactly as it did. `0d6>=4` also still parses and totals 0; only targets that
-can never roll a die are rejected. One related total moved: a group whose pool
-turns out empty at run time, `{3, 0d6}>=4`, now totals 0 rather than 3.
+can never roll a die are rejected. There is no in-notation rewrite for a
+literal-only group: replace the literals with the pool they stood in for
+(`3d6>=4`), or drop the count and keep the group's sum (`{3, 5, 7}`).
 
 **A second success count re-scores the pool instead of adding to it.** Group
 braces let one count wrap another (`{4d6>=5f1}<=2f6`), which the parse-time
@@ -103,9 +121,6 @@ top-level counts stopped describing the total. The outermost count now owns the
 tags outright.
 
 ```typescript
-import { roll } from 'roll-parser';
-import { createMockRng } from 'roll-parser/testing';
-
 const result = roll('{4d6>=5f1}<=2f6', { rng: createMockRng([6, 5, 2, 1]) });
 
 result.total; // 1
@@ -114,9 +129,10 @@ result.failures; // 1 — was 0
 result.rendered; // '{4d6>=5f1}<=2f6[__6__, 5, **2**, **1**] = 1'
 ```
 
-`total` never moved — it always came from the outermost count. What changed is
-`successes`, `failures`, `rolls[].modifiers`, and `rendered`, which now agree
-with it, so `successCount.total === successes - failures` holds again. A lone
+`total` never moved — it always came from the outermost count, so a test
+asserting only `total` needs no change. What changed is `successes`,
+`failures`, `rolls[].modifiers`, and `rendered`, which now agree with it, so
+`successCount.total === successes - failures` holds again. A lone
 count is untouched, and so is a nested pair whose thresholds agree
 (`{4d6>=5}>=5`). Dropped dice come out untagged; only the DC side of a `vs`
 keeps tags from an inner count, since no pool pass may tally it.
@@ -129,25 +145,22 @@ the `1d4` from `-3` to `+3`. The parser already refused `(2d6+3)kh2` for exactly
 this reason; the brace form now does too.
 
 ```typescript
-import { roll } from 'roll-parser';
-import { createMockRng } from 'roll-parser/testing';
-
 roll('{2d6+3}kh2', { rng: createMockRng([4, 5]) }); // throws 'INVALID_KEEP_DROP_TARGET' — was 9
 roll('{2d6-1d4}kh3', { rng: createMockRng([4, 5, 3]) }); // throws 'INVALID_KEEP_DROP_TARGET' — was 12
+roll('{2d6*2}kh2', { rng: createMockRng([4, 5]) }); // throws 'INVALID_KEEP_DROP_TARGET'
+roll('{2d6+0}kh2', { rng: createMockRng([4, 5]) }); // throws 'INVALID_KEEP_DROP_TARGET' — identity terms too
 roll('{4d6+2d8}kh3', { rng: createMockRng([6, 6, 6, 1, 8, 1]) }).total; // 20 — unchanged
 ```
 
-Also newly rejected, same cause: a scaled or function-wrapped pool (`{2d6*2}kh2`,
-`{abs(1d6-1d8)}kh1`), and a success count, which returned the face sum rather
-than the tally. `{4d6>=5}kh1` throws `INVALID_SUCCESS_COUNT_TARGET`, not the
-keep/drop code — a single-sub-roll group used to hide the count from the reject
-that `(4d6>=5)kh1` has always hit, and both spellings now report the same thing.
+Also newly rejected, same cause: a function-wrapped pool (`{abs(1d6-1d8)}kh1`),
+and a success count, which returned the face sum rather than the tally.
+`{4d6>=5}kh1` throws `INVALID_SUCCESS_COUNT_TARGET`, not the keep/drop code — a
+single-sub-roll group used to hide the count from the reject that `(4d6>=5)kh1`
+has always hit, and both spellings now report the same thing.
 
-The check is structural rather than arithmetic, so a term that happened to be an
-identity is refused along with the rest even though its total was already right:
-`{2d6+0}kh2`, `{2d6*1}kh2`, and `{2d6+1d8-0}kh3` all throw now. Widening the rule
-to evaluate the term first would accept `{2d6+0}kh2` and still reject
-`{2d6+3}kh2`, which is a worse contract to build notation against.
+The check is structural rather than arithmetic, so identity terms are refused
+with the rest even though their total was already right: `{2d6+0}kh2`,
+`{2d6*1}kh2`, and `{2d6+1d8-0}kh3` all throw.
 
 Additive pools are the form this syntax exists for and are untouched —
 `{4d6+2d8}kh3`, `{2d6kh1+1d8}kh2`, `{{1d6, 1d8}+2d6}kh2`. Multi-sub-roll groups
@@ -162,9 +175,6 @@ Roll20 counts one success per sub-roll total, and that is what the count does
 now.
 
 ```typescript
-import { roll } from 'roll-parser';
-import { createMockRng } from 'roll-parser/testing';
-
 const result = roll('{2d6, 2d6}>=10', { rng: createMockRng([6, 5, 2, 1]) });
 
 result.total; // 1 — was 0
@@ -172,37 +182,46 @@ result.successes; // 1 — was 0
 result.rendered; // '{2d6[6, 5], 2d6[2, 1]}>=10 = 1'
 ```
 
-Four things move with it. `rendered` shows each sub-roll's own bracket instead
-of one flat pool, since the dice no longer are the units. The dice come back
-untagged — no `'success'` or `'failure'` in `rolls[].modifiers` — for the same
-reason. A `fT` threshold now scores subtotals too, so `{4d6+2d8, 3d20+3,
-5d10+1}>=40f<=10` reports 2 successes and 1 failure rather than a per-face
-tally. And a literal sub-roll is a subtotal like any other, so it is now scored
-rather than skipped: `{3, 1d6}>=4f<=3` with face `[6]` reports one success and
-one failure where it used to report one success alone. Single-sub-roll groups
-(`{4d6}>=5`, `{2d6+1d8}>=5`) are the flat-pool form and are unchanged.
+Four things move with it:
+
+- **`rendered`** shows each sub-roll's own bracket instead of one flat pool —
+  the dice are no longer the units.
+- **`rolls[].modifiers`** comes back untagged: no `'success'` or `'failure'` on
+  any die, for the same reason. Read `successes` / `failures` instead.
+- **`fT` thresholds** score subtotals too, so `{4d6+2d8, 3d20+3,
+  5d10+1}>=40f<=10` weighs three subtotals rather than 21 faces.
+- **A literal sub-roll** is a subtotal like any other, so it is scored rather
+  than skipped.
+
+```typescript
+const literal = roll('{3, 1d6}>=4f<=3', { rng: createMockRng([6]) });
+
+literal.successes; // 1
+literal.failures; // 1 — was 0
+literal.total; // 0 — was 1
+```
+
+Single-sub-roll groups (`{4d6}>=5`, `{2d6+1d8}>=5`) are the flat-pool form and
+are unchanged.
 
 **Two group spellings of a success count are now parse errors.** Both used to
 reach the flat counter with the subtotals already gone.
 
 ```typescript
-import { roll } from 'roll-parser';
-
 roll('{3d20+5}>=21'); // throws 'INVALID_SUCCESS_COUNT_TARGET' — was a count of bare faces
 roll('{2d6, 2d8}kh1>=4'); // throws 'INVALID_SUCCESS_COUNT_TARGET' — was a count of loose dice
+roll('({2d6, 2d8})>=4'); // throws 'INVALID_SUCCESS_COUNT_TARGET'
 ```
 
-The first is the single-sub-roll rule keep/drop already has: that form compares
-one face at a time, so a scalar term never reaches the comparison. A scaled or
-function-wrapped pool goes with it — `{2d6*2}>=4` and `{floor(2d6/2)}>=2` throw
-too, exactly as `{2d6*2}kh2` does. Roll20 folds the remaining math into each
-roll instead, which is only well defined for `pool ± scalar`, so the form is
-refused rather than half-implemented. The second
-covers every way a multi-sub-roll group can arrive somewhere other than as the
-count's direct target — `{{2d6, 2d8}}>=4` and `({2d6, 2d8})>=4` throw the same
-code. To keep a rejected expression, fold the scalar into the threshold —
-`3d20>=16` counts the same dice `{3d20+5}>=21` was meant to — or, for the
-selection case, count the group directly (`{2d6, 2d8}>=4`).
+- **`{3d20+5}>=21`** hits the single-sub-roll rule keep/drop already has: that
+  form compares one face at a time, so a scalar term never reaches the
+  comparison. A scaled or function-wrapped pool goes with it — `{2d6*2}>=4` and
+  `{floor(2d6/2)}>=2` throw too, exactly as `{2d6*2}kh2` does. To keep it, fold
+  the scalar into the threshold: `3d20>=16` counts the same dice.
+- **`{2d6, 2d8}kh1>=4`** covers every way a multi-sub-roll group can arrive
+  somewhere other than as the count's direct target — `{{2d6, 2d8}}>=4` and
+  `({2d6, 2d8})>=4` throw the same code. To keep it, count the group directly:
+  `{2d6, 2d8}>=4`.
 
 ## Upgrading from 3.0.0 to 3.1.0
 
@@ -248,8 +267,8 @@ group sub-roll nested inside another one used to emit mismatched delimiters —
 `{{(1d6[1]), 1d8[4]}, ({(1d10[1]), 1d12[3]})}`. Anything parsing that output
 should be reading `--json` instead.
 
-**New, optional: `roll-parser/render`.** A subpath export whose
-`renderBreakdown(result, marks?)` rebuilds the breakdown from `result.parts`
+**New, optional: `renderBreakdown` from `roll-parser/render`.** A subpath
+export whose `renderBreakdown(result, marks?)` rebuilds the breakdown from `result.parts`
 with markers you choose, so you no longer have to regex the markdown out of
 `rendered`. With no marks its output is byte-identical to `rendered`, which
 makes it a drop-in starting point:
@@ -300,9 +319,7 @@ classes. v3 has `roll(notation, options)` for the common path, and
 | `convert(obj)`, `Roll`, `WodRoll`, `Result` | removed — there are no roll-description objects to build or convert |
 
 **Result fields moved.** v2 returned `Result { notation, value, rolls }` where
-`rolls` was a plain `number[]`. The v3 snippets below draw from
-`createMockRng` (exported by `roll-parser/testing`) so their numbers are exact
-rather than whatever the dice happened to do:
+`rolls` was a plain `number[]`.
 
 <!-- readme-test: skip -->
 ```typescript

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
   parse depth are all bounded, and every failure is a typed error with a stable
   code and a source span.
 - **Small and fast.** ≈12.7 kB brotli for the whole library, ≈5.5 kB for just
-  `parse`, ≈213 B for the testing entry point. Zero runtime dependencies, zero
+  `parse`, ≈1.4 kB for `roll-parser/render`, ≈213 B for the testing entry
+  point. Zero runtime dependencies, zero
   `node:` imports. A `1d20` round trip takes about 0.5 µs.
 - **Tested.** 1,500+ tests behind CI-enforced coverage floors — 100% of
   functions, 98% of lines — including every code example in this README, which
@@ -84,22 +85,28 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 
 ## Contents
 
-- [Install](#install)
-- [Notation reference](#notation-reference)
+**Start here**
+
+- [Install](#install) — [CDN](#cdn--browser-without-a-bundler) · [Upgrading](#upgrading)
+- [Notation reference](#notation-reference) — [Dice](#dice) · [Arithmetic](#arithmetic-and-functions) · [Modifiers](#modifiers) · [Pools and checks](#pools-and-checks)
 - [Recipes by game system](#recipes-by-game-system)
-- [Working with results](#working-with-results)
-- [Randomness](#randomness)
-- [Options](#options)
-- [Error handling](#error-handling)
-- [Using the parser directly](#using-the-parser-directly)
-- [TypeScript](#typescript)
-- [CLI](#cli)
-- [Performance](#performance)
-- [Known limitations](#known-limitations)
-- [Versioning](#versioning)
-- [Upgrading](#upgrading)
-- [Contributing](#contributing)
-- [License](#license)
+
+**Using results**
+
+- [Working with results](#working-with-results) — [RollResult](#rollresult) · [The parts tree](#the-parts-tree)
+- [Rendering](#rendering) — [Custom markers](#custom-markers) · [Reading crit and fumble](#reading-crit-and-fumble)
+
+**Configuring a roll**
+
+- [Options](#options) — [Safety limits](#safety-limits)
+- [Randomness](#randomness) — [Seeded rolls](#seeded-rolls) · [Replay](#replay-and-saveresume) · [Custom RNGs](#custom-rngs) · [Testing](#testing)
+
+**Reference**
+
+- [Error handling](#error-handling) — [Notation errors](#notation-errors) · [Error classes](#error-classes) · [Error codes](#error-codes)
+- [Using the parser directly](#using-the-parser-directly) · [TypeScript](#typescript)
+- [CLI](#cli) · [Performance](#performance) · [Known limitations](#known-limitations)
+- [Versioning](#versioning) · [Contributing](#contributing) · [License](#license)
 
 ## Install
 
@@ -145,9 +152,9 @@ as one request:
 
 ### Upgrading
 
-[MIGRATION.md](MIGRATION.md) covers every upgrade path, newest first — 3.0.0 to
-3.1.0, v2 to v3, and the v3 pre-releases. v3 is a complete rewrite and the 2.x
-API is not compatible; to stay on the old line, pin `roll-parser@2.3.2`.
+[MIGRATION.md](MIGRATION.md) covers every upgrade path, newest first. v3 is a
+complete rewrite and the 2.x API is not compatible; to stay on the old line,
+pin `roll-parser@2.3.2`.
 
 ## Notation reference
 
@@ -221,14 +228,17 @@ Chained keep/drop modifiers do **not** nest. `4d6kh3dl1` flattens into two
 specs applied independently to the same pool, with the dropped sets unioned —
 the Roll20 rule.
 
-`cs` / `cf` covers the whole pool, including dice that `!`, `!p`, `r`, and `ro`
-add after it — `1d6cs<2!` and `1d6!cs<2` flag the same dice. One case stays
-order-sensitive: an explicit threshold reads a die's current value, so
-modifiers that rewrite it rather than add a die (`!!`, `minN`, `maxN`) are
-judged on whatever that value is when the threshold runs. With `[6, 6, 3]`,
-`1d6cs>10!!` reports no critical while `1d6!!cs>10` reports one, judging the
-compounded 15. The side you *don't* override always reads the natural face, so
-`1d6cf>5!p` and `1d6!pcf>5` agree with plain `1d6!p` on the added 6.
+`cs` / `cf` covers the whole pool, dice that `!`, `!p`, `r`, and `ro` add
+included, and position does not matter — `1d6cs<2!` and `1d6!cs<2` flag the
+same dice. The side you leave alone keeps the default rule, reading each die's
+natural face, so writing `cf>5` does not disturb `critical`: `1d6cf>5!p` and
+`1d6!pcf>5` both agree with plain `1d6!p` on the appended die.
+
+One case stays order-sensitive: an explicit threshold reads a die's current
+value, so modifiers that rewrite it rather than add a die (`!!`, `minN`,
+`maxN`) are judged on whatever that value is when the threshold runs. With
+`[6, 6, 3]`, `1d6cs>10!!` reports no critical while `1d6!!cs>10` reports one,
+judging the compounded 15.
 
 ### Pools and checks
 
@@ -238,9 +248,9 @@ compounded 15. The side you *don't* override always reads the natural face, so
 | `fT` / `f<cmp>T` | Subtract dice meeting the failure threshold — `10d10>=6f1`, `10d10>=6f<=2` |
 | `<roll> vs <dc>` | PF2e degree of success, with nat-20/nat-1 upgrade and downgrade |
 | `{a, b}khN` | Grouped roll: each sub-roll's subtotal competes as one compound die |
-| `{a+b}khN` | Single-sub-roll group: keep/drop selects across the flattened pool — added dice terms only |
+| `{a+b}khN` | Single-sub-roll group: keep/drop selects across the flattened pool — `+`-joined pools only, a literal or any math throws |
 | `{a, b}<cmp>T` | Grouped roll: each sub-roll's subtotal is counted, not its dice — `{2d6, 2d6}>=10` |
-| `{a+b}<cmp>T` | Single-sub-roll group: counts across the flattened pool — added dice terms only |
+| `{a+b}<cmp>T` | Single-sub-roll group: counts across the flattened pool — `+`-joined pools only, a literal or any math throws |
 
 > [!IMPORTANT]
 > Success counting is **terminal** — no modifier or arithmetic applies to it
@@ -249,10 +259,8 @@ compounded 15. The side you *don't* override always reads the natural face, so
 > result: `{10d10>=6}+2`.
 >
 > Braces also let a second count re-score the same pool — `{4d6>=5}<=2f5`. The
-> outermost count wins outright: every die is judged against its thresholds
-> alone, so `successes`, `failures`, and the rendered markers agree with it, and
-> dice it does not count come out untagged. The one exception is the DC side of
-> a `vs`, which sits outside every pool pass and keeps whatever tagged it.
+> outermost count owns the result; see
+> [RollResult](#rollresult) for what that means for the fields you read.
 
 > [!WARNING]
 > A bare `d` after a dice expression is rejected: `4d6d1` throws
@@ -301,7 +309,7 @@ pool.total; // 5 — successes minus failures
 | `notation` | `string` | Exactly what you passed in |
 | `expression` | `string` | Normalized form; meta-expressions appear as their resolved values |
 | `rendered` | `string` | Markdown breakdown with per-die markers |
-| `rolls` | `DieResult[]` | Every die in order: `sides`, `result`, `modifiers`, `critical`, `fumble` |
+| `rolls` | `DieResult[]` | Every die in order, meta-expression dice included: `sides`, `result`, `modifiers`, `critical`, `fumble` |
 | `parts` | `RollPart` | Typed evaluation tree mirroring the AST 1:1 |
 | `successes` / `failures` | `number?` | Present only when success counting was used |
 | `degree` / `natural` | `DegreeOfSuccess?` / `number?` | Present only for a top-level `vs` |
@@ -331,6 +339,12 @@ JSON.stringify(roll('3d6', { rng: createMockRng([4, 2, 6]) }));
 > [!NOTE]
 > `rolls[]` and the `rolls[]` inside `parts` hold the *same* `DieResult`
 > objects — no deep clone, so annotating a die is visible through both views.
+
+When counts nest through braces (`{4d6>=5}<=2f5`), the outermost one owns the
+result: every die is judged against its thresholds alone, so `successes`,
+`failures`, `rolls[].modifiers`, and `rendered` all agree with it, and dice it
+does not count come out untagged. The DC side of a `vs` is the exception — it
+sits outside every pool pass and keeps whatever tagged it.
 
 ### The parts tree
 
@@ -459,9 +473,9 @@ The 19 is critical only because `cs>=19` said so — the booleans are where the
 override lands. Compose the two marks rather than branching on one: overlapping
 thresholds set both, and `1d6cs>=3cf<=4` rolling a 3 does exactly that.
 
-`site/src/dice.ts` in this repo is the working version: `dieStates` turns the
-same booleans into CSS classes, `dieTitle` into a tooltip, and the tray legend
-lights up only for the states a roll actually produced.
+The [playground](https://roll-parser.edloidas.io/) does exactly this — its
+[source](https://github.com/edloidas/roll-parser/blob/master/site/src/dice.ts)
+turns the same booleans into CSS classes, a tooltip, and a legend.
 
 That loop is right for a plain pool. Four decisions it cannot dodge:
 
@@ -478,11 +492,10 @@ That loop is right for a plain pool. Four decisions it cannot dodge:
   every flagged die — but its callbacks receive the die, so gate on the tag.
   For a hand-rolled walk, `result.parts` keeps the two sides apart: the
   `versus` part carries `roll` and `dc` as separate subtrees.
-- **Never splice `rendered` by bracket position.** `{2d6, 2d8}kh1` puts one
-  strike around the whole dropped sub-roll, `{2d6[6, 6], ~~2d8[1, 1]~~}`, yet
-  its inner dice each carry `'dropped'` — group selection re-flags them after
-  the sub-roll's own text was captured. Marking every `'dropped'` die into that
-  string yields `~~2d8[~~1~~, ~~1~~]~~`. Rebuild with
+- **Never splice `rendered` by bracket position.** `{2d6, 2d8}kh1` strikes the
+  dropped sub-roll as a whole, `{2d6[6, 6], ~~2d8[1, 1]~~}`, yet its inner dice
+  each carry `'dropped'` too — marking every `'dropped'` die into that string
+  yields `~~2d8[~~1~~, ~~1~~]~~`. Rebuild with
   [`renderBreakdown`](#custom-markers) instead of patching the baked string.
 - **Density is your call.** The default rule flags the max face of any pool,
   not just d20s — `3d6` rolling a 6 is `critical: true` — so marking it
@@ -1051,16 +1064,12 @@ Values are **p50**, from
 two significant digits: another machine shifts every row, and a busy one
 inflates the heavy cases most.
 
-The `10d10>=6f1` `roll` figure and the `4d6sd` row come from a later
-five-pass measurement on the same machine, after the per-die `'dc'` tag checks
-that had entered the keep/drop, success-count, and sort paths were hoisted out
-of those loops. That session was not idle: `evaluate / 10d10>=6f1` and
-`evaluate / 10d10sd` each read bimodally across passes with roughly 10% between
-the two modes, so those two are quoted as "recovered to the pre-exclusion
-range" rather than to a point value. The rows this hoist does not touch
-(`1d20`, `2d6+3`, `4d6kh3`, `100d6`) re-measured within noise of the figures
-above and are left as first measured, since the earlier idle session is the
-better data for them.
+The `4d6sd` row and the `10d10>=6f1` `roll` figure come from a later five-pass
+measurement on the same machine, after the per-die `'dc'` tag checks were
+hoisted out of the keep/drop, success-count, and sort loops. That session was
+not idle and those two read bimodally with roughly 10% between the modes, so
+take them as a recovered range rather than point values. Every other row is as
+first measured.
 
 p50 rather than mean, because the mean here is effectively a GC-pause
 histogram and swings ±40% between processes. Every bench body is JIT-primed
@@ -1080,17 +1089,42 @@ any commit that regresses a case past 1.75x. Bundle size is gated in CI by
 
 ## Known limitations
 
-- **Keep/drop does not echo into the render prefix.** `4d6kh3` renders as
-  `4d6[1, 6, ~~1~~, 3] = 10`, while every other modifier family does echo
-  (`8d6![…]`, `4d6sd[…]`, `10d10>=6f1[…]`). The dropped die is still marked;
-  only the `kh3` is missing, and `result.expression` has it.
-- **`4d6d1` is a parse error, not "drop 1".** The bare `d` is the dice
-  operator, and reading `4d6d1` as "roll 4d6, then roll that many d1" is a
-  silent trap, so it throws `AMBIGUOUS_DICE_CHAIN`.
-- **Threshold comparisons bind tight.** `1d6!>=5+2` parses as `(1d6!>=5)+2`;
-  parenthesize for a computed threshold, `1d6!>=(5+2)`. Success counts bind the
-  same way but are terminal, so `1d6>=5+2` errors outright — write
-  `1d6>=(5+2)`, or `{1d6>=5}+2` to add to the count itself.
+### Notation the parser rejects
+
+| Form | Throws | Write instead |
+|------|--------|---------------|
+| `{2d6+3}kh2`, `{2d6-1d4}kh3`, `{2d6*2}kh2`, `{2d6+0}kh2` | `INVALID_KEEP_DROP_TARGET` | `{2d6}kh2 + 3`, or one sub-roll per term: `{2d6+3, 1d8}kh1` |
+| `{3d20+5}>=21`, `{2d6-1d4}>=3`, `{2d6*2}>=4`, `{floor(2d6/2)}>=2` | `INVALID_SUCCESS_COUNT_TARGET` | fold the scalar into the threshold: `3d20>=16` |
+| `{3, 5, 7}>=4` | `INVALID_SUCCESS_COUNT_TARGET` | give the group a pool: `3d6>=4` |
+| `{{2d6, 2d8}}>=4`, `({2d6, 2d8})>=4`, `{2d6, 2d8}kh1>=4` | `INVALID_SUCCESS_COUNT_TARGET` | count the group directly: `{2d6, 2d8}>=4` |
+| `{4d6>=5}kh1` | `INVALID_SUCCESS_COUNT_TARGET` | the count is already terminal — select first, `{4d6kh1}>=5` |
+| `{2d6, 1d8}s` | `INVALID_SORT_TARGET` | flatten to one sub-roll: `{2d6+1d8}s` |
+| `4d6d1` | `AMBIGUOUS_DICE_CHAIN` | `4d6dl1` to drop a die, `(4d6)d1` for nested dice |
+
+The first two rows share one cause: a single-sub-roll group compares dice one
+face at a time, so a literal, a subtracted or scaled pool, or a function wrapper
+never reaches the comparison. The check is structural rather than arithmetic, so
+an identity term (`{2d6+0}kh2`) is refused with the rest. Adding pools
+(`{4d6+2d8}kh3`, `{2d6+1d8}>=5`) is the form these braces exist for and always
+works.
+
+A counted group needs at least one die somewhere in it — one real pool is
+enough, and the other sub-rolls may be literals: `{3, 1d6}>=4` scores both
+subtotals, the literal `3` included. A pool that is merely empty at run time
+(`0d6>=4`) still parses and totals 0. Subtotals exist only while the count holds
+the group directly, which is why the fourth row throws rather than falling back
+to loose faces; the DC side of a `vs` is exempt (`{1d20 vs {2d6, 2d8}}>=5`
+counts the d20), since no pool pass tallies a DC.
+
+Sorting a multi-sub-roll group is refused rather than shipped wrong: spec-correct
+sorting there is hierarchical — dice within each sub-roll, then sub-rolls by
+total — and the evaluator only flat-sorts.
+
+### Rendering and `expression`
+
+- **Keep/drop does not echo into the render prefix** — see
+  [Rendering](#rendering). The dropped die is still marked; only the `kh3` is
+  missing, and `result.expression` has it.
 - **`result.expression` substitutes meta-expressions with their resolved
   values,** so it does not round-trip through `parse` when they are present:
   `roll('(1d4)d6').expression` is `'4d6'` when the `1d4` rolled 4, and
@@ -1106,42 +1140,13 @@ any commit that regresses a case past 1.75x. Bundle size is gated in CI by
 - **Outer parentheses drop when crit thresholds collapse.** `(1d20cs>19)cs=1`
   reports `expression: '1d20cs>19cs=1'` because chained `cs`/`cf` fold into one
   node. It re-parses to the same AST; only the text differs.
-- **Sorting a multi-sub-roll group is rejected.** `{2d6, 1d8}s` throws
-  `INVALID_SORT_TARGET`. Spec-correct sorting there is hierarchical — dice
-  within each sub-roll, then sub-rolls by total — and the evaluator only
-  flat-sorts, so the syntax is refused rather than shipped wrong. Single
-  sub-roll groups (`{2d6+1d8}s`) still work as the flat-pool escape hatch.
-- **Keep/drop on a single-sub-roll group takes added dice terms only.**
-  `{4d6+2d8}kh3` selects across the six faces and totals them, which is the
-  whole point of the form. A term that contributes to the group's total without
-  contributing a face — a literal, a subtracted or scaled pool, a function call —
-  has nowhere to go in that sum, so `{2d6+3}kh2`, `{2d6-1d4}kh3`, and
-  `{2d6*2}kh2` throw `INVALID_KEEP_DROP_TARGET` instead of quietly returning the
-  face sum, and `{4d6>=5}kh1` throws `INVALID_SUCCESS_COUNT_TARGET` like the
-  `(4d6>=5)kh1` it brackets. The check is structural, not arithmetic, so an
-  identity term is refused with the rest — `{2d6+0}kh2` reads the same as
-  `{2d6+3}kh2` here. Put the arithmetic outside the selection (`{2d6}kh2+3`) or
-  give each term its own sub-roll (`{2d6+3, 1d8}kh1`), where keep/drop compares
-  subtotals.
-- **Success counting a group that rolls no dice is rejected.** `{3, 5, 7}>=4`
-  throws `INVALID_SUCCESS_COUNT_TARGET`. A count needs a pool to score, and a
-  literal-only group has none, so the syntax is refused rather than answered
-  wrongly. Groups holding at least one pool (`{3, 1d6}>=4`) count their
-  subtotals, and a pool that is merely empty at run time (`0d6>=4`) still
-  totals 0.
-- **Only a direct multi-sub-roll group counts subtotals.** Subtotals exist while
-  `evalSuccessCount` holds the group itself, so reaching one any other way —
-  `{{2d6, 2d8}}>=4`, `({2d6, 2d8})>=4`, `{2d6, 2d8}kh1>=4` — throws
-  `INVALID_SUCCESS_COUNT_TARGET` rather than falling back to loose faces. The DC
-  side of a `vs` is free of the rule (`{1d20 vs {2d6, 2d8}}>=5` counts the d20),
-  since no pool pass tallies a DC.
-- **A single-sub-roll group counts added dice terms only.** `{3d20+5}>=21`,
-  `{2d6-1d4}>=3`, `{2d6*2}>=4`, and `{floor(2d6/2)}>=2` throw
-  `INVALID_SUCCESS_COUNT_TARGET`. That form compares dice one face at a time, so
-  a scalar, a subtracted term, a scale factor, or a function wrapper never
-  reaches the comparison — the same restriction keep/drop has on `{2d6+3}kh2`.
-  Roll20 folds the remaining math into each roll instead, which is only well
-  defined for `pool ± scalar`. Adding pools (`{2d6+1d8}>=5`) still works.
+
+### Arithmetic and precedence
+
+- **Threshold comparisons bind tight.** `1d6!>=5+2` parses as `(1d6!>=5)+2`;
+  parenthesize for a computed threshold, `1d6!>=(5+2)`. Success counts bind the
+  same way but are terminal, so `1d6>=5+2` errors outright — write
+  `1d6>=(5+2)`, or `{1d6>=5}+2` to add to the count itself.
 - **Division does not floor.** `7/2` totals `3.5`, not `3` — arithmetic is plain
   IEEE-754 throughout. Wrap it when you need an integer: `floor(7/2)` totals `3`.
 - **The power operator has no overflow guard.** `2**999` totals `5.357…e+300`.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ dice land in `result.rolls` tagged `'meta'` so an audit log can still show them.
 
 `result.rendered` uses markdown markers, so a Discord bot or chat log can print
 it as-is: `~~n~~` for a die dropped by keep/drop or group selection, `**n**` for
-a success, `__n__` for a failure.
+a success, `__n__` for a failure. The dialect is Discord's, not a universal one
+— Telegram MarkdownV2 rejects `**bold**` and spells strike `~n~` — so expect a
+transform, or emit your own dialect with [`renderBreakdown`](#custom-markers).
 
 ```typescript
 roll('4d6kh3', { seed: 'demo' }).rendered; // '4d6[1, 6, ~~1~~, 3] = 10'
@@ -431,6 +433,80 @@ Marks compose in a fixed order: `critical` then `fumble` innermost, then
 exactly one of `dropped`, `success`, or `failure` — a dropped die is never
 also shown as a success. With no marks the output is byte-identical to
 `result.rendered`; a property test pins that.
+
+#### Reading crit and fumble
+
+`rendered` carries no marker for a crit or a fumble — those live on the dice.
+`die.critical` and `die.fumble` already reflect any `cs` / `cf` override, so a
+UI that builds its own elements reads the booleans rather than the string.
+
+```typescript
+const result = roll('4d20cs>=19', { rng: createMockRng([20, 19, 7, 1]) });
+
+const marked = result.rolls
+  .filter((die) => !die.modifiers.includes('meta'))
+  .map((die) => {
+    let text = String(die.result);
+    if (die.critical) text = `<b>${text}</b>`;
+    if (die.fumble) text = `<i>${text}</i>`;
+    return text;
+  });
+
+marked.join(', '); // '<b>20</b>, <b>19</b>, 7, <i>1</i>'
+```
+
+The 19 is critical only because `cs>=19` said so — the booleans are where the
+override lands. Compose the two marks rather than branching on one: overlapping
+thresholds set both, and `1d6cs>=3cf<=4` rolling a 3 does exactly that.
+
+`site/src/dice.ts` in this repo is the working version: `dieStates` turns the
+same booleans into CSS classes, `dieTitle` into a tooltip, and the tray legend
+lights up only for the states a roll actually produced.
+
+That loop is right for a plain pool. Four decisions it cannot dodge:
+
+- **`'meta'` dice are not yours to show.** They resolve counts, sides, and
+  modifier arguments, and they carry ordinary crit flags — in `4d6kh(1d2)` the
+  `1d2` rolling a 2 hits its max face and arrives `critical: true`. The filter
+  above is not optional.
+- **`'dc'` dice are a judgment call.** They do render — `1d20 vs 2d10` shows
+  `1d20[5] vs 2d10[10, 10]` — but they sit outside the roll-side pool while
+  still taking the default crit rule, so that `[10, 10]` arrives as two crits
+  nobody rolled for. Drop them and a per-die zip has no dice left for a
+  two-number bracket; keep them and the DC side lights up on its own faces.
+  [`renderBreakdown`](#custom-markers) does not decide this for you — it marks
+  every flagged die — but its callbacks receive the die, so gate on the tag.
+  For a hand-rolled walk, `result.parts` keeps the two sides apart: the
+  `versus` part carries `roll` and `dc` as separate subtrees.
+- **Never splice `rendered` by bracket position.** `{2d6, 2d8}kh1` puts one
+  strike around the whole dropped sub-roll, `{2d6[6, 6], ~~2d8[1, 1]~~}`, yet
+  its inner dice each carry `'dropped'` — group selection re-flags them after
+  the sub-roll's own text was captured. Marking every `'dropped'` die into that
+  string yields `~~2d8[~~1~~, ~~1~~]~~`. Rebuild with
+  [`renderBreakdown`](#custom-markers) instead of patching the baked string.
+- **Density is your call.** The default rule flags the max face of any pool,
+  not just d20s — `3d6` rolling a 6 is `critical: true` — so marking it
+  unconditionally makes ordinary pools glitter. Gate on `die.sides === 20`, or
+  on whatever your table's rule is. `d1` and Fate dice are the exceptions:
+  having no exceptional face, they stay `false` unless `cs` / `cf` says so.
+
+The claims above, in code:
+
+```typescript
+import { renderBreakdown } from 'roll-parser/render';
+
+roll('1d6cs>=3cf<=4', { rng: createMockRng([3]) }).rolls[0]?.fumble; // true
+roll('4d6kh(1d2)', { rng: createMockRng([2, 3, 6, 2, 5]) }).rolls[0]?.critical; // true
+roll('1d20 vs 2d10', { rng: createMockRng([5, 10, 10]) }).rolls[2]?.critical; // true
+roll('3dF', { rng: createMockRng([1, 0, -1]) }).rolls[0]?.critical; // false
+roll('{2d6, 2d8}kh1', { rng: createMockRng([6, 6, 1, 1]) }).rendered;
+// '{2d6[6, 6], ~~2d8[1, 1]~~} = 12'
+
+// Gating a mark on the `'dc'` tag keeps the DC side unmarked
+renderBreakdown(roll('1d20 vs 2d10', { rng: createMockRng([5, 10, 10]) }), {
+  critical: (die, text) => (die.modifiers.includes('dc') ? text : `<b>${text}</b>`),
+}); // '1d20[5] vs 2d10[10, 10] = Critical Failure'
+```
 
 ## Randomness
 

--- a/src/evaluator/env.ts
+++ b/src/evaluator/env.ts
@@ -62,7 +62,7 @@ export type EvalEnv = {
    * `true` once a `vs` has tagged its DC dice `'dc'`. Lets every pool
    * operation skip its per-die `isVersusDc` check outright — the tag exists in
    * a small minority of notation, and the call inside the loop cost 11-38% on
-   * keep/drop, success, and sort notation that can never carry one (#281).
+   * keep/drop, success, and sort notation that can never carry one.
    *
    * ! Monotonic: set by `evalVersus`, never cleared. `insideVersus` is not a
    * ! model for it — that flag resets in a `finally`, and it is false exactly

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -483,15 +483,29 @@ function evalMetaOperand(node: ASTNode, rng: RNG, ctx: EvalContext, env: EvalEnv
   }
 
   const metaCtx = createContext();
-  // A meta operand resolves to a scalar, so its verdicts are released with its
-  // dice — the tally counterpart of the `TALLY_FLAGS` strip in `mergeMetaRolls`.
-  const successTally = env.subtotalSuccesses;
-  const failureTally = env.subtotalFailures;
-  const value = evalNode(node, rng, metaCtx, env).total;
-  env.subtotalSuccesses = successTally;
-  env.subtotalFailures = failureTally;
+  // The tally counterpart of the `TALLY_FLAGS` strip in `mergeMetaRolls`.
+  const value = evalDiscardingSubtotals(node, rng, metaCtx, env).total;
   mergeMetaRolls(ctx, metaCtx);
   return value;
+}
+
+/**
+ * Evaluates a node whose result is consumed as a scalar — a meta operand or a
+ * `vs` DC — rolling back any subtotal verdicts it scored so they never reach
+ * the top-level tally.
+ */
+function evalDiscardingSubtotals(
+  node: ASTNode,
+  rng: RNG,
+  ctx: EvalContext,
+  env: EvalEnv,
+): EvalResult {
+  const successTally = env.subtotalSuccesses;
+  const failureTally = env.subtotalFailures;
+  const result = evalNode(node, rng, ctx, env);
+  env.subtotalSuccesses = successTally;
+  env.subtotalFailures = failureTally;
+  return result;
 }
 
 /** Rejects dice counts that cannot address a pool. */
@@ -1719,12 +1733,8 @@ function evalVersus(node: VersusNode, rng: RNG, ctx: EvalContext, env: EvalEnv):
     const dcCtx = createContext();
     // A subtotal count on the DC side (`1d20 vs {{2d6, 2d6}>=10}`) is rolled
     // back for the same reason `countTaggedDice` skips DC dice: no pool pass
-    // may tally that side, so its verdicts stay out of the top-level counts.
-    const dcSuccessTally = env.subtotalSuccesses;
-    const dcFailureTally = env.subtotalFailures;
-    const dcResult = evalNode(node.dc, rng, dcCtx, env);
-    env.subtotalSuccesses = dcSuccessTally;
-    env.subtotalFailures = dcFailureTally;
+    // may tally that side.
+    const dcResult = evalDiscardingSubtotals(node.dc, rng, dcCtx, env);
 
     const degree = calculateDegree(rollResult.total, dcResult.total, natural);
 

--- a/src/evaluator/modifiers/crit-threshold.ts
+++ b/src/evaluator/modifiers/crit-threshold.ts
@@ -48,11 +48,8 @@ import { matchesCondition } from './compare.js';
 import { isVersusDc } from './flags.js';
 
 /**
- * Applies success/fail threshold arrays to a dice pool, overriding each
- * die's `critical` and `fumble` flags in place. Writing `natural` for
- * `initialResult ?? result`, a die matches `'default'` on the success side
- * when `natural === sides && sides > 1`, and on the fail side when
- * `natural === 1 && sides > 1`. Meta dice are skipped.
+ * Applies success/fail threshold arrays to a dice pool, overriding each die's
+ * `critical` and `fumble` flags in place. Meta and DC dice are skipped.
  *
  * Also records the rule against every die it touched, so later explode and
  * reroll dice can inherit it via {@link inheritCritRule}.
@@ -79,12 +76,11 @@ export function applyCritThresholds(
 /**
  * Judges one die by a recorded rule, overwriting both flags. A side always
  * carries at least `'default'` — `evalCritThreshold` fills the side the user
- * left out — so neither flag is silently left untouched. `natural` is the face
- * the `'default'` sentinel reads; an explicit threshold always reads `result`.
+ * left out — so neither flag is silently left untouched.
  */
 function applyCritRule(die: DieResult, rule: CritRule, natural: number): void {
-  die.critical = rule.success.some((t) => matchesCrit(t, die, natural));
-  die.fumble = rule.fail.some((t) => matchesFumble(t, die, natural));
+  die.critical = rule.success.some((t) => matchesThreshold(t, die, natural, die.sides));
+  die.fumble = rule.fail.some((t) => matchesThreshold(t, die, natural, 1));
 }
 
 /**
@@ -108,17 +104,19 @@ export function inheritCritRule(env: EvalEnv, parent: DieResult, child: DieResul
   rules.set(child, rule);
 }
 
-function matchesCrit(threshold: ResolvedCritThreshold, die: DieResult, natural: number): boolean {
+/**
+ * `defaultFace` is the face the `'default'` sentinel looks for — `die.sides`
+ * on the success side, `1` on the fail side. The `sides > 1` guard mirrors
+ * `createDieResult`: a d1 always rolls 1, so it is neither.
+ */
+function matchesThreshold(
+  threshold: ResolvedCritThreshold,
+  die: DieResult,
+  natural: number,
+  defaultFace: number,
+): boolean {
   if (threshold === 'default') {
-    return natural === die.sides && die.sides > 1;
-  }
-  return matchesCondition(die.result, threshold.operator, threshold.value);
-}
-
-function matchesFumble(threshold: ResolvedCritThreshold, die: DieResult, natural: number): boolean {
-  if (threshold === 'default') {
-    // Mirrors `createDieResult` — a d1 always rolls 1, never a fumble.
-    return natural === 1 && die.sides > 1;
+    return natural === defaultFace && die.sides > 1;
   }
   return matchesCondition(die.result, threshold.operator, threshold.value);
 }

--- a/src/evaluator/modifiers/flags.ts
+++ b/src/evaluator/modifiers/flags.ts
@@ -22,8 +22,8 @@ import type { DieModifier, DieResult } from '../../types.js';
  * `{1d20 vs 2d10, 1d4}>=5` must not count the DC faces as successes.
  *
  * ! Call this behind the shared `hasVersusDc` env flag, never bare. Unguarded
- * ! inside a per-die loop it cost 11-38% on notation that cannot carry the tag
- * ! (#281); the flag is `false` until a `vs` has actually tagged something.
+ * ! inside a per-die loop it cost 11-38% on notation that cannot carry the
+ * ! tag; the flag is `false` until a `vs` has actually tagged something.
  */
 export function isVersusDc(die: DieResult): boolean {
   return die.modifiers.includes('dc');

--- a/src/evaluator/modifiers/keep-drop.ts
+++ b/src/evaluator/modifiers/keep-drop.ts
@@ -134,12 +134,10 @@ function markSingleExtreme(
 }
 
 /**
- * Calculates total from dice, excluding dropped dice.
+ * Sums the dice a keep/drop pass left standing.
  *
- * @param dice - Array of die results
  * @param hasVersusDc - Shared env flag; skips the DC exclusion when no `vs` has
  *   tagged anything
- * @returns Sum of non-dropped dice
  */
 export function sumKeptDice(dice: DieResult[], hasVersusDc: boolean): number {
   let total = 0;

--- a/src/evaluator/modifiers/sort.ts
+++ b/src/evaluator/modifiers/sort.ts
@@ -37,7 +37,7 @@ export function sortDice(
       : (a: DieResult, b: DieResult) => b.result - a.result;
 
   // Scan before allocating: the `filter` this replaced built a throwaway array
-  // on every sort to serve a case only a `vs` can produce (#281).
+  // on every sort to serve a case only a `vs` can produce.
   if (!hasVersusDc || !dice.some(isVersusDc)) return [...dice].sort(cmp);
 
   // Sort only the pool members, then lay them back into the slots they came

--- a/src/evaluator/modifiers/success-count.ts
+++ b/src/evaluator/modifiers/success-count.ts
@@ -41,7 +41,7 @@ export function countSuccesses(
 
   // ! Excluded up front, never inside the loop below. Even short-circuited on a
   // ! false flag, a `hasVersusDc && isVersusDc(die)` guard in this loop costs
-  // ! ~9% on `10d10>=6f1` — measured, not assumed (#281). Filtering keeps the
+  // ! ~9% on `10d10>=6f1` — measured, not assumed. Filtering keeps the
   // ! hot body identical to the pre-exclusion one and pays an allocation only
   // ! on the `vs` path. The dice are the same objects either way, so the
   // ! `'success'` / `'failure'` tags written below still land on the pool.

--- a/src/parser/guards.ts
+++ b/src/parser/guards.ts
@@ -61,7 +61,7 @@ export function unwrapAllTransparent(node: ASTNode): ASTNode {
  * Returns `true` when `node` or any descendant satisfies `isHit`. Recurses
  * directly through the entire node vocabulary: arithmetic operands,
  * modifier-chain targets, `Versus` sides, function arguments, and group
- * sub-expressions. This is the shared driver behind the four deep walkers
+ * sub-expressions. This is the shared driver behind the deep walkers
  * below. The shallow walkers (`containsDicePool`, `containsFatePool`) stay
  * hand-written because their rejection semantics deliberately stop at
  * arithmetic boundaries.

--- a/src/render.ts
+++ b/src/render.ts
@@ -123,7 +123,6 @@ function failCode(point: ResolvedComparePoint): string {
 function expr(part: RollPart): string {
   switch (part.type) {
     case 'literal':
-      return String(part.value);
     case 'variable':
       return String(part.value);
     case 'dice':
@@ -145,10 +144,7 @@ function expr(part: RollPart): string {
     case 'explode':
       return `${expr(part.target)}${explodeCode(part)}`;
     case 'reroll':
-      return joinModifierCode(
-        expr(part.target),
-        `${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`,
-      );
+      return joinModifierCode(expr(part.target), rerollCode(part));
     case 'dieBound':
       return joinModifierCode(expr(part.target), dieBoundCode(part));
     case 'sort':
@@ -165,6 +161,10 @@ function expr(part: RollPart): string {
 function explodeCode(part: Extract<RollPart, { type: 'explode' }>): string {
   const marker = EXPLODE_MARKERS[part.variant];
   return part.threshold == null ? marker : `${marker}${comparePointCode(part.threshold)}`;
+}
+
+function rerollCode(part: Extract<RollPart, { type: 'reroll' }>): string {
+  return `${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`;
 }
 
 /** Negative bounds are parenthesized so the expression re-parses. */
@@ -239,9 +239,8 @@ function poolOf(part: RollPart): DieResult[] {
 }
 
 /**
- * Marks one die. `plain` suppresses the three state marks for dice inside a
- * dropped sub-roll, where the group wrapper already carries the verdict —
- * crit and fumble survive, since they describe the face, not the selection.
+ * Marks one die. `plain` suppresses the three state marks inside a dropped
+ * sub-roll — the rule {@link DieMarks.droppedGroup} documents.
  */
 function markDie(die: DieResult, marks: DieMarks, plain: boolean): string {
   let text = String(die.result);
@@ -320,25 +319,20 @@ function renderPart(part: RollPart, marks: DieMarks, plain: boolean): string {
     case 'explode':
       return renderModifier(part.target, explodeCode(part), part.rolls, marks, plain);
     case 'reroll':
-      return renderModifier(
-        part.target,
-        `${part.once ? 'ro' : 'r'}${comparePointCode(part.condition)}`,
-        part.rolls,
-        marks,
-        plain,
-      );
+      return renderModifier(part.target, rerollCode(part), part.rolls, marks, plain);
     case 'successCount':
       // Subtotal counting renders through the group, which shows each sub-roll's
       // own dice; only the flat form collapses into one bracket.
       return part.target.type === 'group' && part.target.parts.length >= 2
         ? `${renderPart(part.target, marks, plain)}${successCountCode(part)}`
         : renderModifier(part.target, successCountCode(part), part.rolls, marks, plain);
+    // These three render as their own normalized expression plus a pool.
     case 'dieBound':
-      return `${joinModifierCode(expr(part.target), dieBoundCode(part))}${renderPool(poolOf(part.target), marks, plain)}`;
+      return `${expr(part)}${renderPool(poolOf(part.target), marks, plain)}`;
     case 'sort':
-      return `${joinModifierCode(expr(part.target), part.order === 'ascending' ? 's' : 'sd')}${renderPool(part.rolls, marks, plain)}`;
+      return `${expr(part)}${renderPool(part.rolls, marks, plain)}`;
     case 'critThreshold':
-      return `${joinModifierCode(expr(part.target), critThresholdCode(part))}${renderPool(poolOf(part.target), marks, plain)}`;
+      return `${expr(part)}${renderPool(poolOf(part.target), marks, plain)}`;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,12 +458,9 @@ export type RollResult = Readonly<{
    * The outermost count owns the outcome: it re-scores the pool against its own
    * thresholds, so no die is ever both a success and a failure, and dice it
    * does not count come out untagged rather than keeping the inner count's
-   * tags. The DC side of a `vs` is the exception a flat re-score makes: it sits
-   * outside every pool pass, so it keeps whatever tagged it. A count on
-   * sub-roll subtotals (`{1d20 vs {2d10>=5}, 1d8}>=1`) releases it along with
-   * the rest — its verdicts live on no die, so the tags have to go for
-   * `rendered` to keep describing them. Either way a DC never reaches this
-   * tally.
+   * tags. The DC side of a `vs` is never tallied here; it keeps whatever tags
+   * an inner count gave it, unless the outer count scores subtotals rather
+   * than dice, which leaves every die untagged.
    */
   successes?: number;
   /**


### PR DESCRIPTION
Documents reading `critical`/`fumble` off `DieResult`, then applies a finalizing review pass over everything that landed since v3.0.0 — MIGRATION.md, README.md, and the new source.

## Changes

`docs: document reading crit/fumble and rendering custom markers #293`

- New `Reading crit and fumble` subsection under Rendering: the per-die loop over `result.rolls`, plus the four traps a hand-rolled renderer hits — `'meta'` dice, `'dc'` dice, splicing `rendered` by bracket position, and crit density
- Named `rendered`'s markdown as Discord-flavored, with `renderBreakdown` as the path to another dialect
- Every claim pinned as an executable fence, so `readme.test.ts` fails if the library stops producing it

`docs: add the missing 3.2.0 migration entry and tighten the notes`

- Added the `expression`/`rendered` spacing change from #299, which shipped in 3.2.0 with no migration entry — `4d6 s kh2` normalizes to `4d6s kh2`, so snapshot assertions over either string need re-recording
- Navigation split to one entry per line, matching README's Contents
- Replaced a roll-dependent success/failure tally with a claim that does not depend on the dice
- Rewrote the 3.2.0 summary to lead with the forms that now throw; dropped six repeated import preambles

`docs: group the README contents and restructure known limitations`

- Rebuilt `## Contents` as a grouped two-level index; `Upgrading` no longer sits 14th while living inside Install
- Folded seven overlapping rejection bullets into one table with a `Write instead` column — every rewrite in it was executed before being documented
- Corrected why `{3, 5, 7}>=4` is refused: a counted group needs one die somewhere in it, not "a pool to score", which contradicted the notation table
- Moved the nested-count tag-ownership rule to `RollResult`, where the fields it describes live

`refactor: compact the render module and dedupe crit and subtotal handling`

- Collapsed the duplicated serialization spellings in `render.ts`
- Merged `matchesCrit`/`matchesFumble` into `matchesThreshold`; extracted `evalDiscardingSubtotals`
- Dropped `(#281)` issue references from source comments, per the project comment rules

## Verification

`bun validate` passes on every commit. The refactor was re-reviewed adversarially by Fable and Codex against a behavior-preservation brief: Fable returned no findings; Codex's single finding claimed the `sort` render case switched to `poolOf(part.target)`, which it did not — `src/render.ts:333` renders `part.rolls`, and the property test pinning `renderBreakdown` byte-identical to `RollResult.rendered` still holds.

Closes #293
