### PR TITLE
feat: render errors as JSON when --json is set #343

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,6 +1022,9 @@ Error: Invalid dice sides: 0
   2d6+1d0+3
       ^
 
+$ roll-parser "2d6+1d0+3" --json --seed demo
+{"error":{"message":"Invalid dice sides: 0","code":"INVALID_DICE_SIDES","span":{"start":4,"end":7}},"notation":"2d6+1d0+3","seed":"demo",...}
+
 $ roll-parser --seed demo -- -1d6+3
 2
 ```
@@ -1042,6 +1045,16 @@ the same major and the dice repeat. Omitting `--seed` mints one, so an
 unplanned roll stays reproducible too. `--help` and `--version` win over
 any usage error that precedes them. Errors go to stderr; only the result goes
 to stdout.
+
+Once `--json` is parsed, every diagnostic is one JSON line on stderr instead
+of the caret diagram. `code` is the same stable `RollParserErrorCode` the
+library throws, and `span` is what `getErrorSpan` returns — `{ start }` for a
+lexer or parser error, `{ start, end }` for an evaluator one, absent when the
+failure carries no position. A roll error also repeats the `notation` and
+`seed` that produced it, so a failure replays through `--seed` exactly as a
+result does. Branch on `code`, not on `message`, which is free to change
+between releases. An unknown option and a missing `--seed` value are reported
+before `--json` can be established, so those two stay plain text.
 
 | Exit code | Meaning |
 |----------:|---------|

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -102,6 +102,15 @@ describe('cli main', () => {
       expect(stdout).toContain('1  Roll or parse error');
       expect(stdout).toContain('2  Usage error');
     });
+
+    test('help documents the json error line and its one exclusion', () => {
+      const { stdout } = run(['--help']);
+
+      expect(stdout).toContain('JSON errors:');
+      expect(stdout).toContain('"error"');
+      expect(stdout).toContain('"span"');
+      expect(stdout).toContain('stay plain text');
+    });
   });
 
   describe('rolling', () => {
@@ -189,12 +198,21 @@ describe('cli main', () => {
       );
     });
 
-    test('--json leaves errors as plain text on stderr', () => {
-      const { stdout, stderr, exitCode } = run(['2d6+&', '--json']);
+    test('--json renders errors as JSON on stderr (#343)', () => {
+      const { stdout, stderr, exitCode } = run(['2d6+&', '--json', '--seed', 'test']);
 
       expect(exitCode).toBe(1);
       expect(stdout).toBe('');
-      expect(stderr).toBe(`Error: Unexpected character: '&'\n  2d6+&\n      ^\n`);
+      expect(JSON.parse(stderr)).toEqual({
+        error: {
+          message: "Unexpected character: '&'",
+          code: 'UNEXPECTED_CHARACTER',
+          span: { start: 4 },
+        },
+        notation: '2d6+&',
+        seed: 'test',
+        version: VERSION,
+      });
     });
 
     test('an unseeded roll still lands in range', () => {
@@ -295,6 +313,95 @@ describe('cli main', () => {
 
       expect(exitCode).toBe(1);
       expect(stderr).toBe('Error: Invalid dice sides: 0\n  2d6+1d0+3\n      ^\n');
+    });
+  });
+
+  describe('json errors', () => {
+    test('the record is a single line and stdout stays empty', () => {
+      const { stdout, stderr } = run(['2d6+&', '--json', '--seed', 'test']);
+
+      expect(stdout).toBe('');
+      expect(stderr.endsWith('\n')).toBe(true);
+      expect(stderr.trimEnd()).not.toContain('\n');
+    });
+
+    test('an evaluator error carries the span end the caret cannot show', () => {
+      const { stderr, exitCode } = run(['2d6+1d0+3', '--json', '--seed', 'test']);
+
+      expect(exitCode).toBe(1);
+      expect(JSON.parse(stderr).error).toEqual({
+        message: 'Invalid dice sides: 0',
+        code: 'INVALID_DICE_SIDES',
+        span: { start: 4, end: 7 },
+      });
+    });
+
+    test('a parser error carries a start-only span', () => {
+      const { stderr, exitCode } = run(['(1+2', '--json', '--seed', 'test']);
+
+      expect(exitCode).toBe(1);
+      expect(JSON.parse(stderr).error).toEqual({
+        message: "Expected ')' but got end of input",
+        code: 'EXPECTED_TOKEN',
+        span: { start: 4 },
+      });
+    });
+
+    test('a missing notation is JSON too, still exit 2', () => {
+      const { stdout, stderr, exitCode } = run(['--json']);
+
+      expect(exitCode).toBe(2);
+      expect(stdout).toBe('');
+      expect(JSON.parse(stderr)).toEqual({
+        error: { message: 'No dice notation provided.' },
+        version: VERSION,
+      });
+    });
+
+    test('an unknown option is reported before --json, so it stays plain text', () => {
+      // `parseArgs` returns at the bad option, so the flag was never established.
+      const { stderr, exitCode } = run(['--bogus', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(stderr).toBe('Error: Unknown option: --bogus\nRun "roll-parser --help" for usage.\n');
+    });
+
+    test('a missing --seed value stays plain text even with --json before it', () => {
+      const { stderr, exitCode } = run(['2d6', '--json', '--seed']);
+
+      expect(exitCode).toBe(2);
+      expect(stderr).toBe('Error: Missing value for --seed\nRun "roll-parser --help" for usage.\n');
+    });
+
+    test('a seeded failure replays from its own record', () => {
+      const record = JSON.parse(run(['1d6/(1d2-1)', '--json', '--seed', 'test']).stderr);
+
+      expect(record.error.code).toBe('DIVISION_BY_ZERO');
+
+      const replay = JSON.parse(run(['1d6/(1d2-1)', '--json', '--seed', record.seed]).stderr);
+
+      expect(replay).toEqual(record);
+    });
+
+    test('an unseeded failure records the minted seed and replays from it', () => {
+      // `1d6/0` draws before it divides, so the failure doesn't depend on which value came back.
+      const record = JSON.parse(run(['1d6/0', '--json']).stderr);
+
+      expect(record.error.code).toBe('DIVISION_BY_ZERO');
+      expect(typeof record.seed).toBe('string');
+      expect(record.seed).not.toBe('');
+
+      const replay = JSON.parse(run(['1d6/0', '--json', '--seed', record.seed]).stderr);
+
+      expect(replay).toEqual(record);
+    });
+
+    test('the minted seed on a failure is fresh on every run', () => {
+      const seeds = new Set(
+        Array.from({ length: 5 }, () => JSON.parse(run(['1d6/0', '--json']).stderr).seed),
+      );
+
+      expect(seeds.size).toBe(5);
     });
   });
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,7 +8,12 @@
  * @module cli/main
  */
 
-import { getErrorSpan, isRollParserError } from '../errors.js';
+import {
+  type ErrorSpan,
+  getErrorSpan,
+  isRollParserError,
+  type RollParserErrorCode,
+} from '../errors.js';
 import { VERSION } from '../index.js';
 import { roll } from '../roll.js';
 import { parseArgs } from './args.js';
@@ -32,7 +37,15 @@ JSON output:
   mapping — rerun with --seed <seed> on the same major to replay the roll.
   When --seed is omitted the CLI mints one. The "degree" field
   (DegreeOfSuccess) serializes as a number: 0 critical failure, 1 failure,
-  2 success, 3 critical success. Errors stay plain text on stderr.
+  2 success, 3 critical success.
+
+JSON errors:
+  Once --json is parsed, every diagnostic is one JSON line on stderr:
+  {"error":{"message":...,"code":...,"span":{"start":N}},...}. A roll error
+  adds the "notation" and "seed" that produced it, so a failure replays like
+  a result does; "code" and "span" are absent when the failure carries
+  neither. Unknown options and a missing --seed value are reported before
+  --json is known, so those stay plain text.
 
 Exit codes:
   0  Success
@@ -80,14 +93,41 @@ export function writeErrorContext(notation: string, error: unknown, write: Write
   write(`  ${' '.repeat(column)}^\n`);
 }
 
+/** The `error` member of the `--json` failure record. */
+type JsonErrorBody = {
+  message: string;
+  code?: RollParserErrorCode;
+  span?: ErrorSpan | undefined;
+};
+
+/**
+ * What the failure record needs to replay a roll that got as far as the
+ * dice. A usage error passes no context — it never reached the dice, so
+ * there is no roll to reproduce.
+ */
+type RollContext = {
+  notation: string;
+  seed: string;
+};
+
+/**
+ * Writes one failure record as compact JSON. `JSON.stringify` drops the
+ * absent members, so a lexer error carries no `end` and a usage error carries
+ * neither `code` nor `span` — the key is missing rather than null, matching
+ * how the success payload omits `seed`.
+ */
+function writeJsonError(write: WriteFn, error: JsonErrorBody, context?: RollContext): void {
+  write(`${JSON.stringify({ error, ...context, version: VERSION })}\n`);
+}
+
 /**
  * Runs one CLI invocation and returns the process exit code: `0` on success,
  * `1` for a roll-parser error, `2` for a usage error. Anything that is not a
  * `RollParserError` propagates so the runtime reports it with a stack.
  *
- * `--json` swaps the success payload only — diagnostics stay plain text on
- * stderr and the exit codes are identical, so scripts can branch on the code
- * before parsing stdout.
+ * `--json` swaps the success payload on stdout and every diagnostic raised
+ * after it is parsed on stderr. Exit codes are identical either way, so
+ * scripts can still branch on the code before reading a stream.
  */
 export function main(env: CliEnv): number {
   const { argv, stdout, stderr } = env;
@@ -112,21 +152,34 @@ export function main(env: CliEnv): number {
   }
 
   if (args.notation == null) {
-    stderr('Error: No dice notation provided.\n');
-    stderr('Run "roll-parser --help" for usage.\n');
+    if (args.json) {
+      writeJsonError(stderr, { message: 'No dice notation provided.' });
+    } else {
+      stderr('Error: No dice notation provided.\n');
+      stderr('Run "roll-parser --help" for usage.\n');
+    }
     return 2;
   }
 
+  // `SeededRNG`'s auto-seed is unreachable, so mint one that can be echoed back.
+  const seed = args.seed ?? crypto.randomUUID();
+
   try {
-    // `SeededRNG`'s auto-seed is unreachable, so mint one that can be echoed back.
-    const seed = args.seed ?? crypto.randomUUID();
     const result = roll(args.notation, { seed });
     const output = formatResult(result, { json: args.json, verbose: args.verbose, seed });
     stdout(`${output}\n`);
   } catch (error) {
     if (isRollParserError(error)) {
-      stderr(`Error: ${error.message}\n`);
-      writeErrorContext(args.notation, error, stderr);
+      if (args.json) {
+        writeJsonError(
+          stderr,
+          { message: error.message, code: error.code, span: getErrorSpan(error) },
+          { notation: args.notation, seed },
+        );
+      } else {
+        stderr(`Error: ${error.message}\n`);
+        writeErrorContext(args.notation, error, stderr);
+      }
       return 1;
     }
     throw error;

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -502,8 +502,10 @@ function runCliCase(entry: CliCase): void {
   };
   const exitCode = main({ argv: entry.argv, stdout: write, stderr: write });
 
-  // Without this the README's exit-code table stays entirely unchecked.
-  const diagnostic = entry.expected.startsWith('Error:');
+  // Without this the README's exit-code table stays entirely unchecked. Under
+  // --json a diagnostic is a JSON object keyed `error` rather than an `Error:`
+  // line, so both spellings have to count.
+  const diagnostic = entry.expected.startsWith('Error:') || entry.expected.startsWith('{"error":');
   if (diagnostic !== (exitCode !== 0)) {
     throw new Error(
       `${entry.file}:${entry.line} documents ${diagnostic ? 'an error' : 'a success'} but the CLI exited ${exitCode}\n  $ ${entry.command}`,


### PR DESCRIPTION
## Changes

- Emit one JSON line on stderr for every diagnostic raised after `--json` is parsed
- Carry the error's stable `code` and the span `getErrorSpan` already normalizes
- Repeat the `notation` and `seed` that produced a roll failure, so it replays like a result does
- Hoist the minted seed above the `try` so the `catch` can echo it
- Document the contract and its one exclusion in `HELP_TEXT` and `README.md`
- Teach `readme.test.ts` that a `{"error":` line is a diagnostic, not a success

Exit codes and empty-stdout-on-failure are unchanged.

## Three deviations from the issue, for your call

**`span` rather than a flat `position`.** The evaluator carries a start and an end, so a single number would either drop the end or need a second name for it, and `ErrorSpan` is already the exported type for that shape. The issue's rationale endorses `getErrorSpan`'s shape; its example shows a flat number. Reverting to the literal form is a one-line change.

**Usage errors raised before `--json` is established stay plain text.** `parseArgs` returns at the bad option, and recovering the flag means re-implementing the argument grammar: `--seed --json` binds `--json` as the seed value, and `-- --json` makes it notation, so a scan that just looks for the flag reports JSON the user never asked for. Doing it properly means restructuring `parseArgs` from early-return to accumulate-then-decide — its own issue if it is wanted. `No dice notation provided` *is* JSON, because the flag is known by then.

**The record carries `notation`, `seed` and `version`.** README promises an unseeded roll stays reproducible, and a failing one was not — the minted seed was declared inside the `try` and never echoed.

Closes #343
