### PR TITLE
test: pin meta-operand draw order and unseeded RNG freshness

### DIFF
--- a/src/evaluator/draws.test.ts
+++ b/src/evaluator/draws.test.ts
@@ -138,6 +138,17 @@ describe('evaluator draw consumption', () => {
       expect(countDraws('1d(1d4)', [4, 3]).draws).toBe(2);
     });
 
+    test('(1d2)d(1d4) draws the count expression before the sides expression', () => {
+      // With one meta operand the two are indistinguishable; only a notation
+      // carrying both can tell `count → sides` from `sides → count`. Here the
+      // documented order resolves to 2d3, the reverse to 3d2.
+      const notation = '(1d2)d(1d4)';
+      const result = evaluate(parse(notation), createMockRng([2, 3, 1, 1]), { notation });
+
+      expect(result.expression).toBe('2d3');
+      expect(countDraws(notation, [2, 3, 1, 1]).draws).toBe(4);
+    });
+
     test('4d6kh(1d2) draws the keep count before the pool', () => {
       expect(countDraws('4d6kh(1d2)', [1, 5, 3, 4, 6]).draws).toBe(5);
     });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -238,10 +238,17 @@ describe('roll() integration', () => {
       expect(result.total).toBe(18);
     });
 
-    test('no options uses random RNG', () => {
-      const result = roll('1d6');
-      expect(result.total).toBeGreaterThanOrEqual(1);
-      expect(result.total).toBeLessThanOrEqual(6);
+    test('no options builds a fresh RNG on every call', () => {
+      // A range check alone is satisfied by a pinned default seed, which would
+      // hand every caller the same roll. Four d1000 leave 10^12 sequences, so
+      // twenty repeats collide only if the stream is not fresh.
+      const sequences = Array.from({ length: 20 }, () =>
+        roll('4d1000')
+          .rolls.map((die) => die.result)
+          .join(','),
+      );
+
+      expect(new Set(sequences).size).toBe(sequences.length);
     });
   });
 


### PR DESCRIPTION
Two documented rules had no test that could distinguish a correct implementation from a broken one. Swapping the `count` and `sides` evaluations in `evalDice`, or pinning the default seed in `roll()`, passed the full suite before this change.

Added `(1d2)d(1d4)` to the meta-expression draws. `(1d2)d6` and `1d(1d4)` each carry one meta operand, so the order between the two evaluations was unobservable; a notation carrying both resolves to `2d3` under the documented order and `3d2` under the reverse.

Replaced the range-only assertion on an optionless `roll()` with twenty repeats of `4d1000` asserted distinct. The old test was satisfied by a pinned default seed, and its name claimed more than it checked.

Each mutation now fails exactly one test.