### PR TITLE
feat: point an orphaned fail threshold at the success count #320

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,11 @@ total — and the evaluator only flat-sorts.
   parenthesize for a computed threshold, `1d6!>=(5+2)`. Success counts bind the
   same way but are terminal, so `1d6>=5+2` errors outright — write
   `1d6>=(5+2)`, or `{1d6>=5}+2` to add to the count itself.
+- **An explode claims the comparison that follows it.** `3d6!>4` explodes on
+  5 and 6; it is not a success count, so there is nothing for an `f` clause to
+  attach to and `3d6!>4f1` throws `UNEXPECTED_TOKEN`. Parenthesize the explode
+  to count its pool, `(3d6!)>4f1`, or give the count its own threshold,
+  `3d6!>4>=5f1`.
 - **Division does not floor.** `7/2` totals `3.5`, not `3` — arithmetic is plain
   IEEE-754 throughout. Wrap it when you need an integer: `floor(7/2)` totals `3`.
   Operands that must be whole numbers — dice count, dice sides, keep/drop count —

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1312,6 +1312,38 @@ describe('Parser', () => {
     });
   });
 
+  describe('orphaned fail threshold', () => {
+    it('rejects an explode that took the comparison: 3d6!>4f1 (#320)', () => {
+      const error = expectRollError(() => parseAst('3d6!>4f1'), ParseError, 'UNEXPECTED_TOKEN');
+      expect(error.message).toContain('requires a success count');
+      expect(error.position).toBe(6);
+    });
+
+    it('rejects a fail threshold with no comparison at all: 3d6f1 (#320)', () => {
+      const error = expectRollError(() => parseAst('3d6f1'), ParseError, 'UNEXPECTED_TOKEN');
+      expect(error.message).toContain('requires a success count');
+      expect(error.position).toBe(3);
+    });
+
+    it.each(['10d10!>=6f1', '3d6!!>4f1', '(3d6!>4)f1', '3d6!f1', '3d6r<3f1'])(
+      'rejects orphaned fail threshold: %s (#320)',
+      (notation) => {
+        expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
+      },
+    );
+
+    it('parses the rewrites README offers for 3d6!>4f1 (#320)', () => {
+      // The documented escape hatches — a lie the moment either stops parsing.
+      expect(parseAst('(3d6!)>4f1').type).toBe('SuccessCount');
+      expect(parseAst('3d6!>4>=5f1').type).toBe('SuccessCount');
+    });
+
+    it('leaves a leading f on its own error: f1 (#320)', () => {
+      // NUD position, never LED — `parseLed` is not on this path.
+      expectRollError(() => parseAst('f1'), ParseError, 'UNEXPECTED_TOKEN');
+    });
+  });
+
   describe('success count rejected in meta-expression positions', () => {
     // SuccessCount is terminal at every meta-expression parse site: modifier
     // count, dice sides/count (infix + prefix), Fate/percent dice count,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -395,6 +395,9 @@ export class Parser {
       case TokenType.VS:
         return this.parseVersus(left, token);
 
+      case TokenType.FAIL:
+        return Parser.throwOrphanFailThreshold(token);
+
       default:
         throw new ParseError(
           `Unexpected infix token '${token.value}'`,
@@ -1186,6 +1189,26 @@ export class Parser {
     this.rejectVersusMetaOperand(failValue, token);
 
     return { operator: '=', value: failValue };
+  }
+
+  /**
+   * Rejects an `f` that reached LED position, which means no success count is
+   * there to own it — `parseSuccessCount` consumes its own `f`, so this is the
+   * only way the token surfaces.
+   *
+   * The trigger clause names the cause of nearly every orphan: an explode's
+   * comparison is optional, so `3d6!>4f1` reads as a success count with a botch
+   * threshold when `!` has already spent the `>4`. Naming it unconditionally
+   * keeps this off the `index.js` byte budget; **README.md → Arithmetic and
+   * precedence** carries the two rewrites.
+   */
+  private static throwOrphanFailThreshold(token: Token): never {
+    throw new ParseError(
+      `Fail threshold requires a success count; an explode's comparison is its trigger`,
+      'UNEXPECTED_TOKEN',
+      token.position,
+      token,
+    );
   }
 
   private parseVersus(left: ASTNode, token: Token): VersusNode {


### PR DESCRIPTION
`f` reaching LED position always means no success count is there to own it, since `parseSuccessCount` consumes its own `f`. It previously fell to the `parseLed` default arm and reported `Unexpected infix token 'f'`, which taught nothing about the case that produces it — `3d6!>4f1` and `10d10!>=6f1`, where `!` already claimed the comparison as its explode trigger.

- Added a `TokenType.FAIL` arm to `parseLed` throwing a message that names the missing success count and the explode trigger that consumed the comparison
- Kept the `UNEXPECTED_TOKEN` code and one unconditional string — branching on the left node to tailor the hint overran the 12.85 kB `index.js` budget, which has ~80 B of headroom
- Documented the `(3d6!)>4f1` and `3d6!>4>=5f1` rewrites in the README precedence gotchas
- Covered the orphan paths in `parser.test.ts`, asserting both documented rewrites still parse

Rejected the alternative of re-binding the explode's compare point to a success count on lookahead: it would make `3d6!>4` denote two different ASTs depending on a token three characters later, and bare `10d10!>=6` would still mean "explode on 6 or better".

Closes #320
