### PR TITLE
feat: name what the parser was waiting for at end of input #327

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ a running `site:dev` resolves `roll-parser` into it and caches resolution failur
 it cannot recover from; `scripts/prune-dist.ts` deletes what the passes did not
 write, and `bun run clean` (which `release:dry` runs) is the pristine path. Do not
 reintroduce a bundler: Bun ≤1.3.11 breaks pure re-export entrypoints (e.g. `src/testing.ts`) and `--target browser` silently stubs `node:` builtins instead of erroring
-- Byte budgets are a release gate (`check:size`): 13.1 kB `index.js`, 6.1 kB `{ parse }`, 12.9 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
+- Byte budgets are a release gate (`check:size`): 13.5 kB `index.js`, 6.25 kB `{ parse }`, 13 kB `{ roll }`, 250 B `testing.js` — see `size-limit` in `package.json` before adding surface area. Raising a budget is its own commit, never a line in a feature PR
 - `files` ships `src/` deliberately: `.d.ts.map` points consumer go-to-definition at the real sources. Removing it breaks nothing visibly — the jumps just die
 - Relative imports in `src/` carry explicit `.js` extensions — enforced by `moduleResolution: nodenext` at typecheck time
 - Library code must stay environment-neutral: no Node/Bun globals or `node:` imports outside `src/cli/` — enforced by Biome `noNodejsModules`, `types: []` in `tsconfig.build.json`, and the `browser-smoke` CI job

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 - **Safe on untrusted input.** Dice count, explosion depth, reroll depth, and
   parse depth are all bounded, and every failure is a typed error with a stable
   code and a source span.
-- **Small and fast.** ≈13 kB brotli for the whole library, ≈5.9 kB for just
+- **Small and fast.** ≈13.2 kB brotli for the whole library, ≈6.1 kB for just
   `parse`, ≈1.4 kB for `roll-parser/render`, ≈213 B for the testing entry
   point. Zero runtime dependencies, zero
   `node:` imports. A `1d20` round trip takes about 0.5 µs.

--- a/package.json
+++ b/package.json
@@ -102,19 +102,19 @@
     {
       "name": "index.js (full library)",
       "path": "dist/index.js",
-      "limit": "13.1 kB"
+      "limit": "13.5 kB"
     },
     {
       "name": "index.js — { parse }",
       "path": "dist/index.js",
       "import": "{ parse }",
-      "limit": "6.1 kB"
+      "limit": "6.25 kB"
     },
     {
       "name": "index.js — { roll }",
       "path": "dist/index.js",
       "import": "{ roll }",
-      "limit": "12.9 kB"
+      "limit": "13 kB"
     },
     {
       "name": "render.js — { renderBreakdown }",

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -999,6 +999,25 @@ describe('Lexer', () => {
         expect(error.message).toContain(`must start with a letter or '_'`);
       }
     });
