### PR TITLE
refactor: make first-error-wins enforceable in parseArgs #358

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -187,6 +187,21 @@ describe('parseArgs', () => {
       expect(result).toEqual({ ok: false, error: 'Unknown option: --first', json: true });
     });
 
+    test('reports the missing seed value when it precedes an unknown option', () => {
+      const result = parseArgs(['--seed', '', '--bogus', '--json']);
+      expect(result).toEqual({ ok: false, error: 'Missing value for --seed', json: true });
+    });
+
+    test('reports the unknown option when it precedes a missing seed value', () => {
+      const result = parseArgs(['--bogus', '--seed', '', '--json']);
+      expect(result).toEqual({ ok: false, error: 'Unknown option: --bogus', json: true });
+    });
+
+    test('reports the missing --seed= value when it precedes an unknown option', () => {
+      const result = parseArgs(['--seed=', '--bogus', '--json']);
+      expect(result).toEqual({ ok: false, error: 'Missing value for --seed', json: true });
+    });
+
     test('is not set when --seed consumed it as a value', () => {
       const result = parseArgs(['--seed', '--json', '--bogus']);
       expect(result).toEqual({ ok: false, error: 'Unknown option: --bogus', json: false });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -92,6 +92,11 @@ export function parseArgs(argv: string[]): ParseArgsResult {
   let error: string | undefined;
   const positional: string[] = [];
 
+  // First usage error wins — a later one is deliberately dropped.
+  const failWith = (message: string): void => {
+    error ??= message;
+  };
+
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i] as string;
 
@@ -107,7 +112,7 @@ export function parseArgs(argv: string[]): ParseArgsResult {
       // `--seed -abc` is a valid seed, not a missing value.
       const next = argv[i + 1];
       if (next == null || next === '') {
-        error ??= 'Missing value for --seed';
+        failWith('Missing value for --seed');
       } else {
         seed = next;
         i++;
@@ -115,12 +120,12 @@ export function parseArgs(argv: string[]): ParseArgsResult {
     } else if (arg.startsWith('--seed=')) {
       const value = arg.slice('--seed='.length);
       if (value === '') {
-        error ??= 'Missing value for --seed';
+        failWith('Missing value for --seed');
       } else {
         seed = value;
       }
     } else if (arg.startsWith('--') || (arg.startsWith('-') && !isNegativeNotation(arg))) {
-      error ??= `Unknown option: ${arg}`;
+      failWith(`Unknown option: ${arg}`);
     } else {
       positional.push(arg);
     }


### PR DESCRIPTION
## Changes

- Added a local `failWith(message)` helper in `parseArgs` that owns the `error ??=` assignment
- Routed all three usage-error sites through it: `--seed` missing value, `--seed=` empty value, unknown option
- Added three tests pinning first-error-wins across two different error sites in both orders, plus the `--seed=` site

Closes #358
