### PR TITLE
feat: point whole-number operand errors at the rounding fix #318

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ a running `site:dev` resolves `roll-parser` into it and caches resolution failur
 it cannot recover from; `scripts/prune-dist.ts` deletes what the passes did not
 write, and `bun run clean` (which `release:dry` runs) is the pristine path. Do not
 reintroduce a bundler: Bun ≤1.3.11 breaks pure re-export entrypoints (e.g. `src/testing.ts`) and `--target browser` silently stubs `node:` builtins instead of erroring
-- Byte budgets are a release gate (`check:size`): 12.85 kB `index.js`, 6 kB `{ parse }`, 12.5 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
+- Byte budgets are a release gate (`check:size`): 12.85 kB `index.js`, 6 kB `{ parse }`, 12.75 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
 - `files` ships `src/` deliberately: `.d.ts.map` points consumer go-to-definition at the real sources. Removing it breaks nothing visibly — the jumps just die
 - Relative imports in `src/` carry explicit `.js` extensions — enforced by `moduleResolution: nodenext` at typecheck time
 - Library code must stay environment-neutral: no Node/Bun globals or `node:` imports outside `src/cli/` — enforced by Biome `noNodejsModules`, `types: []` in `tsconfig.build.json`, and the `browser-smoke` CI job

--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,9 @@ total — and the evaluator only flat-sorts.
   `1d6>=(5+2)`, or `{1d6>=5}+2` to add to the count itself.
 - **Division does not floor.** `7/2` totals `3.5`, not `3` — arithmetic is plain
   IEEE-754 throughout. Wrap it when you need an integer: `floor(7/2)` totals `3`.
+  Operands that must be whole numbers — dice count, dice sides, keep/drop count —
+  reject a fraction instead of rounding it for you: `5d(20/3)` throws
+  `INVALID_DICE_SIDES`, `5d(round(20/3))` rolls `5d7`.
 - **The power operator has no overflow guard.** `2**999` totals `5.357…e+300`.
   Only a non-finite result throws `NON_FINITE_RESULT`, so finite-but-enormous
   totals pass through unflagged.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 - **Safe on untrusted input.** Dice count, explosion depth, reroll depth, and
   parse depth are all bounded, and every failure is a typed error with a stable
   code and a source span.
-- **Small and fast.** ≈12.7 kB brotli for the whole library, ≈5.5 kB for just
+- **Small and fast.** ≈12.8 kB brotli for the whole library, ≈5.7 kB for just
   `parse`, ≈1.4 kB for `roll-parser/render`, ≈213 B for the testing entry
   point. Zero runtime dependencies, zero
   `node:` imports. A `1d20` round trip takes about 0.5 µs.

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
       "name": "index.js — { roll }",
       "path": "dist/index.js",
       "import": "{ roll }",
-      "limit": "12.5 kB"
+      "limit": "12.75 kB"
     },
     {
       "name": "render.js — { renderBreakdown }",

--- a/src/evaluator/evaluator.test.ts
+++ b/src/evaluator/evaluator.test.ts
@@ -3324,6 +3324,90 @@ describe('evaluate', () => {
       }
       expect(result.total).toBe(12);
     });
