### PR TITLE
fix: sync the 404 accent token with the light palette #322

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -31,7 +31,7 @@
         --border: rgba(43, 35, 23, 0.55);
         --text: #2b2317;
         --text-muted: #6b5d45;
-        --accent: #a06b1f;
+        --accent: #855512;
       }
       @media (prefers-color-scheme: light) {
         :root:not([data-theme='dark']):not([data-theme='light']) {
@@ -40,7 +40,7 @@
           --border: rgba(43, 35, 23, 0.55);
           --text: #2b2317;
           --text-muted: #6b5d45;
-          --accent: #a06b1f;
+          --accent: #855512;
         }
       }
 


### PR DESCRIPTION
## Changes

- Replaced the stale `#a06b1f` with `#855512` in both light blocks of `site/404.html`, the pre-#322 value its inline palette kept while `style.css` moved on
- Lifts the `code` span and the link hover/focus colour from 3.88 to 5.42 against the page's own gradient, clearing AA's 4.5:1 — the `.die` stroke cleared the 3:1 graphic bar at either value

Follow-up to #322, which retuned the palette in `site/src/style.css` but not the copy `site/404.html` inlines under its "keep the two in sync" contract. Surfaced by the review on #323, which fixed `--border` in the same three blocks. The remaining five mirrored tokens already matched in both themes, so this closes the last gap in that contract.
