### PR TITLE
feat: sharpen the messages invalid notation reports #326

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ a running `site:dev` resolves `roll-parser` into it and caches resolution failur
 it cannot recover from; `scripts/prune-dist.ts` deletes what the passes did not
 write, and `bun run clean` (which `release:dry` runs) is the pristine path. Do not
 reintroduce a bundler: Bun ≤1.3.11 breaks pure re-export entrypoints (e.g. `src/testing.ts`) and `--target browser` silently stubs `node:` builtins instead of erroring
-- Byte budgets are a release gate (`check:size`): 13 kB `index.js`, 6 kB `{ parse }`, 12.8 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
+- Byte budgets are a release gate (`check:size`): 13.1 kB `index.js`, 6.1 kB `{ parse }`, 12.9 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
 - `files` ships `src/` deliberately: `.d.ts.map` points consumer go-to-definition at the real sources. Removing it breaks nothing visibly — the jumps just die
 - Relative imports in `src/` carry explicit `.js` extensions — enforced by `moduleResolution: nodenext` at typecheck time
 - Library code must stay environment-neutral: no Node/Bun globals or `node:` imports outside `src/cli/` — enforced by Biome `noNodejsModules`, `types: []` in `tsconfig.build.json`, and the `browser-smoke` CI job

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ a running `site:dev` resolves `roll-parser` into it and caches resolution failur
 it cannot recover from; `scripts/prune-dist.ts` deletes what the passes did not
 write, and `bun run clean` (which `release:dry` runs) is the pristine path. Do not
 reintroduce a bundler: Bun ≤1.3.11 breaks pure re-export entrypoints (e.g. `src/testing.ts`) and `--target browser` silently stubs `node:` builtins instead of erroring
-- Byte budgets are a release gate (`check:size`): 12.85 kB `index.js`, 6 kB `{ parse }`, 12.75 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
+- Byte budgets are a release gate (`check:size`): 13 kB `index.js`, 6 kB `{ parse }`, 12.8 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
 - `files` ships `src/` deliberately: `.d.ts.map` points consumer go-to-definition at the real sources. Removing it breaks nothing visibly — the jumps just die
 - Relative imports in `src/` carry explicit `.js` extensions — enforced by `moduleResolution: nodenext` at typecheck time
 - Library code must stay environment-neutral: no Node/Bun globals or `node:` imports outside `src/cli/` — enforced by Biome `noNodejsModules`, `types: []` in `tsconfig.build.json`, and the `browser-smoke` CI job

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 - **Safe on untrusted input.** Dice count, explosion depth, reroll depth, and
   parse depth are all bounded, and every failure is a typed error with a stable
   code and a source span.
-- **Small and fast.** ≈12.8 kB brotli for the whole library, ≈5.7 kB for just
+- **Small and fast.** ≈13 kB brotli for the whole library, ≈5.9 kB for just
   `parse`, ≈1.4 kB for `roll-parser/render`, ≈213 B for the testing entry
   point. Zero runtime dependencies, zero
   `node:` imports. A `1d20` round trip takes about 0.5 µs.

--- a/package.json
+++ b/package.json
@@ -102,19 +102,19 @@
     {
       "name": "index.js (full library)",
       "path": "dist/index.js",
-      "limit": "13 kB"
+      "limit": "13.1 kB"
     },
     {
       "name": "index.js — { parse }",
       "path": "dist/index.js",
       "import": "{ parse }",
-      "limit": "6 kB"
+      "limit": "6.1 kB"
     },
     {
       "name": "index.js — { roll }",
       "path": "dist/index.js",
       "import": "{ roll }",
-      "limit": "12.8 kB"
+      "limit": "12.9 kB"
     },
     {
       "name": "render.js — { renderBreakdown }",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     {
       "name": "index.js (full library)",
       "path": "dist/index.js",
-      "limit": "12.85 kB"
+      "limit": "13 kB"
     },
     {
       "name": "index.js — { parse }",
@@ -114,7 +114,7 @@
       "name": "index.js — { roll }",
       "path": "dist/index.js",
       "import": "{ roll }",
-      "limit": "12.75 kB"
+      "limit": "12.8 kB"
     },
     {
       "name": "render.js — { renderBreakdown }",

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -334,6 +334,42 @@ describe('roll() integration', () => {
     });
   });
 
