### PR TITLE
feat: render pre-parse usage errors as JSON under --json #351

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `--json` now covers the two usage errors that escaped it. `Unknown option: <x>` and `Missing value for --seed` were raised at the offending token, before the flag was known, so they printed as plain text; `parseArgs` now records the first usage error and runs the loop to the end, so the flag survives alongside it. Detection stays positional: `--seed --json` binds `--json` as the seed value and `roll-parser -- --json` makes it notation, and neither emits JSON. The record is `{"error":{"message":...},"version":...}` — a usage error never reached the dice, so it carries no `code`, `span`, `notation` or `seed`. Exit code 2 is unchanged ([#351](https://github.com/edloidas/roll-parser/issues/351))
+
 ## [3.3.1] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1053,8 +1053,10 @@ lexer or parser error, `{ start, end }` for an evaluator one, absent when the
 failure carries no position. A roll error also repeats the `notation` and
 `seed` that produced it, so a failure replays through `--seed` exactly as a
 result does. Branch on `code`, not on `message`, which is free to change
-between releases. An unknown option and a missing `--seed` value are reported
-before `--json` can be established, so those two stay plain text.
+between releases. Usage errors are covered too — an unknown option and a
+missing `--seed` value carry a `message` and nothing else. Detection honours
+what `--json` actually binds to, so `--seed --json` reads the flag as the seed
+value and `roll-parser -- --json` reads it as notation; neither emits JSON.
 
 | Exit code | Meaning |
 |----------:|---------|

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -73,7 +73,7 @@ describe('parseArgs', () => {
 
     test('rejects unknown short options that do not look like notation', () => {
       const result = parseArgs(['-x']);
-      expect(result).toEqual({ ok: false, error: 'Unknown option: -x' });
+      expect(result).toEqual({ ok: false, error: 'Unknown option: -x', json: false });
     });
   });
 
@@ -131,17 +131,17 @@ describe('parseArgs', () => {
 
     test('returns error for --seed without value', () => {
       const result = parseArgs(['2d6', '--seed']);
-      expect(result).toEqual({ ok: false, error: 'Missing value for --seed' });
+      expect(result).toEqual({ ok: false, error: 'Missing value for --seed', json: false });
     });
 
     test('returns error for --seed= with empty value', () => {
       const result = parseArgs(['--seed=']);
-      expect(result).toEqual({ ok: false, error: 'Missing value for --seed' });
+      expect(result).toEqual({ ok: false, error: 'Missing value for --seed', json: false });
     });
 
     test('returns error for --seed with an empty value', () => {
       const result = parseArgs(['2d6', '--seed', '']);
-      expect(result).toEqual({ ok: false, error: 'Missing value for --seed' });
+      expect(result).toEqual({ ok: false, error: 'Missing value for --seed', json: false });
     });
 
     test('parses --seed with negative numeric value', () => {
@@ -172,6 +172,31 @@ describe('parseArgs', () => {
   });
 
   describe('json flag', () => {
+    test('survives a usage error raised at a later argument', () => {
+      const result = parseArgs(['2d6', '--json', '--bogus']);
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --bogus', json: true });
+    });
+
+    test('survives a usage error raised at an earlier argument', () => {
+      const result = parseArgs(['--bogus', '2d6', '--json']);
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --bogus', json: true });
+    });
+
+    test('reports the first of several usage errors', () => {
+      const result = parseArgs(['--first', '--second', '--json']);
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --first', json: true });
+    });
+
+    test('is not set when --seed consumed it as a value', () => {
+      const result = parseArgs(['--seed', '--json', '--bogus']);
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --bogus', json: false });
+    });
+
+    test('is not set when the terminator made it notation', () => {
+      const result = parseArgs(['--bogus', '--', '--json']);
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --bogus', json: false });
+    });
+
     test('parses --json', () => {
       const result = parseArgs(['2d6', '--json']);
       expect(result.ok).toBe(true);
@@ -323,7 +348,7 @@ describe('parseArgs', () => {
   describe('error cases', () => {
     test('returns error for unknown long flag', () => {
       const result = parseArgs(['--unknown']);
-      expect(result).toEqual({ ok: false, error: 'Unknown option: --unknown' });
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --unknown', json: false });
     });
 
     // The `-x` short-flag case sits in `notation parsing`, next to the

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -19,9 +19,13 @@ export type CliArgs = {
 };
 
 /**
- * Result of parsing CLI arguments — either success or a usage error.
+ * Result of parsing CLI arguments — either success or a usage error. The
+ * failure arm carries `json` so a usage error renders in the format the
+ * caller asked for.
  */
-export type ParseArgsResult = { ok: true; args: CliArgs } | { ok: false; error: string };
+export type ParseArgsResult =
+  | { ok: true; args: CliArgs }
+  | { ok: false; error: string; json: boolean };
 
 /** Argument that stops option parsing — everything after it is notation. */
 const TERMINATOR = '--';
@@ -85,6 +89,7 @@ export function parseArgs(argv: string[]): ParseArgsResult {
   let verbose = false;
   let json = false;
   let seed: string | undefined;
+  let error: string | undefined;
   const positional: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -102,23 +107,29 @@ export function parseArgs(argv: string[]): ParseArgsResult {
       // `--seed -abc` is a valid seed, not a missing value.
       const next = argv[i + 1];
       if (next == null || next === '') {
-        return { ok: false, error: 'Missing value for --seed' };
+        error ??= 'Missing value for --seed';
+      } else {
+        seed = next;
+        i++;
       }
-      seed = next;
-      i++;
     } else if (arg.startsWith('--seed=')) {
       const value = arg.slice('--seed='.length);
       if (value === '') {
-        return { ok: false, error: 'Missing value for --seed' };
+        error ??= 'Missing value for --seed';
+      } else {
+        seed = value;
       }
-      seed = value;
-    } else if (arg.startsWith('--')) {
-      return { ok: false, error: `Unknown option: ${arg}` };
-    } else if (arg.startsWith('-') && !isNegativeNotation(arg)) {
-      return { ok: false, error: `Unknown option: ${arg}` };
+    } else if (arg.startsWith('--') || (arg.startsWith('-') && !isNegativeNotation(arg))) {
+      error ??= `Unknown option: ${arg}`;
     } else {
       positional.push(arg);
     }
+  }
+
+  // The loop runs to the end even after a usage error: only it knows that
+  // `--seed --json` binds the flag as a seed value and `-- --json` makes it notation.
+  if (error != null) {
+    return { ok: false, error, json };
   }
 
   // Joined, not separate rolls — a shell splits `roll-parser 2d6 + 3` into three

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -103,13 +103,15 @@ describe('cli main', () => {
       expect(stdout).toContain('2  Usage error');
     });
 
-    test('help documents the json error line and its one exclusion', () => {
+    test('help documents the json error line and the two positional exclusions', () => {
       const { stdout } = run(['--help']);
 
       expect(stdout).toContain('JSON errors:');
       expect(stdout).toContain('"error"');
       expect(stdout).toContain('"span"');
-      expect(stdout).toContain('stay plain text');
+      expect(stdout).toContain('Usage errors are covered too');
+      expect(stdout).toContain('a seed value in --seed --json');
+      expect(stdout).toContain('notation after --');
     });
   });
 
@@ -357,19 +359,40 @@ describe('cli main', () => {
       });
     });
 
-    test('an unknown option is reported before --json, so it stays plain text', () => {
-      // `parseArgs` returns at the bad option, so the flag was never established.
-      const { stderr, exitCode } = run(['--bogus', '--json']);
+    test('an unknown option is JSON even though it precedes --json', () => {
+      const { stdout, stderr, exitCode } = run(['--bogus', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(stdout).toBe('');
+      expect(JSON.parse(stderr)).toEqual({
+        error: { message: 'Unknown option: --bogus' },
+        version: VERSION,
+      });
+    });
+
+    test('a missing --seed value is JSON too', () => {
+      const { stdout, stderr, exitCode } = run(['2d6', '--json', '--seed']);
+
+      expect(exitCode).toBe(2);
+      expect(stdout).toBe('');
+      expect(JSON.parse(stderr)).toEqual({
+        error: { message: 'Missing value for --seed' },
+        version: VERSION,
+      });
+    });
+
+    test('a usage error stays plain text when --seed consumed --json', () => {
+      const { stderr, exitCode } = run(['--seed', '--json', '--bogus']);
 
       expect(exitCode).toBe(2);
       expect(stderr).toBe('Error: Unknown option: --bogus\nRun "roll-parser --help" for usage.\n');
     });
 
-    test('a missing --seed value stays plain text even with --json before it', () => {
-      const { stderr, exitCode } = run(['2d6', '--json', '--seed']);
+    test('a usage error stays plain text when -- made --json notation', () => {
+      const { stderr, exitCode } = run(['--bogus', '--', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(stderr).toBe('Error: Missing value for --seed\nRun "roll-parser --help" for usage.\n');
+      expect(stderr).toBe('Error: Unknown option: --bogus\nRun "roll-parser --help" for usage.\n');
     });
 
     test('a seeded failure replays from its own record', () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -40,12 +40,12 @@ JSON output:
   2 success, 3 critical success.
 
 JSON errors:
-  Once --json is parsed, every diagnostic is one JSON line on stderr:
+  Every diagnostic is one JSON line on stderr:
   {"error":{"message":...,"code":...,"span":{"start":N}},...}. A roll error
   adds the "notation" and "seed" that produced it, so a failure replays like
   a result does; "code" and "span" are absent when the failure carries
-  neither. Unknown options and a missing --seed value are reported before
-  --json is known, so those stay plain text.
+  neither. Usage errors are covered too, but only where --json still reads as
+  the flag: it is a seed value in --seed --json, and notation after --.
 
 Exit codes:
   0  Success
@@ -124,8 +124,8 @@ function writeJsonError(write: WriteFn, error: JsonErrorBody, context?: RollCont
  * `1` for a roll-parser error, `2` for a usage error. Anything that is not a
  * `RollParserError` propagates so the runtime reports it with a stack.
  *
- * `--json` swaps the success payload on stdout and every diagnostic raised
- * after it is parsed on stderr. Exit codes are identical either way, so
+ * `--json` swaps the success payload on stdout and every diagnostic on
+ * stderr, usage errors included. Exit codes are identical either way, so
  * scripts can still branch on the code before reading a stream.
  */
 export function main(env: CliEnv): number {
@@ -133,8 +133,12 @@ export function main(env: CliEnv): number {
   const parsed = parseArgs(argv);
 
   if (!parsed.ok) {
-    stderr(`Error: ${parsed.error}\n`);
-    stderr('Run "roll-parser --help" for usage.\n');
+    if (parsed.json) {
+      writeJsonError(stderr, { message: parsed.error });
+    } else {
+      stderr(`Error: ${parsed.error}\n`);
+      stderr('Run "roll-parser --help" for usage.\n');
+    }
     return 2;
   }
 


### PR DESCRIPTION
## Changes

- `parseArgs` records the first usage error and runs the loop to the end instead of returning at the offending token, so `--json` survives alongside it
- `ParseArgsResult`'s failure arm carries `json`
- `main` renders a failed parse through `writeJsonError` when the flag was set; the record is `message` plus `version`, exit code 2 unchanged
- `--seed --json` and `-- --json` still stay plain text — the flag is a seed value in the first and notation in the second
- `HELP_TEXT` and the README JSON-errors paragraph drop the plain-text carve-out
- Five exact-shape assertions in `args.test.ts` gain `json`; five new cases pin the positional rule
- The two `main.test.ts` tests that asserted plain text now assert the JSON record, with two added for the exclusions

Closes #351
