### PR TITLE
refactor: enforce noExcessiveCognitiveComplexity #349

### DIFF
--- a/bench/competitors/matrix.ts
+++ b/bench/competitors/matrix.ts
@@ -216,8 +216,45 @@ type Cell = {
   status: CellStatus;
   notationUsed: string;
   detail?: string;
-  observed?: { mean: number; min: number; max: number };
+  observed?: Observed;
 };
+
+type Observed = { mean: number; min: number; max: number };
+
+function sampleStats(sampler: (notation: string) => number, notation: string): Observed {
+  let sum = 0;
+  let lowest = Number.POSITIVE_INFINITY;
+  let highest = Number.NEGATIVE_INFINITY;
+
+  for (let index = 0; index < SAMPLES; index++) {
+    const value = sampler(notation);
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      throw new Error(`non-numeric result: ${value}`);
+    }
+    sum += value;
+    if (value < lowest) lowest = value;
+    if (value > highest) highest = value;
+  }
+
+  return { mean: sum / SAMPLES, min: lowest, max: highest };
+}
+
+function findExpectationProblems(expect: Expectation, observed: Observed): string[] {
+  const { mean, min, max } = observed;
+  const problems: string[] = [];
+
+  if (expect.min !== undefined && min < expect.min) {
+    problems.push(`min ${min} < ${expect.min}`);
+  }
+  if (expect.max !== undefined && max > expect.max) {
+    problems.push(`max ${max} > ${expect.max}`);
+  }
+  if (expect.mean !== undefined && Math.abs(mean - expect.mean) > (expect.tolerance ?? 0.4)) {
+    problems.push(`mean ${mean.toFixed(2)} vs expected ${expect.mean}`);
+  }
+
+  return problems;
+}
 
 function evaluateCell(matrixCase: MatrixCase, adapterName: AdapterName): Cell {
   const adapter = ADAPTERS.find((candidate) => candidate.name === adapterName);
@@ -239,35 +276,14 @@ function evaluateCell(matrixCase: MatrixCase, adapterName: AdapterName): Cell {
       : adapter.rollTotal;
 
   try {
-    let sum = 0;
-    let lowest = Number.POSITIVE_INFINITY;
-    let highest = Number.NEGATIVE_INFINITY;
-    for (let index = 0; index < SAMPLES; index++) {
-      const value = sampler(notation);
-      if (typeof value !== 'number' || Number.isNaN(value)) {
-        throw new Error(`non-numeric result: ${value}`);
-      }
-      sum += value;
-      if (value < lowest) lowest = value;
-      if (value > highest) highest = value;
-    }
-    const mean = sum / SAMPLES;
-    const { expect } = matrixCase;
-    const problems: string[] = [];
-    if (expect.min !== undefined && lowest < expect.min) {
-      problems.push(`min ${lowest} < ${expect.min}`);
-    }
-    if (expect.max !== undefined && highest > expect.max) {
-      problems.push(`max ${highest} > ${expect.max}`);
-    }
-    if (expect.mean !== undefined && Math.abs(mean - expect.mean) > (expect.tolerance ?? 0.4)) {
-      problems.push(`mean ${mean.toFixed(2)} vs expected ${expect.mean}`);
-    }
+    const observed = sampleStats(sampler, notation);
+    const problems = findExpectationProblems(matrixCase.expect, observed);
+
     return {
       status: problems.length === 0 ? 'pass' : 'semantic',
       notationUsed: notation,
       detail: problems.join('; ') || undefined,
-      observed: { mean: Number(mean.toFixed(3)), min: lowest, max: highest },
+      observed: { ...observed, mean: Number(observed.mean.toFixed(3)) },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,8 @@
         "noDoubleEquals": { "level": "error", "options": { "ignoreNull": true } }
       },
       "complexity": {
-        "noForEach": "off"
+        "noForEach": "off",
+        "noExcessiveCognitiveComplexity": "error"
       }
     }
   },
@@ -67,6 +68,16 @@
         "rules": {
           "correctness": {
             "noNodejsModules": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
           }
         }
       }

--- a/scripts/bench-records.ts
+++ b/scripts/bench-records.ts
@@ -70,6 +70,52 @@ function findStatsProblem({ p50, p75, ticks }: MitataStats): string | null {
   return null;
 }
 