+  // The lexer suggests a rewrite when maximal munch merges two modifiers into
+  // one identifier. A suggestion the parser then rejects is worse than none, so
+  // the whole keyword cross-product has to round-trip (#326).
+  describe('merged-modifier hints round-trip', () => {
+    const MODIFIERS = ['kh', 'kl', 'k', 'dh', 'dl', 'min', 'max', 's', 'sa', 'sd', 'cs', 'cf'];
+    // Keep/drop and the die bounds carry an operand of their own; the sort and
+    // crit modifiers do not, so a merge ending in one is already complete.
+    const NEEDS_OPERAND = new Set(['kh', 'kl', 'k', 'dh', 'dl', 'min', 'max']);
+
+    test('every suggested rewrite parses', () => {
+      let hinted = 0;
+
+      for (const first of MODIFIERS) {
+        for (const second of MODIFIERS) {
+          const tail = NEEDS_OPERAND.has(second) ? '2' : '';
+          let message: string;
+          try {
+            parse(`4d6${first}${second}${tail}`);
+            continue;
+          } catch (error) {
+            message = (error as Error).message;
+          }
+
+          const suggestion = message.match(/write it as '([^']*)'/)?.[1];
+          if (suggestion == null) continue;
+          hinted++;
+
+          expect(() => parse(`4d6${suggestion}${tail}`)).not.toThrow();
+        }
+      }
+
+      // Guards the loop itself: a hint that stopped firing would pass vacuously.
+      expect(hinted).toBeGreaterThan(100);
+    });
+  });
+
   describe('syntax variations', () => {
     test('caret is alias for power operator', () => {
       expect(roll('2^3').total).toBe(8);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -334,16 +334,15 @@ describe('roll() integration', () => {
     });
   });
 
-  // The lexer suggests a rewrite when maximal munch merges two modifiers into
-  // one identifier. A suggestion the parser then rejects is worse than none, so
-  // the whole keyword cross-product has to round-trip (#326).
+  // A suggestion the parser rejects is worse than none, so every hint the lexer
+  // can emit has to round-trip.
   describe('merged-modifier hints round-trip', () => {
     const MODIFIERS = ['kh', 'kl', 'k', 'dh', 'dl', 'min', 'max', 's', 'sa', 'sd', 'cs', 'cf'];
     // Keep/drop and the die bounds carry an operand of their own; the sort and
     // crit modifiers do not, so a merge ending in one is already complete.
     const NEEDS_OPERAND = new Set(['kh', 'kl', 'k', 'dh', 'dl', 'min', 'max']);
 
-    test('every suggested rewrite parses', () => {
+    test('every suggested rewrite parses (#326)', () => {
       let hinted = 0;
 
       for (const first of MODIFIERS) {

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -987,8 +987,19 @@ describe('Lexer', () => {
       // rather than a unicode identifier.
       const error = expectRollError(() => lex('@力'), LexerError, 'UNEXPECTED_CHARACTER');
 
-      expect(error.message).toContain('Empty @ variable name');
+      expect(error.message).toContain('must start with');
       expect(error.position).toBe(0);
+    });
+
+    // One check rejects both a missing name and a name that starts wrong, so
+    // calling every one of them "empty" was false for three of the four (#326).
+    it('should say what a bare @ name must start with, not that it is empty', () => {
+      for (const notation of ['@', '1d20+@', '@1', '@力']) {
+        const error = expectRollError(() => lex(notation), LexerError, 'UNEXPECTED_CHARACTER');
+
+        expect(error.message).not.toContain('Empty');
+        expect(error.message).toContain(`must start with a letter or '_'`);
+      }
     });
   });
 

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -901,6 +901,32 @@ describe('Lexer', () => {
     // anything else that looks blank or numeric to a human is an unexpected
     // character, reported at a code-point-accurate position.
 
+    // Escaped rather than pasted: a no-break, zero-width or BOM code point
+    // renders as nothing between the quotes, so the message alone left the
+    // reader no way to tell what was rejected. The code point names it (#326).
+    it('should name code points the message cannot render', () => {
+      const cases: [string, string][] = [
+        ['2d6\u00A0+3', 'U+00A0'],
+        ['2d6\u200B+3', 'U+200B'],
+        ['\uFEFF2d6', 'U+FEFF'],
+        ['\uFF11\uFF44\uFF16', 'U+FF11'],
+      ];
+
+      for (const [notation, codePoint] of cases) {
+        const error = expectRollError(() => lex(notation), LexerError, 'UNEXPECTED_CHARACTER');
+
+        expect(error.message).toContain(codePoint);
+      }
+    });
+
+    // Printable ASCII is legible between the quotes already; naming it there
+    // would be noise on the overwhelmingly common case.
+    it('should not name printable ASCII code points', () => {
+      const error = expectRollError(() => lex('2d6+&'), LexerError, 'UNEXPECTED_CHARACTER');
+
+      expect(error.message).toBe(`Unexpected character: '&'`);
+    });
+
     it('should reject a no-break space as an unexpected character', () => {
       const error = expectRollError(() => lex('2d6 +3'), LexerError, 'UNEXPECTED_CHARACTER');
 

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -852,8 +852,47 @@ describe('Lexer', () => {
       const error = expectRollError(() => lex('4d6sdkh2'), LexerError, 'UNEXPECTED_IDENTIFIER');
 
       expect(error.message).toContain(`did you mean 'sd' followed by 'kh'`);
-      expect(error.message).toContain('sd1kh');
+      expect(error.message).toContain('sd kh');
       expect(error.position).toBe(3);
+    });
+
+    // `sd` takes no count, so the old `sd1kh` suggestion did not parse. A
+    // count-less first half splits on a space instead (#326).
+    it('should split a count-less modifier on a space, not a count', () => {
+      const error = expectRollError(() => lex('4d6sasd'), LexerError, 'UNEXPECTED_IDENTIFIER');
+
+      expect(error.message).toContain(`did you mean 'sa' followed by 'sd'`);
+      expect(error.message).toContain('sa sd');
+      expect(error.message).not.toContain('sa1sd');
+    });
+
+    // The tail has to be a modifier in its own right. `kx` and `flor` merely
+    // start with one, so any split of them is still unparsable (#326).
+    it('should not hint when the tail is not a modifier', () => {
+      for (const notation of ['2d6kx1', 'flor(1.5)', '4d6khsasd']) {
+        const error = expectRollError(() => lex(notation), LexerError, 'UNEXPECTED_IDENTIFIER');
+
+        expect(error.message).not.toContain('did you mean');
+      }
+    });
+
+    // Both keyword tables are keyed by arbitrary user input. Over a plain object
+    // literal, `constructor` resolves up the prototype chain (#326).
+    it('should treat Object.prototype keys as unknown identifiers', () => {
+      const error = expectRollError(() => lex('constructor'), LexerError, 'UNEXPECTED_IDENTIFIER');
+
+      expect(error.character).toBe('constructor');
+    });
+
+    it('should not splat a prototype member into a split hint', () => {
+      const error = expectRollError(
+        () => lex('4d6constructorkh2'),
+        LexerError,
+        'UNEXPECTED_IDENTIFIER',
+      );
+
+      expect(error.message).not.toContain('native code');
+      expect(error.message).not.toContain('did you mean');
     });
   });
 

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -856,9 +856,8 @@ describe('Lexer', () => {
       expect(error.position).toBe(3);
     });
 
-    // `sd` takes no count, so the old `sd1kh` suggestion did not parse. A
-    // count-less first half splits on a space instead (#326).
-    it('should split a count-less modifier on a space, not a count', () => {
+    // `sd` takes no count, so a count-less first half splits on a space.
+    it('should split a count-less modifier on a space, not a count (#326)', () => {
       const error = expectRollError(() => lex('4d6sasd'), LexerError, 'UNEXPECTED_IDENTIFIER');
 
       expect(error.message).toContain(`did you mean 'sa' followed by 'sd'`);
@@ -867,8 +866,8 @@ describe('Lexer', () => {
     });
 
     // The tail has to be a modifier in its own right. `kx` and `flor` merely
-    // start with one, so any split of them is still unparsable (#326).
-    it('should not hint when the tail is not a modifier', () => {
+    // start with one, so any split of them is still unparsable.
+    it('should not hint when the tail is not a modifier (#326)', () => {
       for (const notation of ['2d6kx1', 'flor(1.5)', '4d6khsasd']) {
         const error = expectRollError(() => lex(notation), LexerError, 'UNEXPECTED_IDENTIFIER');
 
@@ -877,14 +876,14 @@ describe('Lexer', () => {
     });
 
     // Both keyword tables are keyed by arbitrary user input. Over a plain object
-    // literal, `constructor` resolves up the prototype chain (#326).
-    it('should treat Object.prototype keys as unknown identifiers', () => {
+    // literal, `constructor` resolves up the prototype chain.
+    it('should treat Object.prototype keys as unknown identifiers (#326)', () => {
       const error = expectRollError(() => lex('constructor'), LexerError, 'UNEXPECTED_IDENTIFIER');
 
       expect(error.character).toBe('constructor');
     });
 
-    it('should not splat a prototype member into a split hint', () => {
+    it('should not splat a prototype member into a split hint (#326)', () => {
       const error = expectRollError(
         () => lex('4d6constructorkh2'),
         LexerError,
@@ -901,10 +900,9 @@ describe('Lexer', () => {
     // anything else that looks blank or numeric to a human is an unexpected
     // character, reported at a code-point-accurate position.
 
-    // Escaped rather than pasted: a no-break, zero-width or BOM code point
-    // renders as nothing between the quotes, so the message alone left the
-    // reader no way to tell what was rejected. The code point names it (#326).
-    it('should name code points the message cannot render', () => {
+    // Escaped rather than pasted — these render as nothing between the quotes,
+    // which is the whole reason the code point has to be named.
+    it('should name code points the message cannot render (#326)', () => {
       const cases: [string, string][] = [
         ['2d6\u00A0+3', 'U+00A0'],
         ['2d6\u200B+3', 'U+200B'],
@@ -991,9 +989,9 @@ describe('Lexer', () => {
       expect(error.position).toBe(0);
     });
 
-    // One check rejects both a missing name and a name that starts wrong, so
-    // calling every one of them "empty" was false for three of the four (#326).
-    it('should say what a bare @ name must start with, not that it is empty', () => {
+    // One check rejects a missing name and a wrongly-started one alike, so the
+    // message has to hold for both.
+    it('should say what a bare @ name must start with, not that it is empty (#326)', () => {
       for (const notation of ['@', '1d20+@', '@1', '@力']) {
         const error = expectRollError(() => lex(notation), LexerError, 'UNEXPECTED_CHARACTER');
 

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -130,6 +130,17 @@ const MODIFIER_SEPARATORS: Record<string, string> = Object.assign(Object.create(
 } satisfies Record<string, string>);
 
 /**
+ * Names a code point the message cannot render. A pasted no-break space, zero-width
+ * space or byte-order mark shows as nothing between the quotes, so the reader is
+ * left an empty pair and no way to tell what was rejected. Printable ASCII is
+ * legible there already and stays unadorned.
+ */
+function nameCodePoint(codePoint: number | undefined): string {
+  if (codePoint == null || (codePoint > 0x20 && codePoint < 0x7f)) return '';
+  return ` (U+${codePoint.toString(16).toUpperCase().padStart(4, '0')})`;
+}
+
+/**
  * Builds a hint for identifiers that merged two modifiers. Maximal munch joins
  * them when the first takes no count — `4d6khs` lexes as one identifier `khs`
  * instead of `kh` + `s` — so the fix is to re-separate them.
@@ -257,7 +268,12 @@ export class Lexer {
         // report the full code point instead of a lone surrogate ('�').
         const codePoint = this.input.codePointAt(startPos);
         const display = codePoint == null ? char : String.fromCodePoint(codePoint);
-        throw new LexerError('Unexpected character', 'UNEXPECTED_CHARACTER', startPos, display);
+        throw new LexerError(
+          `Unexpected character${nameCodePoint(codePoint)}`,
+          'UNEXPECTED_CHARACTER',
+          startPos,
+          display,
+        );
       }
     }
   }

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -384,7 +384,14 @@ export class Lexer {
     } else {
       const nameStart = this.pos;
       if (this.isAtEnd() || !this.isIdentifierStart(this.peek())) {
-        throw new LexerError('Empty @ variable name', 'UNEXPECTED_CHARACTER', startPos, '@');
+        // ! Reached by a missing name and by a name starting with a digit or a
+        // ! non-ASCII letter alike, so the message names the rule, not emptiness.
+        throw new LexerError(
+          `@ variable name must start with a letter or '_'`,
+          'UNEXPECTED_CHARACTER',
+          startPos,
+          '@',
+        );
       }
       this.advance();
       while (!this.isAtEnd() && this.isIdentifierPart(this.peek())) {

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -110,10 +110,9 @@ const IDENTIFIER_KEYWORDS: Record<string, TokenType> = Object.assign(Object.crea
  * not. Membership doubles as the filter — the keywords left out (`d`, `f`, `r`,
  * `ro`, `vs`, the function names) have no split that parses.
  */
-// ! Both halves of a merge are looked up here, so the pair is only ever
-// ! suggested when both are separable. `min`/`max` share `TokenType.FUNCTION`
-// ! with `floor`, so the separator cannot be derived from the token type.
-// ! Null-prototype for the same reason as `IDENTIFIER_KEYWORDS` above.
+// ! `min`/`max` share `TokenType.FUNCTION` with `floor`, so the separator
+// ! cannot be derived from the token type. Null-prototype for the same reason
+// ! as `IDENTIFIER_KEYWORDS` above.
 const MODIFIER_SEPARATORS: Record<string, string> = Object.assign(Object.create(null), {
   kh: '1',
   kl: '1',
@@ -130,10 +129,9 @@ const MODIFIER_SEPARATORS: Record<string, string> = Object.assign(Object.create(
 } satisfies Record<string, string>);
 
 /**
- * Names a code point the message cannot render. A pasted no-break space, zero-width
- * space or byte-order mark shows as nothing between the quotes, so the reader is
- * left an empty pair and no way to tell what was rejected. Printable ASCII is
- * legible there already and stays unadorned.
+ * Names a code point the message cannot render — a no-break space, zero-width
+ * space or byte-order mark shows as nothing between the quotes. Printable ASCII
+ * is legible there already and stays unadorned.
  */
 function nameCodePoint(codePoint: number | undefined): string {
   if (codePoint == null || (codePoint > 0x20 && codePoint < 0x7f)) return '';
@@ -145,9 +143,8 @@ function nameCodePoint(codePoint: number | undefined): string {
  * them when the first takes no count — `4d6khs` lexes as one identifier `khs`
  * instead of `kh` + `s` — so the fix is to re-separate them.
  *
- * Both halves must be separable modifiers. `flor` starts with `f` and `kx`
- * starts with `k`, but neither tail is a modifier, so no split of either parses
- * and the hint stays out of the way.
+ * Both halves must be separable: `flor` and `kx` start with a keyword but end
+ * in something no split can rescue, so they get no hint.
  */
 function buildIdentifierHint(identifier: string): string {
   for (let length = identifier.length - 1; length >= 1; length--) {
@@ -384,8 +381,9 @@ export class Lexer {
     } else {
       const nameStart = this.pos;
       if (this.isAtEnd() || !this.isIdentifierStart(this.peek())) {
-        // ! Reached by a missing name and by a name starting with a digit or a
-        // ! non-ASCII letter alike, so the message names the rule, not emptiness.
+        // Reached by a missing name and by one starting with a digit or a
+        // non-ASCII letter alike, so the message names the rule rather than
+        // any one of those causes.
         throw new LexerError(
           `@ variable name must start with a letter or '_'`,
           'UNEXPECTED_CHARACTER',

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -71,8 +71,14 @@ const CHAR_UPPER_Z = 90;
 const CHAR_LOWER_A = 97;
 const CHAR_LOWER_Z = 122;
 
-/** Known identifier keywords mapped to their token types. */
-const IDENTIFIER_KEYWORDS: Record<string, TokenType> = {
+/**
+ * Known identifier keywords mapped to their token types.
+ *
+ * Null-prototype, because every lookup here is keyed by arbitrary user input.
+ * Over a plain object literal `'constructor'` resolves to `Object`'s own, and
+ * the identifier leaves the lexer as a token whose `type` is a function.
+ */
+const IDENTIFIER_KEYWORDS: Record<string, TokenType> = Object.assign(Object.create(null), {
   kh: TokenType.KEEP_HIGH,
   kl: TokenType.KEEP_LOW,
   k: TokenType.KEEP_HIGH,
@@ -96,20 +102,50 @@ const IDENTIFIER_KEYWORDS: Record<string, TokenType> = {
   sd: TokenType.SORT_DESC,
   cs: TokenType.CRIT_SUCCESS,
   cf: TokenType.CRIT_FAIL,
-};
+} satisfies Record<string, TokenType>);
 
 /**
- * Builds a hint for identifiers that start with a known keyword. Maximal
- * munch merges adjacent modifiers when the first has no count — `4d6khs`
- * lexes as one identifier `khs` instead of `kh` + `s`. Point the user at the
- * explicit-count (or whitespace) split.
+ * Dice-pool modifiers that maximal munch can merge, mapped to what re-separates
+ * them: a count for the ones that take an operand, a space for the ones that do
+ * not. Membership doubles as the filter — the keywords left out (`d`, `f`, `r`,
+ * `ro`, `vs`, the function names) have no split that parses.
+ */
+// ! Both halves of a merge are looked up here, so the pair is only ever
+// ! suggested when both are separable. `min`/`max` share `TokenType.FUNCTION`
+// ! with `floor`, so the separator cannot be derived from the token type.
+// ! Null-prototype for the same reason as `IDENTIFIER_KEYWORDS` above.
+const MODIFIER_SEPARATORS: Record<string, string> = Object.assign(Object.create(null), {
+  kh: '1',
+  kl: '1',
+  k: '1',
+  dh: '1',
+  dl: '1',
+  min: '1',
+  max: '1',
+  s: ' ',
+  sa: ' ',
+  sd: ' ',
+  cs: ' ',
+  cf: ' ',
+} satisfies Record<string, string>);
+
+/**
+ * Builds a hint for identifiers that merged two modifiers. Maximal munch joins
+ * them when the first takes no count — `4d6khs` lexes as one identifier `khs`
+ * instead of `kh` + `s` — so the fix is to re-separate them.
+ *
+ * Both halves must be separable modifiers. `flor` starts with `f` and `kx`
+ * starts with `k`, but neither tail is a modifier, so no split of either parses
+ * and the hint stays out of the way.
  */
 function buildIdentifierHint(identifier: string): string {
   for (let length = identifier.length - 1; length >= 1; length--) {
     const prefix = identifier.slice(0, length);
-    if (IDENTIFIER_KEYWORDS[prefix] == null) continue;
+    const separator = MODIFIER_SEPARATORS[prefix];
+    if (separator == null) continue;
     const rest = identifier.slice(length);
-    return ` (did you mean '${prefix}' followed by '${rest}'? separate modifiers with a count or space, e.g. '${prefix}1${rest}')`;
+    if (MODIFIER_SEPARATORS[rest] == null) continue;
+    return ` (did you mean '${prefix}' followed by '${rest}'? write it as '${prefix}${separator}${rest}')`;
   }
   return '';
 }

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -591,7 +591,7 @@ describe('Parser', () => {
     // `Unexpected infix token '1'` named the digit and used parser jargon; the
     // digit is not the surprise, the modifier it follows is (#326).
     it('should name the count-less modifier rather than the digit', () => {
-      for (const notation of ['2d6s1', '2d6sa1', '2d6sd1', '2d6!0', '2d6!p3', '2d6!!2']) {
+      for (const notation of ['2d6s1', '2d6sa1', '2d6sd1', '2d6!0', '2d6!p3', '2d6cs1', '2d6cf1']) {
         const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
 
         expect(error.message).toBe('This modifier takes no count');

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -591,16 +591,17 @@ describe('Parser', () => {
     // `Unexpected infix token '1'` named the digit and used parser jargon; the
     // digit is not the surprise, the modifier it follows is (#326).
     it('should name the count-less modifier rather than the digit', () => {
-      for (const notation of ['2d6s1', '2d6sa1', '2d6sd1', '2d6cs1', '2d6cf1', '2d6!0', '2d6!p3']) {
+      for (const notation of ['2d6s1', '2d6sa1', '2d6sd1', '2d6!0', '2d6!p3', '2d6!!2']) {
         const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
 
         expect(error.message).toBe('This modifier takes no count');
       }
     });
 
-    // Two juxtaposed values are a different mistake and keep the generic wording.
-    it('should keep the generic message when no modifier precedes the number', () => {
-      for (const notation of ['2d6 3', '1 2']) {
+    // An explode that already took its comparison did not refuse a count, so the
+    // stray number is an unrelated juxtaposition and keeps the generic wording.
+    it('should keep the generic message once the modifier consumed a threshold', () => {
+      for (const notation of ['2d6 3', '1 2', '2d6!>1 2', '2d6!p>4 7', '2d6cs>5 3']) {
         const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
 
         expect(error.message).toContain('Unexpected infix token');

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -1176,6 +1176,30 @@ describe('Parser', () => {
       expectRollError(() => parseAst('10d10>=6>=5'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
     });
 
+    // The rejection covers three shapes, and only one of them is a modifier —
+    // the message has to be true of arithmetic and operand use as well (#326).
+    it('should name terminality rather than a modifier that is often absent', () => {
+      const shapes = [
+        '10d10>=6kh5', // a modifier
+        '5d6>=5+3', // arithmetic
+        '2 * (1d6>=5)', // arithmetic, the count on the right
+        '4d(1d6>=3)', // reused as a meta operand
+        '10d10>=6>=5', // chained
+      ];
+
+      for (const notation of shapes) {
+        const error = expectRollError(
+          () => parseAst(notation),
+          ParseError,
+          'INVALID_SUCCESS_COUNT_TARGET',
+        );
+
+        expect(error.message).toBe(
+          'Success counting is terminal: it cannot be part of a larger expression',
+        );
+      }
+    });
+
     it('should reject non-dice target: 1>=3', () => {
       expectRollError(() => parseAst('1>=3'), ParseError, 'INVALID_SUCCESS_COUNT_TARGET');
     });

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -588,6 +588,25 @@ describe('Parser', () => {
       expect(() => parseAst('kh3')).toThrow(ParseError);
     });
 
+    // `Unexpected infix token '1'` named the digit and used parser jargon; the
+    // digit is not the surprise, the modifier it follows is (#326).
+    it('should name the count-less modifier rather than the digit', () => {
+      for (const notation of ['2d6s1', '2d6sa1', '2d6sd1', '2d6cs1', '2d6cf1', '2d6!0', '2d6!p3']) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
+
+        expect(error.message).toBe('This modifier takes no count');
+      }
+    });
+
+    // Two juxtaposed values are a different mistake and keep the generic wording.
+    it('should keep the generic message when no modifier precedes the number', () => {
+      for (const notation of ['2d6 3', '1 2']) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
+
+        expect(error.message).toContain('Unexpected infix token');
+      }
+    });
+
     it('should name the expected symbol and end of input in expect() errors', () => {
       expect(() => parseAst('((1d6')).toThrow(`Expected ')' but got end of input`);
       expect(() => parseAst('floor 2')).toThrow(`Expected '(' but got '2'`);

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -607,6 +607,15 @@ describe('Parser', () => {
       }
     });
 
+    // `vs` reaching prefix position means nothing is there to be checked against
+    // the DC, which `Unexpected token 'vs'` never said (#326).
+    it('should say versus needs a left-hand roll', () => {
+      const error = expectRollError(() => parseAst('vs 15'), ParseError, 'UNEXPECTED_TOKEN');
+
+      expect(error.message).toBe('Versus needs a roll on its left');
+      expect(error.position).toBe(0);
+    });
+
     it('should name the expected symbol and end of input in expect() errors', () => {
       expect(() => parseAst('((1d6')).toThrow(`Expected ')' but got end of input`);
       expect(() => parseAst('floor 2')).toThrow(`Expected '(' but got '2'`);

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -588,9 +588,8 @@ describe('Parser', () => {
       expect(() => parseAst('kh3')).toThrow(ParseError);
     });
 
-    // `Unexpected infix token '1'` named the digit and used parser jargon; the
-    // digit is not the surprise, the modifier it follows is (#326).
-    it('should name the count-less modifier rather than the digit', () => {
+    // The digit is not the surprise; the modifier it follows is.
+    it('should name the count-less modifier rather than the digit (#326)', () => {
       for (const notation of ['2d6s1', '2d6sa1', '2d6sd1', '2d6!0', '2d6!p3', '2d6cs1', '2d6cf1']) {
         const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
 
@@ -600,7 +599,7 @@ describe('Parser', () => {
 
     // An explode that already took its comparison did not refuse a count, so the
     // stray number is an unrelated juxtaposition and keeps the generic wording.
-    it('should keep the generic message once the modifier consumed a threshold', () => {
+    it('should keep the generic message once the modifier consumed a threshold (#326)', () => {
       for (const notation of ['2d6 3', '1 2', '2d6!>1 2', '2d6!p>4 7', '2d6cs>5 3']) {
         const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
 
@@ -608,9 +607,7 @@ describe('Parser', () => {
       }
     });
 
-    // `vs` reaching prefix position means nothing is there to be checked against
-    // the DC, which `Unexpected token 'vs'` never said (#326).
-    it('should say versus needs a left-hand roll', () => {
+    it('should say versus needs a left-hand roll (#326)', () => {
       const error = expectRollError(() => parseAst('vs 15'), ParseError, 'UNEXPECTED_TOKEN');
 
       expect(error.message).toBe('Versus needs a roll on its left');
@@ -1206,8 +1203,8 @@ describe('Parser', () => {
     });
 
     // The rejection covers three shapes, and only one of them is a modifier —
-    // the message has to be true of arithmetic and operand use as well (#326).
-    it('should name terminality rather than a modifier that is often absent', () => {
+    // the message has to be true of arithmetic and operand use as well.
+    it('should name terminality rather than a modifier that is often absent (#326)', () => {
       const shapes = [
         '10d10>=6kh5', // a modifier
         '5d6>=5+3', // arithmetic
@@ -2274,9 +2271,7 @@ describe('Parser', () => {
         expect(error.message).toContain('Empty group');
       });
 
-      // `{}` named the mistake; `()` fell through to the generic prefix arm and
-      // reported `Unexpected token ')'` at the closer instead (#326).
-      it('should reject empty parentheses the way it rejects an empty group', () => {
+      it('should reject empty parentheses the way it rejects an empty group (#326)', () => {
         const error = expectRollError(() => parseAst('()'), ParseError, 'UNEXPECTED_TOKEN');
 
         expect(error.message).toBe('Empty parentheses');

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -2245,6 +2245,16 @@ describe('Parser', () => {
         expect(error.message).toContain('Empty group');
       });
 
+      // `{}` named the mistake; `()` fell through to the generic prefix arm and
+      // reported `Unexpected token ')'` at the closer instead (#326).
+      it('should reject empty parentheses the way it rejects an empty group', () => {
+        const error = expectRollError(() => parseAst('()'), ParseError, 'UNEXPECTED_TOKEN');
+
+        expect(error.message).toBe('Empty parentheses');
+        // The opener, so the caret lands on the construct rather than its closer.
+        expect(error.position).toBe(0);
+      });
+
       it('should reject unterminated group with EOF', () => {
         const error = expectRollError(() => parseAst('{1d6, 2d8'), ParseError, 'EXPECTED_TOKEN');
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -398,13 +398,30 @@ export class Parser {
       case TokenType.FAIL:
         return Parser.throwOrphanFailThreshold(token);
 
-      default:
+      default: {
+        // A bare number after a modifier that takes none — `2d6s1`, `2d6!0`.
+        // The digit is not the surprise; the modifier it follows is. Explode and
+        // crit thresholds want a comparison here, sort wants nothing; **README.md
+        // → Modifiers** carries the forms.
+        const { type } = left;
+        if (
+          token.type === TokenType.NUMBER &&
+          (type === 'Sort' || type === 'Explode' || type === 'CritThreshold')
+        ) {
+          throw new ParseError(
+            'This modifier takes no count',
+            'UNEXPECTED_TOKEN',
+            token.position,
+            token,
+          );
+        }
         throw new ParseError(
           `Unexpected infix token '${token.value}'`,
           'UNEXPECTED_TOKEN',
           token.position,
           token,
         );
+      }
     }
   }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -419,13 +419,10 @@ export class Parser {
         return Parser.throwOrphanFailThreshold(token);
 
       default: {
-        // A bare number after a modifier that took none — `2d6s1`, `2d6!0`. The
-        // digit is not the surprise; the modifier it follows is.
-        // ! Sort consumes nothing, ever. An explode only qualifies while its
-        // ! threshold is unset — past `2d6!>1 2` the modifier did take a
-        // ! comparison, and the stray number is an unrelated juxtaposition.
-        // ! A crit threshold reads the same way, but through its `'default'`
-        // ! sentinel rather than an empty list — bare `cs` fills the list too.
+        // A bare number after a modifier that took none — `2d6s1`, `2d6!0`.
+        // ! Only while the modifier is still empty-handed: past `2d6!>1 2` the
+        // ! explode did take its comparison, and the stray number is an
+        // ! unrelated juxtaposition that keeps the generic message.
         if (
           token.type === TokenType.NUMBER &&
           (left.type === 'Sort' ||
@@ -558,9 +555,8 @@ export class Parser {
   }
 
   private parseGrouped(token: Token): GroupedNode {
-    // Mirrors `parseGroup`'s empty check. Without it `)` reaches the prefix arm
-    // and reports itself as an unexpected token, naming the closer rather than
-    // the empty construct.
+    // Mirrors `parseGroup`'s empty check; without it `)` reaches the prefix arm
+    // and reports itself, naming the closer rather than the empty construct.
     if (this.peek().type === TokenType.RPAREN) {
       throw new ParseError('Empty parentheses', 'UNEXPECTED_TOKEN', token.position, token);
     }
@@ -708,9 +704,9 @@ export class Parser {
     const node = unwrapGrouped(target);
     if (isSuccessCount(node)) {
       // ! Three shapes reach here and only one is a modifier — arithmetic
-      // ! (`5d6>=5+3`) and meta-operand reuse (`4d(1d6>=3)`) do too. The message
-      // ! names the property all three violate; **README.md → Pools and checks**
-      // ! carries the worked rewrites.
+      // ! (`5d6>=5+3`) and meta-operand reuse (`4d(1d6>=3)`) do too, so the
+      // ! message has to stay true of all three. **README.md → Pools and
+      // ! checks** carries the worked rewrites.
       throw new ParseError(
         `Success counting is terminal: it cannot be part of a larger expression`,
         'INVALID_SUCCESS_COUNT_TARGET',

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -173,6 +173,16 @@ const TOKEN_DISPLAY = {
 type ExpectableToken = keyof typeof TOKEN_DISPLAY;
 
 /**
+ * True while a crit threshold carries only the bare `cs`/`cf` sentinel, so no
+ * comparison was consumed. Emptiness cannot answer this — bare `cs` fills the
+ * list with `'default'` rather than leaving it empty.
+ */
+function isBareCritThreshold(node: CritThresholdNode): boolean {
+  const isDefault = (threshold: CritThreshold): boolean => threshold === 'default';
+  return node.successThresholds.every(isDefault) && node.failThresholds.every(isDefault);
+}
+
+/**
  * Arity table for math functions. `min` and `max` are inclusive.
  * `POSITIVE_INFINITY` means unbounded (variadic).
  */
@@ -414,11 +424,13 @@ export class Parser {
         // ! Sort consumes nothing, ever. An explode only qualifies while its
         // ! threshold is unset — past `2d6!>1 2` the modifier did take a
         // ! comparison, and the stray number is an unrelated juxtaposition.
-        // ! `CritThreshold` is out: bare `cs` still fills its threshold list
-        // ! with a sentinel, so an empty list cannot tell the two apart.
+        // ! A crit threshold reads the same way, but through its `'default'`
+        // ! sentinel rather than an empty list — bare `cs` fills the list too.
         if (
           token.type === TokenType.NUMBER &&
-          (left.type === 'Sort' || (left.type === 'Explode' && left.threshold == null))
+          (left.type === 'Sort' ||
+            (left.type === 'Explode' && left.threshold == null) ||
+            (left.type === 'CritThreshold' && isBareCritThreshold(left)))
         ) {
           throw new ParseError(
             'This modifier takes no count',

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -324,6 +324,16 @@ export class Parser {
       case TokenType.EOF:
         throw new ParseError('Unexpected end of input', 'UNEXPECTED_END', token.position);
 
+      // Reaching prefix position means no roll precedes the `vs`, so there is
+      // nothing to check against the DC.
+      case TokenType.VS:
+        throw new ParseError(
+          'Versus needs a roll on its left',
+          'UNEXPECTED_TOKEN',
+          token.position,
+          token,
+        );
+
       default:
         throw new ParseError(
           `Unexpected token '${token.value}'`,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -517,6 +517,13 @@ export class Parser {
   }
 
   private parseGrouped(token: Token): GroupedNode {
+    // Mirrors `parseGroup`'s empty check. Without it `)` reaches the prefix arm
+    // and reports itself as an unexpected token, naming the closer rather than
+    // the empty construct.
+    if (this.peek().type === TokenType.RPAREN) {
+      throw new ParseError('Empty parentheses', 'UNEXPECTED_TOKEN', token.position, token);
+    }
+
     const expression = this.parseExpression(0);
     const close = this.expect(TokenType.RPAREN);
     return { type: 'Grouped', expression, start: token.position, end: close.end };

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -409,14 +409,16 @@ export class Parser {
         return Parser.throwOrphanFailThreshold(token);
 
       default: {
-        // A bare number after a modifier that takes none — `2d6s1`, `2d6!0`.
-        // The digit is not the surprise; the modifier it follows is. Explode and
-        // crit thresholds want a comparison here, sort wants nothing; **README.md
-        // → Modifiers** carries the forms.
-        const { type } = left;
+        // A bare number after a modifier that took none — `2d6s1`, `2d6!0`. The
+        // digit is not the surprise; the modifier it follows is.
+        // ! Sort consumes nothing, ever. An explode only qualifies while its
+        // ! threshold is unset — past `2d6!>1 2` the modifier did take a
+        // ! comparison, and the stray number is an unrelated juxtaposition.
+        // ! `CritThreshold` is out: bare `cs` still fills its threshold list
+        // ! with a sentinel, so an empty list cannot tell the two apart.
         if (
           token.type === TokenType.NUMBER &&
-          (type === 'Sort' || type === 'Explode' || type === 'CritThreshold')
+          (left.type === 'Sort' || (left.type === 'Explode' && left.threshold == null))
         ) {
           throw new ParseError(
             'This modifier takes no count',

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -659,8 +659,12 @@ export class Parser {
     // never hide inside one and widening the set would never match.
     const node = unwrapGrouped(target);
     if (isSuccessCount(node)) {
+      // ! Three shapes reach here and only one is a modifier — arithmetic
+      // ! (`5d6>=5+3`) and meta-operand reuse (`4d(1d6>=3)`) do too. The message
+      // ! names the property all three violate; **README.md → Pools and checks**
+      // ! carries the worked rewrites.
       throw new ParseError(
-        `Cannot apply modifier after success counting`,
+        `Success counting is terminal: it cannot be part of a larger expression`,
         'INVALID_SUCCESS_COUNT_TARGET',
         token.position,
         token,


### PR DESCRIPTION
Audited the whole rejection surface — all 158 invalid notations the suite feeds to `expectRollError` plus ~110 fresh probes, giving 254 failing inputs across 30 of the 34 codes. 13 findings came out; external review triaged them to 8, and 7 land here. No new error codes, so nothing in this PR forces a minor.

## Changes

`buildIdentifierHint` no longer suggests notation that fails. It is gated on both halves being separable modifiers, and the separator follows whether the first half takes a count — `sd1kh` became `sd kh`, and `flor`/`kx` stopped collecting a split hint no rewrite could satisfy. 87% of the hints it used to emit were unparsable; a round-trip test now asserts all 144 it emits parse.

Both keyword tables carry a null prototype. `4d6constructorkh2` was splatting `function Object() { [native code] }` into the message, and underneath it `lex('constructor')` was a pre-existing bug returning a token whose `type` was the `Object` constructor.

`Cannot apply modifier after success counting` became `Success counting is terminal: it cannot be part of a larger expression` — true of all 28 inputs that reach it, where the old text named a modifier absent from most of them.

`UNEXPECTED_CHARACTER` names the code point when the character is not printable ASCII. A pasted no-break space, zero-width space or BOM rendered as an empty pair of quotes with nothing to identify it.

`Empty @ variable name` became `@ variable name must start with a letter or '_'`. One check rejects a missing name and a wrongly-started one alike, so the old text was false for `@1` and `@力`.

`()` reports `Empty parentheses` at the opener rather than `Unexpected token ')'` at the closer, matching what `{}` already did.

A stray count after a modifier that took none — `2d6s1`, `2d6!0`, `2d6cs1` — reports `This modifier takes no count` instead of the parser jargon `Unexpected infix token '1'`. It fires only where no comparison was consumed, so `2d6!>1 2` and `2d6cs>5 3` keep the generic wording.

`vs 15` reports `Versus needs a roll on its left`.

## Budgets

Two `build:` commits raise `index.js` to 13.1 kB, `{ parse }` to 6.1 kB and `{ roll }` to 12.9 kB, isolated from the feature commits as the size-budget rule requires. Final emit is 13,057 / 5,999 / 12,796 B. The README size claims are refreshed to match.

## Not included

Findings 2, 6, 10, 11 and 13 were dropped as not worth their bytes — the reasoning is recorded on the issue. Finding 4, splitting `UNEXPECTED_END`, is #327: it changes how `parseExpression` passes state to `parseNud`, which is a parsing change rather than a message one. The 25 silently accepted inputs the audit turned up (`2d6min2max1`, `2d6cs>7`, `2d6!<0`) stay accepted; they have coherent deterministic semantics and rejecting them would be policy, not syntax validation.

Closes #326
