### PR TITLE
chore: sharpen npm discoverability metadata #333

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Dice notation for tabletop RPGs, rolled into structured results.
   <a href="https://github.com/edloidas/roll-parser/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/edloidas/roll-parser/ci.yml?branch=master&label=CI" alt="CI status"></a>
   <a href="https://github.com/edloidas/roll-parser/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/roll-parser?color=blue" alt="MIT license"></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/node/v/roll-parser?color=5fa04e" alt="Node.js >= 22.12"></a>
+  <a href="https://github.com/edloidas/roll-parser#why-roll-parser"><img src="https://img.shields.io/badge/min%2Bbrotli-%E2%89%A413.5%20kB-8b5cf6" alt="min+brotli ≤13.5 kB"></a>
 </p>
 
 <p align="center">
@@ -51,11 +52,11 @@ roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) }).total; // 14, every run
 
 ## Why roll-parser
 
-- **Complete notation.** Keep/drop, three flavours of exploding dice, rerolls,
-  min/max clamps, success pools, crit thresholds, sorting, grouped rolls, PF2e
-  degrees of success, math functions, variables, computed dice — enough for D&D 5e,
-  Pathfinder, World of Darkness, Shadowrun, Fate, Savage Worlds, and Call of
-  Cthulhu without escape hatches. Spelled the way
+- **Complete notation.** A dice roller that takes keep/drop, three flavours of
+  exploding dice, rerolls, min/max clamps, success pools, crit thresholds,
+  sorting, grouped rolls, PF2e degrees of success, math functions, variables,
+  computed dice — enough for D&D 5e, Pathfinder, World of Darkness, Shadowrun,
+  Fate, Savage Worlds, and Call of Cthulhu without escape hatches. Spelled the way
   [Roll20](https://help.roll20.net/hc/en-us/articles/360037773133-Dice-Reference)
   spells it wherever the two overlap, so the notation your table already uses
   keeps working.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roll-parser",
   "version": "3.3.0",
-  "description": "High-performance dice notation parser for tabletop RPGs. TypeScript-first, runs on Node, Bun, and browsers with zero dependencies.",
+  "description": "Dice notation parser and roller for tabletop RPGs — D&D 5e, Pathfinder, Fate. Typed results, seeded rolls, zero dependencies. TypeScript, Node, Bun, browser.",
   "type": "module",
   "bin": {
     "roll-parser": "./dist/cli/index.js"
@@ -44,12 +44,11 @@
     "tabletop",
     "dnd",
     "d20",
-    "typescript",
-    "esm",
-    "browser",
-    "zero-dependency",
-    "cli",
-    "bun"
+    "roller",
+    "die",
+    "notation",
+    "pathfinder",
+    "dice notation"
   ],
   "homepage": "https://roll-parser.edloidas.io/",
   "bugs": {


### PR DESCRIPTION
npm ranks default search on keyword matching over name, description, readme, and keywords, with no popularity component — a package named `dice` with 102 downloads/month and an empty README outranks `@diceui/shared` at 199k. The name is not worth changing, so this touches the three fields that are reachable.

- Rewrote `description` to lead with queryable nouns, add the missing `roller` token, and name D&D 5e, Pathfinder, and Fate
- Added `roller`, `die`, `notation`, `pathfinder`, and the space-separated `dice notation` keyword, the form `droll` ranks #1 on
- Dropped `typescript`, `esm`, `browser`, `zero-dependency`, `cli`, and `bun`, none of which ranked inside the top 100 for their own keyword chip
- Added a `min+brotli ≤13.5 kB` badge linking to the size breakdown, so the enforced budget sits alongside the 885 kB unpacked size npm reports for shipping `src/`
- Reworded the `Complete notation` bullet so "dice roller" appears in the README, where it previously did not occur once

No new README section: `Recipes by game system` and the `Why roll-parser` bullets already carry the system and ecosystem vocabulary, and padding a 55 kB README works against per-term weight.

The keyword prune is the speculative part — document-length normalization is suggested by short-README packages dominating every dice query, not proven. Package metadata reaches npm only on the next publish.

Closes #333
