### PR TITLE
refactor: derive the failure tints from --failure #324

### DIFF
--- a/site/src/style.css
+++ b/site/src/style.css
@@ -350,7 +350,7 @@ body {
 }
 
 .die.is-fumble .die-shape {
-  fill: rgba(207, 106, 94, 0.18);
+  fill: color-mix(in srgb, var(--failure) 18%, transparent);
 }
 
 .die.is-critical {
@@ -594,7 +594,7 @@ button.die-overflow:hover {
 
 .mini-die.is-fumble {
   border-color: var(--failure);
-  background: rgba(207, 106, 94, 0.18);
+  background: color-mix(in srgb, var(--failure) 18%, transparent);
 }
 
 .mini-die.is-dropped {
@@ -722,7 +722,7 @@ button.die-overflow:hover {
 
 .lg-sample.is-fumble {
   border-color: var(--failure);
-  background: rgba(207, 106, 94, 0.18);
+  background: color-mix(in srgb, var(--failure) 18%, transparent);
 }
 
 .lg-sample.is-success {
@@ -1083,7 +1083,7 @@ button.die-overflow:hover {
 
 .notation-input.is-invalid {
   border-color: var(--failure);
-  box-shadow: 0 0 0 2px rgba(207, 106, 94, 0.4);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--failure) 40%, transparent);
 }
 
 .copied-flag {
@@ -1198,10 +1198,11 @@ button.die-overflow:hover {
   word-break: break-all;
 }
 
-/* Tint stays at 0.18: `--failure` text sits on this red wash rather than on a
-   surface token, and 0.22 drops it to 4.44 — under AA in both themes. */
+/* ! `--failure` text sits on this wash, so the tint eats its own contrast.
+   Measured over `--bg`, 14% holds 4.93 dark / 4.55 light; 18% drops the light
+   theme to 4.29, under AA. Re-measure before raising it. */
 .error-span {
-  background: rgba(207, 106, 94, 0.18);
+  background: color-mix(in srgb, var(--failure) 14%, transparent);
   color: var(--failure);
   border-bottom: 2px solid var(--failure);
   border-radius: 2px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,16 +3,13 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "nodenext",
-    "moduleResolution": "nodenext",
     "lib": ["ES2022"],
     "types": ["@types/bun"],
 
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
     "noUnusedLocals": true,


### PR DESCRIPTION
Replaced the five `rgba(207, 106, 94, …)` literals in `site/src/style.css` with `color-mix(in srgb, var(--failure) <n>%, transparent)`, so the three fumble tints, the invalid-input ring, and the `.error-span` wash follow the token in both themes instead of painting the pre-#322 dark red under the light palette. Alphas stay distinct: 18% on the tints, 40% on the ring.

Dropped the `.error-span` wash to 14% — the re-measurement the issue asks for. On the light token the old 18% measures 4.29 over `--bg`, under AA; 14% holds 4.93 dark / 4.55 light. Its comment now names that measurement basis.

Carries a second, unrelated commit dropping three `tsconfig.json` options that `module: nodenext` already implies under TypeScript 7.

Known gap, not addressed here: a die that is both a fumble and a failure renders a `.mini-die` with `--failure` text on the `--failure` wash. Inside a `.grp` chip (`background: var(--surface)`) that pair is under AA at every plausible alpha — 4.38 even with no wash at all in the dark glow region — so the cause is the token against `--surface`, not the tint. Pre-existing and unchanged by this PR; worth its own issue alongside the #322 token work.

Closes #324
