### PR TITLE
fix: raise --border to meet WCAG non-text contrast #323

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -20,7 +20,7 @@
       :root {
         --bg: #16120b;
         --bg-glow: #2a2113;
-        --border: rgba(255, 230, 190, 0.15);
+        --border: rgba(255, 230, 190, 0.45);
         --text: #f0e6d2;
         --text-muted: #b3a583;
         --accent: #d9a441;
@@ -28,7 +28,7 @@
       :root[data-theme='light'] {
         --bg: #f5ecdb;
         --bg-glow: #fffaf0;
-        --border: rgba(43, 35, 23, 0.15);
+        --border: rgba(43, 35, 23, 0.55);
         --text: #2b2317;
         --text-muted: #6b5d45;
         --accent: #a06b1f;
@@ -37,7 +37,7 @@
         :root:not([data-theme='dark']):not([data-theme='light']) {
           --bg: #f5ecdb;
           --bg-glow: #fffaf0;
-          --border: rgba(43, 35, 23, 0.15);
+          --border: rgba(43, 35, 23, 0.55);
           --text: #2b2317;
           --text-muted: #6b5d45;
           --accent: #a06b1f;

--- a/site/src/reference.css
+++ b/site/src/reference.css
@@ -236,7 +236,7 @@
 
 .widget:hover {
   transform: translateY(-3px);
-  border-color: var(--accent-soft);
+  border-color: var(--accent);
   background: var(--surface-strong);
 }
 

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -56,16 +56,17 @@
 
 /* ! Foreground tokens are tuned to clear WCAG AA (4.5:1) against the tightest
    surface they land on — `--surface-strong`, not `--bg`, since the 7%/9% ink
-   wash sits under the breakdown chips and mini-dice. `--die-stroke` is the one
-   exception: it only ever paints SVG strokes and 1.5px borders, so it answers
-   to the 3:1 graphic bar. Re-measure against `--surface-strong` before
-   lightening any of these. */
+   wash sits under the breakdown chips and mini-dice. `--die-stroke` and
+   `--border` answer to the 3:1 non-text bar instead: they only paint strokes
+   and component edges. The `--surface` washes carry none of that bar, so
+   `--border` is measured composited over every fill it lands on, not just
+   `--bg`. Re-measure before weakening any of these. */
 :root {
   --bg: #16120b;
   --bg-glow: #2a2113;
   --surface: rgba(255, 240, 210, 0.05);
   --surface-strong: rgba(255, 240, 210, 0.09);
-  --border: rgba(255, 230, 190, 0.15);
+  --border: rgba(255, 230, 190, 0.45);
   --text: #f0e6d2;
   --text-muted: #b3a583;
   --text-dim: #9a8d70;
@@ -99,7 +100,7 @@
   --bg-glow: #fffaf0;
   --surface: rgba(43, 35, 23, 0.04);
   --surface-strong: rgba(43, 35, 23, 0.07);
-  --border: rgba(43, 35, 23, 0.15);
+  --border: rgba(43, 35, 23, 0.55);
   --text: #2b2317;
   --text-muted: #6b5d45;
   --text-dim: #6e6049;
@@ -117,7 +118,7 @@
     --bg-glow: #fffaf0;
     --surface: rgba(43, 35, 23, 0.04);
     --surface-strong: rgba(43, 35, 23, 0.07);
-    --border: rgba(43, 35, 23, 0.15);
+    --border: rgba(43, 35, 23, 0.55);
     --text: #2b2317;
     --text-muted: #6b5d45;
     --text-dim: #6e6049;


### PR DESCRIPTION
## Changes

- Raised `--border` to `0.45` in the dark palette and `0.55` in both light blocks of `site/src/style.css`, clearing SC 1.4.11's 3:1 on every fill it lands on — 3.37 dark and 3.30 light at the tightest adjacency, up from 1.47 and 1.33 against `--bg`
- Mirrored the same three values into `site/404.html`, whose inline palette carries a written contract to stay in sync with `style.css`
- Moved `.widget:hover` from `--accent-soft` to `--accent` — at 2.25 dark and 1.60 light over `--surface-strong` the soft tint now composites fainter than the resting border, so hover read as a de-emphasis
- Named `--border` alongside `--die-stroke` in the token contract note as answering the 3:1 non-text bar rather than the 4.5:1 text bar

The two themes take different alphas because their base inks reach 3:1 at different rates against their own backgrounds. `--surface` was checked as the alternative lever and rejected — carrying the boundary on the fill would mean it stops being a 4-9% wash, a far larger change than a heavier hairline, and SC 1.4.11 is met by either cue alone.

Closes #323
