### PR TITLE
fix: bring the site palette up to WCAG AA contrast #322

### DIFF
--- a/site/src/style.css
+++ b/site/src/style.css
@@ -54,6 +54,12 @@
  * * Tokens
  */
 
+/* ! Foreground tokens are tuned to clear WCAG AA (4.5:1) against the tightest
+   surface they land on — `--surface-strong`, not `--bg`, since the 7%/9% ink
+   wash sits under the breakdown chips and mini-dice. `--die-stroke` is the one
+   exception: it only ever paints SVG strokes and 1.5px borders, so it answers
+   to the 3:1 graphic bar. Re-measure against `--surface-strong` before
+   lightening any of these. */
 :root {
   --bg: #16120b;
   --bg-glow: #2a2113;
@@ -62,11 +68,11 @@
   --border: rgba(255, 230, 190, 0.15);
   --text: #f0e6d2;
   --text-muted: #b3a583;
-  --text-dim: #7d7259;
+  --text-dim: #9a8d70;
   --accent: #d9a441;
   --accent-soft: rgba(217, 164, 65, 0.4);
   --success: #a3c585;
-  --failure: #cf6a5e;
+  --failure: #d4776b;
   --die-stroke: #8a7d63;
   --gold-gradient: linear-gradient(135deg, #f0c060, #d9a441 45%, #a3622f);
 
@@ -96,13 +102,13 @@
   --border: rgba(43, 35, 23, 0.15);
   --text: #2b2317;
   --text-muted: #6b5d45;
-  --text-dim: #9a8b6f;
-  --accent: #a06b1f;
-  --accent-soft: rgba(160, 107, 31, 0.35);
-  --success: #4f7a3a;
-  --failure: #b04a3e;
+  --text-dim: #6e6049;
+  --accent: #855512;
+  --accent-soft: rgba(133, 85, 18, 0.35);
+  --success: #456b33;
+  --failure: #9c4136;
   --die-stroke: #8a7a5c;
-  --gold-gradient: linear-gradient(135deg, #b8842a, #a06b1f 45%, #7a4a18);
+  --gold-gradient: linear-gradient(135deg, #976d23, #855512 45%, #593611);
 }
 
 @media (prefers-color-scheme: light) {
@@ -114,13 +120,13 @@
     --border: rgba(43, 35, 23, 0.15);
     --text: #2b2317;
     --text-muted: #6b5d45;
-    --text-dim: #9a8b6f;
-    --accent: #a06b1f;
-    --accent-soft: rgba(160, 107, 31, 0.35);
-    --success: #4f7a3a;
-    --failure: #b04a3e;
+    --text-dim: #6e6049;
+    --accent: #855512;
+    --accent-soft: rgba(133, 85, 18, 0.35);
+    --success: #456b33;
+    --failure: #9c4136;
     --die-stroke: #8a7a5c;
-    --gold-gradient: linear-gradient(135deg, #b8842a, #a06b1f 45%, #7a4a18);
+    --gold-gradient: linear-gradient(135deg, #976d23, #855512 45%, #593611);
   }
 }
 
@@ -1191,8 +1197,10 @@ button.die-overflow:hover {
   word-break: break-all;
 }
 
+/* Tint stays at 0.18: `--failure` text sits on this red wash rather than on a
+   surface token, and 0.22 drops it to 4.44 — under AA in both themes. */
 .error-span {
-  background: rgba(207, 106, 94, 0.22);
+  background: rgba(207, 106, 94, 0.18);
   color: var(--failure);
   border-bottom: 2px solid var(--failure);
   border-radius: 2px;


### PR DESCRIPTION
Retunes the site palette so every foreground token clears WCAG AA (4.5:1)
against the tightest surface it actually lands on — `--surface-strong`, the
7%/9% ink wash under the breakdown chips and mini-dice, not `--bg`.

| token              | theme | from      | to        | was  | now  |
| ------------------ | ----- | --------- | --------- | ---- | ---- |
| `--text-dim`       | light | `#9a8b6f` | `#6e6049` | 2.50 | 4.58 |
| `--accent`         | light | `#a06b1f` | `#855512` | 3.40 | 4.76 |
| `--success`        | light | `#4f7a3a` | `#456b33` | 3.76 | 4.62 |
| `--failure`        | light | `#b04a3e` | `#9c4136` | 4.04 | 4.88 |
| `--text-dim`       | dark  | `#7d7259` | `#9a8d70` | 3.17 | 4.59 |
| `--failure`        | dark  | `#cf6a5e` | `#d4776b` | 4.21 | 4.76 |

`--accent-soft` follows `--accent` (same colour, lower alpha), and the light
`--gold-gradient` shifts by the same lightness delta so the hero total clears
the 3:1 large-text bar across all three stops — its leading stop was at 2.81.

`.error-span` needed a separate fix: it is the one place token-coloured text
sits on the red tint rather than on a surface token, and at `0.22` it held
`--failure` to 4.44 in both themes. Dropped to `0.18` — 4.63 light, 4.73 dark.

`--die-stroke` is unchanged. All three of its uses are non-text graphics, so it
answers to the 3:1 bar and its light worst case of 3.13 already clears it.

Both light palette blocks were edited and verified byte-identical, per the
existing sync requirement.

Verified with `bun validate` (all seven stages, 1850 tests) and by eye in the
playground and reference page in both themes.

Deferred, filed separately: #323 (`--border` at 1.33/1.47 fails SC 1.4.11
non-text contrast) and #324 (the five `rgba(207, 106, 94, …)` literals no longer
track `--failure`). The duplicated-light-palette build guard and Biome CSS
coverage remain follow-ups too.

Closes #322