+
+    describe('fractional operands name the rounding fix', () => {
+      const HINT = "(use 'floor', 'ceil', or 'round')";
+
+      test('5d(20/3) reports the fractional sides and the hint', () => {
+        const error = expectRollError(
+          () => evaluate(parse('5d(20/3)'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_DICE_SIDES',
+        );
+
+        expect(error.message).toBe(`Invalid dice sides: 6.666666666666667 ${HINT}`);
+      });
+
+      test('(1/2)d6 reports the fractional count and the hint', () => {
+        const error = expectRollError(
+          () => evaluate(parse('(1/2)d6'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_DICE_COUNT',
+        );
+
+        expect(error.message).toBe(`Invalid dice count: 0.5 ${HINT}`);
+      });
+
+      test('4d6kh(3/2) reports the fractional keep count and the hint', () => {
+        const error = expectRollError(
+          () => evaluate(parse('4d6kh(3/2)'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_KEEP_DROP_COUNT',
+        );
+
+        expect(error.message).toBe(`Invalid keep/drop count: 1.5 ${HINT}`);
+      });
+
+      test('a negative count stays hintless — no rounding rescues it', () => {
+        const error = expectRollError(
+          () => evaluate(parse('(-3/2)d6'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_DICE_COUNT',
+        );
+
+        expect(error.message).toBe('Invalid dice count: -1.5');
+      });
+
+      test('1d0 stays hintless — an integer needs no rounding', () => {
+        const error = expectRollError(
+          () => evaluate(parse('1d0'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_DICE_SIDES',
+        );
+
+        expect(error.message).toBe('Invalid dice sides: 0');
+      });
+
+      test('the message never names a side count that would be accepted', () => {
+        // Truncating the display to a fixed width turned `1.00001` into `1` — a
+        // valid side count, which reads as a library bug rather than a notation
+        // one. The value prints exact for that reason.
+        const error = expectRollError(
+          () => evaluate(parse('5d(100001/100000)'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_DICE_SIDES',
+        );
+
+        expect(error.message).toBe(`Invalid dice sides: 1.00001 ${HINT}`);
+      });
+
+      test('a near-zero fraction is not displayed as zero', () => {
+        const error = expectRollError(
+          () => evaluate(parse('5d(1/100000)'), createMockRng([])),
+          EvaluatorError,
+          'INVALID_DICE_SIDES',
+        );
+
+        expect(error.message).toBe(`Invalid dice sides: 0.00001 ${HINT}`);
+      });
+
+      test('the hinted fix parses and rolls: 5d(round(20/3)) is 5d7', () => {
+        const result = evaluate(parse('5d(round(20/3))'), createMockRng([1, 2, 3, 4, 7]));
+
+        expect(result.rolls.every((die) => die.sides === 7)).toBe(true);
+        expect(result.total).toBe(17);
+      });
+    });
   });
 
   describe('variables', () => {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -207,6 +207,26 @@ function appendAll<T>(target: T[], source: readonly T[]): void {
   }
 }
 
+/**
+ * Message for an operand that has to be a whole number — dice count, dice
+ * sides, keep/drop count. A fractional value there is almost always an
+ * unrounded division (`5d(20/3)`, `4d6kh(3/2)`), and the fix is a function the
+ * notation already carries, so the message names it rather than leaving the
+ * author to find it. Only finite positive values get the hint: no rounding
+ * rescues a negative count or a `NaN`.
+ *
+ * The value prints in full, repeating decimals and all. Shortening it to a
+ * fixed width read better on `20/3` but rounded `1.00001` to `1` — naming a
+ * side count the evaluator accepts, which reads as a bug in the library rather
+ * than in the notation. Exactness is worth more than the digits it costs.
+ */
+function invalidIntegerOperand(label: string, value: number): string {
+  if (Number.isInteger(value) || !Number.isFinite(value) || value <= 0) {
+    return `${label}: ${value}`;
+  }
+  return `${label}: ${value} (use 'floor', 'ceil', or 'round')`;
+}
+
 /** Drops the internal notation `code`, leaving the public `KeepDropSpec` shape. */
 function toPublicSpecs(specs: KeepDropChainEntry[]): KeepDropSpec[] {
   return specs.map(({ code: _code, ...spec }) => spec);
@@ -511,7 +531,11 @@ function evalDiscardingSubtotals(
 /** Rejects dice counts that cannot address a pool. */
 function requireDiceCount(count: number, nodeType: 'Dice' | 'FateDice'): void {
   if (!Number.isInteger(count) || count < 0) {
-    throw new EvaluatorError(`Invalid dice count: ${count}`, 'INVALID_DICE_COUNT', nodeType);
+    throw new EvaluatorError(
+      invalidIntegerOperand('Invalid dice count', count),
+      'INVALID_DICE_COUNT',
+      nodeType,
+    );
   }
 }
 
@@ -564,7 +588,11 @@ function evalDice(node: DiceNode, rng: RNG, ctx: EvalContext, env: EvalEnv): Eva
 
   requireDiceCount(count, 'Dice');
   if (!Number.isInteger(sides) || sides < 1) {
-    throw new EvaluatorError(`Invalid dice sides: ${sides}`, 'INVALID_DICE_SIDES', 'Dice');
+    throw new EvaluatorError(
+      invalidIntegerOperand('Invalid dice sides', sides),
+      'INVALID_DICE_SIDES',
+      'Dice',
+    );
   }
   if (sides > MAX_DICE_SIDES) {
     throw new EvaluatorError(
@@ -952,7 +980,7 @@ function flattenKeepDropChain(
 
     if (!Number.isInteger(modCount) || modCount < 0) {
       throw new EvaluatorError(
-        `Invalid keep/drop count: ${modCount}`,
+        invalidIntegerOperand('Invalid keep/drop count', modCount),
         'INVALID_KEEP_DROP_COUNT',
         'KeepDrop',
       );


### PR DESCRIPTION
Appends `(use 'floor', 'ceil', or 'round')` to the three whole-number operand errors — dice count, dice sides, keep/drop count — so the message names the escape hatch the notation already has.

The hint is limited to finite positive non-integers: `1d0`, negative counts, and non-finite values keep their bare messages, since no rounding rescues them. The displayed value stays exact — shortening it to a fixed decimal width rounded `1.00001` to `1`, naming a side count the evaluator accepts.

The budget bump rides along as its own commit: the hint put `{ roll }` exactly on the 12.5 kB limit, leaving nothing for the next change to the roll path.

Closes #318