+
+    // The `@` these carry is a span anchor, not the offending text, so quoting
+    // it back reads as noise.
+    it('should not echo the @ back on messages that name a rule (#327)', () => {
+      for (const notation of ['@', '@1', '@{abc']) {
+        const error = expectRollError(() => lex(notation), LexerError, 'UNEXPECTED_CHARACTER');
+
+        expect(error.message).not.toContain(`: '@'`);
+        expect(error.character).toBe('@');
+      }
+    });
+
+    it('should still quote the offending text where it is the whole point (#327)', () => {
+      const character = expectRollError(() => lex('2d6+&'), LexerError, 'UNEXPECTED_CHARACTER');
+      expect(character.message).toBe(`Unexpected character: '&'`);
+
+      const identifier = expectRollError(() => lex('1d6mi'), LexerError, 'UNEXPECTED_IDENTIFIER');
+      expect(identifier.message).toBe(`Unexpected identifier: 'mi'`);
+    });
   });
 
   describe('non-string input', () => {

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -41,6 +41,9 @@ export class LexerError extends RollParserError {
    * The offending text — a single character for `UNEXPECTED_CHARACTER` (the
    * whole code point, so astral symbols are not split into surrogates), or
    * the unrecognized word for `UNEXPECTED_IDENTIFIER`.
+   *
+   * Not guaranteed to appear in `message` — errors that name a rule rather than
+   * a character leave it out.
    */
   readonly character: string;
 
@@ -51,7 +54,7 @@ export class LexerError extends RollParserError {
     character: string,
     options?: ErrorOptions,
   ) {
-    super(`${message}: '${character}'`, code, options);
+    super(message, code, options);
     this.name = 'LexerError';
     this.position = position;
     this.character = character;
@@ -266,7 +269,7 @@ export class Lexer {
         const codePoint = this.input.codePointAt(startPos);
         const display = codePoint == null ? char : String.fromCodePoint(codePoint);
         throw new LexerError(
-          `Unexpected character${nameCodePoint(codePoint)}`,
+          `Unexpected character${nameCodePoint(codePoint)}: '${display}'`,
           'UNEXPECTED_CHARACTER',
           startPos,
           display,
@@ -343,7 +346,7 @@ export class Lexer {
     }
 
     throw new LexerError(
-      `Unexpected identifier${buildIdentifierHint(lower)}`,
+      `Unexpected identifier${buildIdentifierHint(lower)}: '${lower}'`,
       'UNEXPECTED_IDENTIFIER',
       startPos,
       lower,

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -607,6 +607,96 @@ describe('Parser', () => {
       }
     });
 
+    // The modifier the stray number follows is never the outermost node here,
+    // so the arithmetic between them has to be seen through.
+    it('names the count-less modifier through a wrapping expression (#327)', () => {
+      for (const notation of ['1+2d6s1', '-2d6s1', '1d20 vs 2d6s1', '1+2d6!0', '1+2d6cs1']) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
+
+        expect(error.message).toBe('This modifier takes no count');
+      }
+    });
+
+    it('keeps the generic message through a wrapper when a threshold was taken (#327)', () => {
+      for (const notation of ['1+2d6!>1 2', '1+2d6cs>5 3', '1+2d6kh1 2', '1+2d6 2']) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
+
+        expect(error.message).toContain('Unexpected infix token');
+      }
+    });
+
+    // A closer ends the construct, so the stray number follows the group, the
+    // call, or the die — not the modifier still inside it.
+    it('stops the search at a closing delimiter (#327)', () => {
+      const closed = [
+        '(2d6s)1',
+        '{2d6s}1',
+        '{1,2d6s}1',
+        'floor(2d6s)1',
+        'max(1,2d6s)1',
+        '2d(2d6s)1',
+        '4d6kh(2d6s)1',
+        '2d6>=(2d6s)1',
+      ];
+
+      for (const notation of closed) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_TOKEN');
+
+        expect(error.message).toContain('Unexpected infix token');
+      }
+    });
+
+    it('should call an empty notation empty rather than truncated (#327)', () => {
+      for (const notation of ['', '   ']) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_END');
+
+        expect(error.message).toBe('Empty notation');
+      }
+    });
+
+    it('should name the operand a truncated notation still owes (#327)', () => {
+      const cases: [string, string][] = [
+        ['d', `Expected a side count after 'd'`],
+        ['1d', `Expected a side count after 'd'`],
+        ['6d', `Expected a side count after 'd'`],
+        ['1d20 vs', `Expected a difficulty class after 'vs'`],
+        ['1d6+', `Expected a value after '+'`],
+        ['2**', `Expected a value after '**'`],
+        ['1d%%', `Expected a value after '%'`],
+        ['-', `Expected a value after '-'`],
+        ['2d6r<', `Expected a value after '<'`],
+        ['2d6r>', `Expected a value after '>'`],
+        ['2d6r=', `Expected a value after '='`],
+        ['2d6>', `Expected a value after '>'`],
+        ['2d6>=', `Expected a value after '>='`],
+        ['2d6cs>', `Expected a value after '>'`],
+        ['2d6!>', `Expected a value after '>'`],
+        // The `f` is what the notation stops on, not the `>=` behind it.
+        ['2d6>=4f', `Expected a value after 'f'`],
+        ['(', `Expected a value after '('`],
+        ['{', `Expected a value after '{'`],
+        ['{1,', `Expected a value after ','`],
+        ['floor(', `Expected a value after '('`],
+        ['floor(1,', `Expected a value after ','`],
+      ];
+
+      for (const [notation, message] of cases) {
+        const error = expectRollError(() => parseAst(notation), ParseError, 'UNEXPECTED_END');
+
+        expect(error.message).toBe(message);
+      }
+    });
+
+    // Typing further into a comparison used to downgrade the diagnosis from
+    // naming the `r` to the generic end-of-input message.
+    it('should not lose specificity as a comparison is typed out (#327)', () => {
+      const partial = expectRollError(() => parseAst('2d6r'), ParseError, 'EXPECTED_TOKEN');
+      expect(partial.message).toBe(`Expected comparison operator after 'r'`);
+
+      const further = expectRollError(() => parseAst('2d6r<'), ParseError, 'UNEXPECTED_END');
+      expect(further.message).toBe(`Expected a value after '<'`);
+    });
+
     it('should say versus needs a left-hand roll (#326)', () => {
       const error = expectRollError(() => parseAst('vs 15'), ParseError, 'UNEXPECTED_TOKEN');
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -183,6 +183,45 @@ function isBareCritThreshold(node: CritThresholdNode): boolean {
 }
 
 /**
+ * Follows a node down to the one whose source text the next token abuts.
+ *
+ * In `1+2d6s1` the sort is already buried under the `+` by the time the stray
+ * `1` reaches LED position.
+ *
+ * ! Only these three descend. Every other node that holds a sub-expression
+ * ! closes it first — `(…)`, `{…}`, `f(…)`, and the parenthesized operand of
+ * ! `2d(…)` or `4d6kh(…)` all put a delimiter between the child and the stray
+ * ! token, so the child is not what that token follows.
+ */
+function rightmostNode(node: ASTNode): ASTNode {
+  let current = node;
+  for (;;) {
+    switch (current.type) {
+      case 'BinaryOp':
+        current = current.right;
+        break;
+      case 'UnaryOp':
+        current = current.operand;
+        break;
+      case 'Versus':
+        current = current.dc;
+        break;
+      default:
+        return current;
+    }
+  }
+}
+
+/**
+ * Names the operand a token was still waiting for when the notation ran out.
+ */
+function expectedOperand(token: Token): string {
+  if (token.type === TokenType.DICE) return 'a side count';
+  if (token.type === TokenType.VS) return 'a difficulty class';
+  return 'a value';
+}
+
+/**
  * Arity table for math functions. `min` and `max` are inclusive.
  * `POSITIVE_INFINITY` means unbounded (variadic).
  */
@@ -230,11 +269,9 @@ export class Parser {
    * Parse the token stream into an AST.
    */
   parse(): ASTNode {
-    if (this.peek().type === TokenType.EOF) {
-      throw new ParseError('Unexpected end of input', 'UNEXPECTED_END', this.peek().position);
-    }
-
-    const ast = this.parseExpression(0);
+    // Nothing has demanded an operand yet, so an immediate EOF is an empty
+    // notation rather than a truncated one.
+    const ast = this.parseExpression(0, undefined);
 
     if (this.peek().type !== TokenType.EOF) {
       const token = this.peek();
@@ -251,14 +288,18 @@ export class Parser {
 
   /**
    * Parse an expression with minimum binding power.
+   *
+   * `pending` is the token that demanded this operand — the `d` of `1d`, the
+   * `<` of `2d6r<`. It exists so a truncated notation can name what it was
+   * waiting for; `undefined` only at the top of the input.
    */
-  private parseExpression(minBp: number): ASTNode {
+  private parseExpression(minBp: number, pending: Token | undefined): ASTNode {
     const entryDepth = this.depth;
     this.depth += 1;
     this.guardDepth();
 
     try {
-      let left = this.parseNud();
+      let left = this.parseNud(pending);
 
       while (this.hasTokens()) {
         const token = this.peek();
@@ -300,7 +341,7 @@ export class Parser {
    * NUD - Null Denotation.
    * Handles tokens that appear at the start of an expression (prefix position).
    */
-  private parseNud(): ASTNode {
+  private parseNud(pending: Token | undefined): ASTNode {
     const token = this.advance();
 
     switch (token.type) {
@@ -332,7 +373,13 @@ export class Parser {
         return this.parseVariable(token);
 
       case TokenType.EOF:
-        throw new ParseError('Unexpected end of input', 'UNEXPECTED_END', token.position);
+        throw new ParseError(
+          pending == null
+            ? 'Empty notation'
+            : `Expected ${expectedOperand(pending)} after '${pending.value}'`,
+          'UNEXPECTED_END',
+          token.position,
+        );
 
       // Reaching prefix position means no roll precedes the `vs`, so there is
       // nothing to check against the DC.
@@ -423,11 +470,12 @@ export class Parser {
         // ! Only while the modifier is still empty-handed: past `2d6!>1 2` the
         // ! explode did take its comparison, and the stray number is an
         // ! unrelated juxtaposition that keeps the generic message.
+        const trailing = rightmostNode(left);
         if (
           token.type === TokenType.NUMBER &&
-          (left.type === 'Sort' ||
-            (left.type === 'Explode' && left.threshold == null) ||
-            (left.type === 'CritThreshold' && isBareCritThreshold(left)))
+          (trailing.type === 'Sort' ||
+            (trailing.type === 'Explode' && trailing.threshold == null) ||
+            (trailing.type === 'CritThreshold' && isBareCritThreshold(trailing)))
         ) {
           throw new ParseError(
             'This modifier takes no count',
@@ -468,7 +516,7 @@ export class Parser {
   }
 
   private parseUnaryMinus(token: Token): UnaryOpNode {
-    const operand = this.parseExpression(BP.UNARY);
+    const operand = this.parseExpression(BP.UNARY, token);
     this.rejectSuccessCountTarget(operand, token);
     return {
       type: 'UnaryOp',
@@ -480,7 +528,7 @@ export class Parser {
   }
 
   private parsePrefixDice(token: Token): DiceNode {
-    const sides = this.parseExpression(BP.DICE_RIGHT);
+    const sides = this.parseExpression(BP.DICE_RIGHT, token);
     this.rejectSuccessCountTarget(sides, token);
     this.rejectVersusMetaOperand(sides, token);
     return {
@@ -496,7 +544,7 @@ export class Parser {
     this.rejectSuccessCountTarget(left, token);
     this.rejectVersusMetaOperand(left, token);
     this.rejectBareDiceChain(left, token);
-    const sides = this.parseExpression(BP.DICE_RIGHT);
+    const sides = this.parseExpression(BP.DICE_RIGHT, token);
     this.rejectSuccessCountTarget(sides, token);
     this.rejectVersusMetaOperand(sides, token);
     return {
@@ -561,7 +609,7 @@ export class Parser {
       throw new ParseError('Empty parentheses', 'UNEXPECTED_TOKEN', token.position, token);
     }
 
-    const expression = this.parseExpression(0);
+    const expression = this.parseExpression(0, token);
     const close = this.expect(TokenType.RPAREN);
     return { type: 'Grouped', expression, start: token.position, end: close.end };
   }
@@ -574,10 +622,10 @@ export class Parser {
       throw new ParseError('Empty group', 'UNEXPECTED_TOKEN', startToken.position, startToken);
     }
 
-    const expressions: ASTNode[] = [this.parseExpression(0)];
+    const expressions: ASTNode[] = [this.parseExpression(0, startToken)];
     while (this.peek().type === TokenType.COMMA) {
-      this.advance();
-      expressions.push(this.parseExpression(0));
+      const comma = this.advance();
+      expressions.push(this.parseExpression(0, comma));
     }
 
     if (this.peek().type !== TokenType.RBRACE) {
@@ -601,16 +649,16 @@ export class Parser {
   private parseFunctionCall(token: Token): FunctionCallNode {
     // `FUNCTION`, `COMMA`, and `RPAREN` all sit at BP -1, so argument boundaries
     // fall out of the inner `parseExpression(0)` calls terminating on their own.
-    this.expect(TokenType.LPAREN);
+    const open = this.expect(TokenType.LPAREN);
 
     const args: ASTNode[] = [];
     if (this.peek().type !== TokenType.RPAREN) {
-      const first = this.parseExpression(0);
+      const first = this.parseExpression(0, open);
       this.rejectSuccessCountTarget(first, token);
       args.push(first);
       while (this.peek().type === TokenType.COMMA) {
-        this.advance();
-        const next = this.parseExpression(0);
+        const comma = this.advance();
+        const next = this.parseExpression(0, comma);
         this.rejectSuccessCountTarget(next, token);
         args.push(next);
       }
@@ -654,7 +702,7 @@ export class Parser {
 
     const operator = this.getOperatorSymbol(token);
     const rightBp = this.getRightBp(token);
-    const right = this.parseExpression(rightBp);
+    const right = this.parseExpression(rightBp, token);
 
     this.rejectSuccessCountTarget(right, token);
 
@@ -868,7 +916,7 @@ export class Parser {
       nextToken === TokenType.LPAREN ||
       nextToken === TokenType.AT;
     const count: ASTNode = hasExplicitCount
-      ? this.parseExpression(BP.DICE_LEFT)
+      ? this.parseExpression(BP.DICE_LEFT, token)
       : Parser.syntheticLiteral(1, token);
     this.rejectSuccessCountTarget(count, token);
     this.rejectVersusMetaOperand(count, token);
@@ -1030,7 +1078,7 @@ export class Parser {
       );
     }
 
-    const value = this.parseExpression(BP.DICE_LEFT);
+    const value = this.parseExpression(BP.DICE_LEFT, token);
     this.rejectSuccessCountTarget(value, token);
     this.rejectVersusMetaOperand(value, token);
 
@@ -1204,7 +1252,7 @@ export class Parser {
 
     const operator = this.getCompareOp(token);
     // Threshold binds at `BP.DICE_LEFT` — see `parseComparePoint` TSDoc.
-    const value = this.parseExpression(BP.DICE_LEFT);
+    const value = this.parseExpression(BP.DICE_LEFT, token);
     this.rejectSuccessCountTarget(value, token);
     this.rejectVersusMetaOperand(value, token);
     const start = target.start ?? token.position;
@@ -1214,8 +1262,8 @@ export class Parser {
       return { type: 'SuccessCount', target, threshold: { operator, value }, start, end };
     }
 
-    this.advance();
-    const failThreshold = this.parseFailThreshold(token);
+    const failToken = this.advance();
+    const failThreshold = this.parseFailThreshold(token, failToken);
 
     return {
       type: 'SuccessCount',
@@ -1227,12 +1275,18 @@ export class Parser {
     };
   }
 
-  /** Parses the `f...` suffix of a success count. Bare `fN` means `f=N`. */
-  private parseFailThreshold(token: Token): ComparePoint {
+  /**
+   * Parses the `f...` suffix of a success count. Bare `fN` means `f=N`.
+   *
+   * `token` is the success-count comparison, which the reject calls report
+   * against; `failToken` is the `f`, so a truncated `2d6>=4f` names it rather
+   * than the comparison behind it.
+   */
+  private parseFailThreshold(token: Token, failToken: Token): ComparePoint {
     if (this.isComparePointAhead()) return this.parseComparePoint();
 
     // Same threshold binding as `parseComparePoint` (BP.DICE_LEFT).
-    const failValue = this.parseExpression(BP.DICE_LEFT);
+    const failValue = this.parseExpression(BP.DICE_LEFT, failToken);
     this.rejectSuccessCountTarget(failValue, token);
     this.rejectVersusMetaOperand(failValue, token);
 
@@ -1274,7 +1328,7 @@ export class Parser {
       throw new ParseError('Cannot chain versus operators', 'NESTED_VERSUS', token.position, token);
     }
 
-    const dc = this.parseExpression(BP.VS_RIGHT);
+    const dc = this.parseExpression(BP.VS_RIGHT, token);
     this.rejectSuccessCountTarget(dc, token);
 
     return {
@@ -1324,7 +1378,7 @@ export class Parser {
 
     this.advance();
 
-    const value = this.parseExpression(BP.DICE_LEFT);
+    const value = this.parseExpression(BP.DICE_LEFT, token);
     this.rejectSuccessCountTarget(value, token);
     this.rejectVersusMetaOperand(value, token);
 


### PR DESCRIPTION
Threads the token that demanded an operand from `parseExpression` into `parseNud`, so the `EOF` arm names what the notation still owed instead of reporting `Unexpected end of input` for all 20 truncated inputs.

- `2d6r<` / `2d6>=` / `2d6cs>` → `Expected a value after '<'`
- `1d20 vs` → `Expected a difficulty class after 'vs'`
- `d` / `1d` / `6d` → `Expected a side count after 'd'`
- `''` / `'   '` → `Empty notation`

`pending` is a required parameter, so the compiler enumerates every call site rather than letting a missed one degrade to the generic message. `parse()`'s own `EOF` pre-check is gone — the `pending === undefined` branch covers empty input at the same position, which keeps both branches reachable.

Fixes the `2d6r` → `2d6r<` downgrade: typing further into a comparison no longer makes the diagnosis worse.

Resolves the count-less-modifier check down the right spine of `BinaryOp`, `UnaryOp` and `Versus`, fixing the `1+2d6s1` false negative. The walk stops at any closer — after `)` or `}` the stray token follows the group, the call or the die, not the modifier still inside it, so `2d(2d6s)1` and `4d6kh(2d6s)1` keep the generic message.

Stops `LexerError` appending `: '<character>'` unconditionally and moves it to the two messages that quote the offending text, so the `@` rules no longer echo an `@` that is only a span anchor. `Unexpected character: '&'` is unchanged.

`UNEXPECTED_END` is retained; no error code was added or removed. Byte budgets are raised in their own commit: `index.js` to 13.5 kB, `{ parse }` to 6.25 kB, `{ roll }` to 13 kB, measuring 13,155 / 6,082 / 12,914.

Closes #327
