### PR TITLE
feat: make --json a self-verifying record #342

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,9 @@ pool.total; // 5 — successes minus failures
 | `successes` / `failures` | `number?` | Present only when success counting was used |
 | `degree` / `natural` | `DegreeOfSuccess?` / `number?` | Present only for a top-level `vs` |
 
-`Readonly` at the top level and fully JSON-serializable — this is exactly what
-the CLI's `--json` flag prints.
+`Readonly` at the top level and fully JSON-serializable. The CLI's `--json`
+flag prints these fields and appends two of its own, `seed` and `version` —
+see [CLI](#cli).
 
 ```typescript
 JSON.stringify(roll('3d6', { rng: createMockRng([4, 2, 6]) }));
@@ -1025,11 +1026,22 @@ $ roll-parser --seed demo -- -1d6+3
 2
 ```
 
+That payload is cut short; in full it ends:
+
+```json
+{"total":8,"notation":"1d20+7 vs 15", …, "seed":"demo","version":"3.3.1"}
+```
+
 Verbose mode rewrites the markdown markers for plain terminals: `~~n~~` becomes
 `(n)`, `**n**` becomes `[n]`, `__n__` becomes `{n}`. `--seed` takes both
 `--seed value` and `--seed=value`, and accepts any non-empty value including a
-dash-prefixed one. `--help` and `--version` win over any usage error that
-precedes them. Errors go to stderr; only the result goes to stdout.
+dash-prefixed one. The `--json` payload ends with two fields the library
+result does not carry: the `seed` that produced the roll and the `version`
+that fixes the seed-to-dice mapping — feed that seed back through `--seed` on
+the same major and the dice repeat. Omitting `--seed` mints one, so an
+unplanned roll stays reproducible too. `--help` and `--version` win over
+any usage error that precedes them. Errors go to stderr; only the result goes
+to stdout.
 
 | Exit code | Meaning |
 |----------:|---------|

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { VERSION } from '../index.js';
 import { createMockRng } from '../rng/mock.js';
 import { roll } from '../roll.js';
 import { formatResult } from './format.js';
@@ -113,7 +114,33 @@ describe('formatResult', () => {
         rendered: '2d6[3, 5] + 3 = 11',
         rolls: result.rolls,
         parts: result.parts,
+        version: VERSION,
       });
+    });
+
+    test('appends the seed that produced the result', () => {
+      const result = roll('2d6+3', { rng: createMockRng([3, 5]) });
+      const parsed = JSON.parse(formatResult(result, { json: true, seed: 'demo' }));
+
+      expect(parsed.seed).toBe('demo');
+      expect(parsed.version).toBe(VERSION);
+      expect(parsed.total).toBe(11);
+    });
+
+    test('omits the seed key entirely when no seed is given', () => {
+      const result = roll('2d6+3', { rng: createMockRng([3, 5]) });
+      const parsed = JSON.parse(formatResult(result, { json: true }));
+
+      expect('seed' in parsed).toBe(false);
+      expect(parsed.version).toBe(VERSION);
+    });
+
+    test('appends its two keys without disturbing the library shape', () => {
+      const result = roll('4d6kh3', { rng: createMockRng([3, 1, 5, 4]) });
+      const parsed = JSON.parse(formatResult(result, { json: true, seed: 'demo' }));
+      const libraryKeys = Object.keys(JSON.parse(JSON.stringify(result)));
+
+      expect(Object.keys(parsed)).toEqual([...libraryKeys, 'seed', 'version']);
     });
 
     test('keeps the structured parts tree', () => {

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -6,6 +6,7 @@
  * @module cli/format
  */
 
+import { VERSION } from '../index.js';
 import { type DieMarks, renderBreakdown } from '../render.js';
 import type { RollResult } from '../types.js';
 
@@ -30,6 +31,8 @@ export type FormatOptions = {
   json?: boolean;
   /** Show the detailed roll breakdown instead of the bare total. */
   verbose?: boolean;
+  /** Seed that produced the result. Emitted in JSON mode only. */
+  seed?: string;
 };
 
 /**
@@ -41,15 +44,20 @@ export type FormatOptions = {
  * tree — as a single-line `JSON.stringify` payload, where `degree` appears as
  * its numeric `DegreeOfSuccess` value.
  *
+ * The JSON payload appends two fields the library result does not carry:
+ * `seed` — the key is absent, not null, when none is given — and `version`,
+ * which fixes the seed-to-dice mapping. Together they let the payload replay
+ * through `--seed` on the same major.
+ *
  * @param result - The roll result to format
  * @param options - Output mode; JSON wins when combined with verbose
  * @returns Formatted string for terminal output
  */
 export function formatResult(result: RollResult, options: FormatOptions = {}): string {
-  const { json = false, verbose = false } = options;
+  const { json = false, verbose = false, seed } = options;
 
   if (json) {
-    return JSON.stringify(result);
+    return JSON.stringify({ ...result, seed, version: VERSION });
   }
 
   if (!verbose) {

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, test } from 'bun:test';
 import { VERSION } from '../index.js';
 import { LexerError } from '../lexer/lexer.js';
+import { roll } from '../roll.js';
 import { main, writeErrorContext } from './main.js';
 
 type CliRun = { stdout: string; stderr: string; exitCode: number };
@@ -93,6 +94,8 @@ describe('cli main', () => {
       const { stdout } = run(['--help']);
 
       expect(stdout).toContain('--json');
+      expect(stdout).toContain('"seed"');
+      expect(stdout).toContain('"version"');
       expect(stdout).toContain('DegreeOfSuccess');
       expect(stdout).toContain('Exit codes:');
       expect(stdout).toContain('0  Success');
@@ -154,6 +157,30 @@ describe('cli main', () => {
       expect(parsed.parts.target.rolls.map((die: { result: number }) => die.result)).toEqual([
         3, 3, 6, 5,
       ]);
+      expect(parsed.seed).toBe('test');
+      expect(parsed.version).toBe(VERSION);
+    });
+
+    test('--json emits a minted seed when --seed is omitted', () => {
+      const first = JSON.parse(run(['4d6kh3', '--json']).stdout);
+
+      expect(typeof first.seed).toBe('string');
+      expect(first.seed).not.toBe('');
+      expect(first.version).toBe(VERSION);
+
+      const replay = JSON.parse(run(['4d6kh3', '--seed', first.seed, '--json']).stdout);
+
+      expect(replay.total).toBe(first.total);
+      expect(replay.rendered).toBe(first.rendered);
+      expect(replay.seed).toBe(first.seed);
+    });
+
+    test('a minted seed is fresh on every unseeded run', () => {
+      const seeds = new Set(
+        Array.from({ length: 5 }, () => JSON.parse(run(['1d20', '--json']).stdout).seed),
+      );
+
+      expect(seeds.size).toBe(5);
     });
 
     test('--json wins over --verbose', () => {
@@ -176,6 +203,13 @@ describe('cli main', () => {
       expect(exitCode).toBe(0);
       expect(Number(stdout.trim())).toBeGreaterThanOrEqual(3);
       expect(Number(stdout.trim())).toBeLessThanOrEqual(18);
+    });
+
+    test('non-JSON output stays the total alone, with no seed appended', () => {
+      const expected = roll('2d6+3', { seed: 'test' });
+
+      expect(run(['2d6+3', '--seed', 'test']).stdout).toBe(`${expected.total}\n`);
+      expect(run(['2d6+3', '--seed', 'test', '--verbose']).stdout).toBe(`${expected.rendered}\n`);
     });
   });
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -27,9 +27,12 @@ Options:
   --               Treat every following argument as notation
 
 JSON output:
-  Emits the complete result, including the structured "parts" tree. The
-  "degree" field (DegreeOfSuccess) serializes as a number: 0 critical failure,
-  1 failure, 2 success, 3 critical success. Errors stay plain text on stderr.
+  Emits the complete result, including the structured "parts" tree, plus the
+  "seed" that produced it and the "version" that fixes the seed-to-dice
+  mapping — rerun with --seed <seed> on the same major to replay the roll.
+  When --seed is omitted the CLI mints one. The "degree" field
+  (DegreeOfSuccess) serializes as a number: 0 critical failure, 1 failure,
+  2 success, 3 critical success. Errors stay plain text on stderr.
 
 Exit codes:
   0  Success
@@ -43,6 +46,9 @@ Examples:
   roll-parser "1d20+7 vs 25" --json
   roll-parser -- -1d6+3
 `;
+
+// The build sets `types: []`, so no ambient runtime globals are declared.
+declare const crypto: { randomUUID(): string };
 
 /** Sink for one stream's worth of CLI output. */
 export type WriteFn = (text: string) => void;
@@ -112,9 +118,10 @@ export function main(env: CliEnv): number {
   }
 
   try {
-    const options = args.seed != null ? { seed: args.seed } : {};
-    const result = roll(args.notation, options);
-    const output = formatResult(result, { json: args.json, verbose: args.verbose });
+    // `SeededRNG`'s auto-seed is unreachable, so mint one that can be echoed back.
+    const seed = args.seed ?? crypto.randomUUID();
+    const result = roll(args.notation, { seed });
+    const output = formatResult(result, { json: args.json, verbose: args.verbose, seed });
     stdout(`${output}\n`);
   } catch (error) {
     if (isRollParserError(error)) {


### PR DESCRIPTION
Appends the seed and the library version to the `--json` payload, so a saved record replays without an out-of-band note of how it was produced.

- Append `seed` and `version` to the `--json` payload in `formatResult`
- Mint a seed with `crypto.randomUUID()` when `--seed` is omitted, so every run emits one that reruns through the flag
- Document both fields in the CLI help text and the README CLI section
- Correct the README claim that `--json` prints exactly `RollResult`
- Pin the appended key order, the absent-seed case, and minted-seed replay in tests

Closes #342