+/**
+ * `label` is resolved by the caller because a problem still has to name the run
+ * when the name is itself what is wrong.
+ */
+function toRecord(
+  group: string | null | undefined,
+  trialGroup: number,
+  trialRun: MitataRun,
+  label: string,
+): { record: BenchmarkRecord } | { problem: string } {
+  // Every bench registers inside a `group()`, so an index the layout cannot
+  // resolve means a corrupt dump, never a legitimately ungrouped bench.
+  if (!isNonEmptyName(group)) {
+    return { problem: `group ${trialGroup} has no name in the layout` };
+  }
+
+  if (!isNonEmptyName(trialRun.name)) {
+    return { problem: 'case name is empty' };
+  }
+
+  const stats = trialRun.stats;
+
+  if (stats == null) {
+    return { problem: 'missing stats' };
+  }
+
+  const problem = findStatsProblem(stats);
+
+  if (problem != null) {
+    return { problem };
+  }
+
+  const { p50, p75, ticks } = stats;
+  const mode = getSamplingMode(ticks);
+
+  return {
+    record: {
+      name: label,
+      unit: 'ns',
+      value: round(p50),
+      range: `± ${round(p75 - p50)} ns`,
+      extra: `group=${group} case=${trialRun.name} p50=${round(p50)}ns p75=${round(p75)}ns mode=${mode}`,
+    },
+  };
+}
+
 export function toRecords(dump: MitataDump): RecordsResult {
   const records: BenchmarkRecord[] = [];
   const problems: string[] = [];
@@ -84,29 +130,10 @@ export function toRecords(dump: MitataDump): RecordsResult {
     for (const [index, trialRun] of trial.runs.entries()) {
       const label = `${groupLabel} / ${isNonEmptyName(trialRun.name) ? trialRun.name : `#${index}`}`;
 
-      // Every bench registers inside a `group()`, so an index the layout cannot
-      // resolve means a corrupt dump, never a legitimately ungrouped bench.
-      if (!isNonEmptyName(group)) {
-        problems.push(`${label}: group ${trial.group} has no name in the layout`);
-        continue;
-      }
+      const outcome = toRecord(group, trial.group, trialRun, label);
 
-      if (!isNonEmptyName(trialRun.name)) {
-        problems.push(`${label}: case name is empty`);
-        continue;
-      }
-
-      const stats = trialRun.stats;
-
-      if (stats == null) {
-        problems.push(`${label}: missing stats`);
-        continue;
-      }
-
-      const problem = findStatsProblem(stats);
-
-      if (problem != null) {
-        problems.push(`${label}: ${problem}`);
+      if ('problem' in outcome) {
+        problems.push(`${label}: ${outcome.problem}`);
         continue;
       }
 
@@ -118,17 +145,7 @@ export function toRecords(dump: MitataDump): RecordsResult {
       }
 
       seen.add(label);
-
-      const { p50, p75, ticks } = stats;
-      const mode = getSamplingMode(ticks);
-
-      records.push({
-        name: label,
-        unit: 'ns',
-        value: round(p50),
-        range: `± ${round(p75 - p50)} ns`,
-        extra: `group=${group} case=${trialRun.name} p50=${round(p50)}ns p75=${round(p75)}ns mode=${mode}`,
-      });
+      records.push(outcome.record);
     }
   }
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -68,6 +68,61 @@ function isNegativeNotation(arg: string): boolean {
 }
 
 /**
+ * A seed is an opaque string, so any non-empty next argument counts:
+ * `--seed -abc` is a valid seed, not a missing value. `null` when it is missing.
+ */
+function readSeedValue(
+  arg: string,
+  next: string | undefined,
+): { seed: string; consumed: number } | null {
+  if (arg === '--seed') {
+    return next == null || next === '' ? null : { seed: next, consumed: 1 };
+  }
+
+  const value = arg.slice('--seed='.length);
+  return value === '' ? null : { seed: value, consumed: 0 };
+}
+
+type ArgAccumulator = {
+  verbose: boolean;
+  json: boolean;
+  seed?: string;
+  error?: string;
+  positional: string[];
+};
+
+/**
+ * First usage error wins — a later one is deliberately dropped. The sole owner
+ * of the `??=`, so a new error site cannot express the precedence wrongly.
+ */
+function failWith(acc: ArgAccumulator, message: string): void {
+  acc.error ??= message;
+}
+
+/** Returns how many further arguments this one consumed as a value. */
+function applyArg(arg: string, next: string | undefined, acc: ArgAccumulator): number {
+  if (arg === '--verbose' || arg === '-v') {
+    acc.verbose = true;
+  } else if (arg === '--json') {
+    acc.json = true;
+  } else if (arg === '--seed' || arg.startsWith('--seed=')) {
+    const read = readSeedValue(arg, next);
+    if (read == null) {
+      failWith(acc, 'Missing value for --seed');
+    } else {
+      acc.seed = read.seed;
+      return read.consumed;
+    }
+  } else if (arg.startsWith('--') || (arg.startsWith('-') && !isNegativeNotation(arg))) {
+    failWith(acc, `Unknown option: ${arg}`);
+  } else {
+    acc.positional.push(arg);
+  }
+
+  return 0;
+}
+
+/**
  * Parses a raw argument array into typed CLI options.
  *
  * @param argv - Arguments to parse (typically `process.argv.slice(2)`)
@@ -86,50 +141,20 @@ export function parseArgs(argv: string[]): ParseArgsResult {
     };
   }
 
-  let verbose = false;
-  let json = false;
-  let seed: string | undefined;
-  let error: string | undefined;
-  const positional: string[] = [];
-
-  // First usage error wins — a later one is deliberately dropped.
-  const failWith = (message: string): void => {
-    error ??= message;
-  };
+  const acc: ArgAccumulator = { verbose: false, json: false, positional: [] };
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i] as string;
 
     if (arg === TERMINATOR) {
-      positional.push(...argv.slice(i + 1));
+      acc.positional.push(...argv.slice(i + 1));
       break;
-    } else if (arg === '--verbose' || arg === '-v') {
-      verbose = true;
-    } else if (arg === '--json') {
-      json = true;
-    } else if (arg === '--seed') {
-      // A seed is an opaque string, so any non-empty next argument counts:
-      // `--seed -abc` is a valid seed, not a missing value.
-      const next = argv[i + 1];
-      if (next == null || next === '') {
-        failWith('Missing value for --seed');
-      } else {
-        seed = next;
-        i++;
-      }
-    } else if (arg.startsWith('--seed=')) {
-      const value = arg.slice('--seed='.length);
-      if (value === '') {
-        failWith('Missing value for --seed');
-      } else {
-        seed = value;
-      }
-    } else if (arg.startsWith('--') || (arg.startsWith('-') && !isNegativeNotation(arg))) {
-      failWith(`Unknown option: ${arg}`);
-    } else {
-      positional.push(arg);
     }
+
+    i += applyArg(arg, argv[i + 1], acc);
   }
+
+  const { verbose, json, seed, error, positional } = acc;
 
   // The loop runs to the end even after a usage error: only it knows that
   // `--seed --json` binds the flag as a seed value and `-- --json` makes it notation.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -119,6 +119,18 @@ function writeJsonError(write: WriteFn, error: JsonErrorBody, context?: RollCont
   write(`${JSON.stringify({ error, ...context, version: VERSION })}\n`);
 }
 
+/** Reports a usage error and returns the exit code for one. */
+function failUsage(stderr: WriteFn, message: string, json: boolean): number {
+  if (json) {
+    writeJsonError(stderr, { message });
+  } else {
+    stderr(`Error: ${message}\n`);
+    stderr('Run "roll-parser --help" for usage.\n');
+  }
+
+  return 2;
+}
+
 /**
  * Runs one CLI invocation and returns the process exit code: `0` on success,
  * `1` for a roll-parser error, `2` for a usage error. Anything that is not a
@@ -133,13 +145,7 @@ export function main(env: CliEnv): number {
   const parsed = parseArgs(argv);
 
   if (!parsed.ok) {
-    if (parsed.json) {
-      writeJsonError(stderr, { message: parsed.error });
-    } else {
-      stderr(`Error: ${parsed.error}\n`);
-      stderr('Run "roll-parser --help" for usage.\n');
-    }
-    return 2;
+    return failUsage(stderr, parsed.error, parsed.json);
   }
 
   const { args } = parsed;
@@ -155,13 +161,7 @@ export function main(env: CliEnv): number {
   }
 
   if (args.notation == null) {
-    if (args.json) {
-      writeJsonError(stderr, { message: 'No dice notation provided.' });
-    } else {
-      stderr('Error: No dice notation provided.\n');
-      stderr('Run "roll-parser --help" for usage.\n');
-    }
-    return 2;
+    return failUsage(stderr, 'No dice notation provided.', args.json);
   }
 
   // `SeededRNG`'s auto-seed is unreachable, so mint one that can be echoed back.

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1598,6 +1598,37 @@ function formatFailCode(operator: CompareOp, value: number): string {
   return operator === '=' ? `f${value}` : `f${operator}${value}`;
 }
 
+/**
+ * The units a success count scores: sub-roll subtotals for a multi-sub group,
+ * the target's own dice otherwise.
+ */
+// ! Releases every die an inner count tagged, `vs` DC dice included, though
+// ! `countSuccesses` spares those. The `stripTallyMarkers` pass below reads
+// ! rendered text and cannot tell a DC die apart, so sparing one here leaves a
+// ! tag whose `**` is already gone and `renderBreakdown` stops reproducing
+// ! `rendered`.
+function clearTallyFlags(rolls: DieResult[]): void {
+  for (const die of rolls) {
+    die.modifiers = stripFlags(die.modifiers, TALLY_FLAGS);
+  }
+}
+
+function countablePool(
+  target: EvalResult,
+  targetCtx: EvalContext,
+  bySubtotal: boolean,
+): DieResult[] {
+  if (!bySubtotal) return targetCtx.rolls;
+
+  return (target.part as Extract<RollPart, { type: 'group' }>).parts.map((sub) => ({
+    sides: 0,
+    result: sub.total,
+    modifiers: [],
+    critical: false,
+    fumble: false,
+  }));
+}
+
 function evalSuccessCount(
   node: SuccessCountNode,
   rng: RNG,
@@ -1657,25 +1688,9 @@ function evalSuccessCount(
   // `ctx.rolls`. Only a direct group target arrives here — the parser refuses
   // every form that would reach the count with the subtotals already gone.
   const bySubtotal = node.target.type === 'Group' && node.target.expressions.length >= 2;
-  const pool: DieResult[] = bySubtotal
-    ? (target.part as Extract<RollPart, { type: 'group' }>).parts.map((sub) => ({
-        sides: 0,
-        result: sub.total,
-        modifiers: [],
-        critical: false,
-        fumble: false,
-      }))
-    : targetCtx.rolls;
+  const pool = countablePool(target, targetCtx, bySubtotal);
 
-  // ! Releases every die an inner count tagged, `vs` DC dice included, though
-  // ! `countSuccesses` spares those. The marker strip below reads rendered text
-  // ! and cannot tell a DC die apart, so sparing one here leaves a tag whose
-  // ! `**` is already gone and `renderBreakdown` stops reproducing `rendered`.
-  if (bySubtotal && poolAlreadyCounted) {
-    for (const die of targetCtx.rolls) {
-      die.modifiers = stripFlags(die.modifiers, TALLY_FLAGS);
-    }
-  }
+  if (bySubtotal && poolAlreadyCounted) clearTallyFlags(targetCtx.rolls);
 
   // An empty pool (`0d6>=4`) scores zero of both, so its total is 0 — never
   // `target.total`, which would break `total === successes - failures`.

--- a/src/evaluator/modifiers/keep-drop.ts
+++ b/src/evaluator/modifiers/keep-drop.ts
@@ -11,6 +11,29 @@ import { isVersusDc } from './flags.js';
 type EligibleDie = { result: number; index: number };
 
 /**
+ * The die at pool slot `index` when it is eligible for keep/drop selection,
+ * `null` otherwise. Marks an ineligible-but-droppable die in `droppedMask` on
+ * the way past.
+ */
+function selectOrMarkDropped(
+  dice: DieResult[],
+  index: number,
+  droppedMask: Uint8Array,
+  hasVersusDc: boolean,
+): DieResult | null {
+  const die = dice[index];
+  if (die == null) return null;
+  if (hasVersusDc && isVersusDc(die)) return null;
+
+  if (die.modifiers.includes('dropped')) {
+    droppedMask[index] = 1;
+    return null;
+  }
+
+  return die;
+}
+
+/**
  * Records into `droppedMask` every pool slot that `kind` / `selector` /
  * `count` drops.
  *
@@ -39,14 +62,8 @@ export function markDroppedIndices(
   const eligible: EligibleDie[] = [];
 
   for (let index = 0; index < dice.length; index++) {
-    const die = dice[index];
+    const die = selectOrMarkDropped(dice, index, droppedMask, hasVersusDc);
     if (die == null) continue;
-    if (hasVersusDc && isVersusDc(die)) continue;
-
-    if (die.modifiers.includes('dropped')) {
-      droppedMask[index] = 1;
-      continue;
-    }
 
     eligible.push({ result: die.result, index });
   }
@@ -64,6 +81,20 @@ export function markDroppedIndices(
     return;
   }
 
+  dropBySelection(eligible, count, isKeep, selector, droppedMask);
+}
+
+/**
+ * Reached only once both whole-pool cases are ruled out, so the selected range
+ * is always a strict subset of `eligible`.
+ */
+function dropBySelection(
+  eligible: EligibleDie[],
+  count: number,
+  isKeep: boolean,
+  selector: KeepDropSpec['selector'],
+  droppedMask: Uint8Array,
+): void {
   // Stable sort — ties resolve by original pool order.
   eligible.sort(
     selector === 'highest' ? (a, b) => b.result - a.result : (a, b) => a.result - b.result,
@@ -95,20 +126,15 @@ function markSingleExtreme(
   hasVersusDc: boolean,
 ): void {
   const isKeep = kind === 'keep';
-  const wantHighest = selector === 'highest';
+  const isMoreExtreme =
+    selector === 'highest' ? (a: number, b: number) => a > b : (a: number, b: number) => a < b;
 
   let extremeIndex = -1;
   let extremeResult = 0;
 
   for (let index = 0; index < dice.length; index++) {
-    const die = dice[index];
+    const die = selectOrMarkDropped(dice, index, droppedMask, hasVersusDc);
     if (die == null) continue;
-    if (hasVersusDc && isVersusDc(die)) continue;
-
-    if (die.modifiers.includes('dropped')) {
-      droppedMask[index] = 1;
-      continue;
-    }
 
     const { result } = die;
 
@@ -118,7 +144,7 @@ function markSingleExtreme(
       continue;
     }
 
-    if (wantHighest ? result > extremeResult : result < extremeResult) {
+    if (isMoreExtreme(result, extremeResult)) {
       // A keep drops the dethroned extreme; a drop keeps everything else.
       if (isKeep) droppedMask[extremeIndex] = 1;
       extremeIndex = index;

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -215,6 +215,14 @@ export class Lexer {
       return this.scanAt();
     }
 
+    return this.scanOperator(char, startPos);
+  }
+
+  /**
+   * Single- and two-character operators. The last resort in `nextToken`'s
+   * dispatch, so an unrecognised character can only be a lexer error.
+   */
+  private scanOperator(char: string, startPos: number): Token {
     this.advance();
 
     switch (char) {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -850,6 +850,41 @@ export class Parser {
     }
   }
 
+  // ! A single-sub-roll Group is the flat-pool escape hatch, so `containsDicePool`
+  // ! deep-walks the arithmetic that `(1d6+5)kh1` rejects outright — but the flat
+  // ! path totals `sumKeptDice`, faces only. `{2d6+3}kh2` and `{2d6-1d4}kh3` are
+  // ! exactly the drop that reject exists to prevent.
+  private rejectSingleSubGroupTarget(target: ASTNode, token: Token): void {
+    const base = unwrapAllTransparent(target);
+    if (base.type !== 'Group' || base.expressions.length !== 1) return;
+
+    const inner = base.expressions[0];
+    if (inner == null) return;
+
+    // Single-sub Groups hide a count from the shallow reject in `parseKeepDrop`,
+    // so peel them to any depth and `{4d6>=5}kh1`, `{{4d6>=5}}kh1`, and
+    // `(4d6>=5)kh1` all report one code. Peeling only picks which error the
+    // caller sees — `sumsToKeptFaces` below refuses a count either way.
+    let innermost = inner;
+    while (true) {
+      const peeled = unwrapGrouped(innermost);
+      if (peeled.type !== 'Group' || peeled.expressions.length !== 1) break;
+      const next = peeled.expressions[0];
+      if (next == null) break;
+      innermost = next;
+    }
+    this.rejectSuccessCountTarget(innermost, token);
+
+    if (!sumsToKeptFaces(inner)) {
+      throw new ParseError(
+        `Keep/drop on a single-sub-roll group requires added dice terms only`,
+        'INVALID_KEEP_DROP_TARGET',
+        token.position,
+        token,
+      );
+    }
+  }
+
   private parseKeepDrop(target: ASTNode, token: Token): KeepDropNode {
     this.rejectSuccessCountTarget(target, token);
     // ! Keep/drop on a Versus target silently drops `degree`/`natural` metadata,
@@ -869,38 +904,7 @@ export class Parser {
       );
     }
 
-    // ! A single-sub-roll Group is the flat-pool escape hatch, so `containsDicePool`
-    // ! deep-walks the arithmetic that `(1d6+5)kh1` rejects outright — but the flat
-    // ! path totals `sumKeptDice`, faces only. `{2d6+3}kh2` and `{2d6-1d4}kh3` are
-    // ! exactly the drop that reject exists to prevent.
-    const base = unwrapAllTransparent(target);
-    if (base.type === 'Group' && base.expressions.length === 1) {
-      const inner = base.expressions[0];
-      if (inner != null) {
-        // Single-sub Groups hide a count from the shallow reject at the top of this
-        // method, so peel them to any depth and `{4d6>=5}kh1`, `{{4d6>=5}}kh1`, and
-        // `(4d6>=5)kh1` all report one code. Peeling only picks which error the
-        // caller sees — `sumsToKeptFaces` below refuses a count either way.
-        let innermost = inner;
-        while (true) {
-          const peeled = unwrapGrouped(innermost);
-          if (peeled.type !== 'Group' || peeled.expressions.length !== 1) break;
-          const next = peeled.expressions[0];
-          if (next == null) break;
-          innermost = next;
-        }
-        this.rejectSuccessCountTarget(innermost, token);
-
-        if (!sumsToKeptFaces(inner)) {
-          throw new ParseError(
-            `Keep/drop on a single-sub-roll group requires added dice terms only`,
-            'INVALID_KEEP_DROP_TARGET',
-            token.position,
-            token,
-          );
-        }
-      }
-    }
+    this.rejectSingleSubGroupTarget(target, token);
 
     const kind =
       token.type === TokenType.KEEP_HIGH || token.type === TokenType.KEEP_LOW ? 'keep' : 'drop';


### PR DESCRIPTION
## Changes

Enabled `complexity/noExcessiveCognitiveComplexity` at Biome's default threshold of 15
Excluded `**/*.test.ts` by filename glob, since the suites sit beside the source
Split `parseKeepDrop` by extracting `rejectInvalidSingleSubGroup`
Split `parseArgs` over an `ArgAccumulator`, adding `applyArg` and `readSeedValue`
Split `evaluateCell` into `sampleStats` and `findExpectationProblems`
Split `toRecords` by extracting `toRecord`
Split `markDroppedIndices` and `markSingleExtreme` on a shared `selectableDie`, plus `dropBySelection`
Extracted `scanOperator` from `nextToken`, `failUsage` from `main`, and `countablePool` from `evalSuccessCount`

## Notes

`src/cli/main.ts` is a ninth offender the issue does not list — it crossed the threshold
after the issue was written, and the rule cannot be enabled while anything is over.
`parseArgs` also drifted from 27 to 26.

`toRecords` and `evaluateCell` were split rather than suppressed. The issue offers a
`biome-ignore` as a fallback if they resist a clean split; they did not, and as script and
bench code they cost no `dist/` bytes. No new suppressions land here.

`failWith` stays the sole owner of the first-error-wins `??=`, so #358's invariant survives
the reshape of `parseArgs`.

`markSingleExtreme` came under the line by hoisting its loop-invariant comparator out of the
scan rather than by extracting a handler — two lines instead of a new function, which matters
against the size budget.

Costs 90 B across the size budgets, none raised. `{ roll }` now sits at 12.90 kB against its
13 kB limit.

Closes #349
