### PR TITLE
docs: stop teaching -- as the way to write negative notation #344

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ Options:
   -v, --verbose    Show detailed roll breakdown
   --json           Print the whole result as compact JSON (wins over --verbose)
   --seed <value>   Use seed for reproducible rolls
-  --               Treat every following argument as notation
+  --               Notation that looks like an option — put options before it
 ```
 
 ```bash
@@ -1025,7 +1025,7 @@ Error: Invalid dice sides: 0
 $ roll-parser "2d6+1d0+3" --json --seed demo
 {"error":{"message":"Invalid dice sides: 0","code":"INVALID_DICE_SIDES","span":{"start":4,"end":7}},"notation":"2d6+1d0+3","seed":"demo",...}
 
-$ roll-parser --seed demo -- -1d6+3
+$ roll-parser -1d6+3 --seed demo
 2
 ```
 
@@ -1045,6 +1045,13 @@ the same major and the dice repeat. Omitting `--seed` mints one, so an
 unplanned roll stays reproducible too. `--help` and `--version` win over
 any usage error that precedes them. Errors go to stderr; only the result goes
 to stdout.
+
+Leading-minus notation needs no `--`: `-1d6+3`, `-d6`, `-dF`, `-(2d6)`,
+`-{2d6}` and `-@str` are all read as notation. `--` is the escape hatch for
+notation that would otherwise parse as an option, and everything after it is
+notation — flags included — so options go before it, never after. A failed roll
+whose notation swallowed one prints `Hint: options must come before "--"` after
+the caret diagram.
 
 Once `--json` is parsed, every diagnostic is one JSON line on stderr instead
 of the caret diagram. `code` is the same stable `RollParserErrorCode` the

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseArgs } from './args.js';
+import { isKnownOption, parseArgs } from './args.js';
 
 describe('parseArgs', () => {
   describe('notation parsing', () => {
@@ -7,6 +7,7 @@ describe('parseArgs', () => {
       const result = parseArgs(['2d6+3']);
       expect(result).toEqual({
         ok: true,
+        terminated: false,
         args: {
           notation: '2d6+3',
           verbose: false,
@@ -22,6 +23,7 @@ describe('parseArgs', () => {
       const result = parseArgs(['2d6', '+', '3']);
       expect(result).toEqual({
         ok: true,
+        terminated: false,
         args: {
           notation: '2d6 + 3',
           verbose: false,
@@ -37,6 +39,7 @@ describe('parseArgs', () => {
       const result = parseArgs([]);
       expect(result).toEqual({
         ok: true,
+        terminated: false,
         args: {
           notation: undefined,
           verbose: false,
@@ -52,6 +55,7 @@ describe('parseArgs', () => {
       const result = parseArgs(['-3']);
       expect(result).toEqual({
         ok: true,
+        terminated: false,
         args: {
           notation: '-3',
           verbose: false,
@@ -273,6 +277,23 @@ describe('parseArgs', () => {
     });
   });
 
+  describe('terminator reporting', () => {
+    test('terminated is true only when -- stopped option parsing', () => {
+      const result = parseArgs(['--', '-1d6']);
+      expect(result).toMatchObject({ ok: true, terminated: true });
+    });
+
+    test('a -- consumed as the --seed value is not a terminator (#344)', () => {
+      const result = parseArgs(['--seed', '--', '2d6']);
+      expect(result).toMatchObject({ ok: true, terminated: false });
+      if (result.ok) expect(result.args.seed).toBe('--');
+    });
+
+    test('terminated is false when no -- appears at all', () => {
+      expect(parseArgs(['2d6+3'])).toMatchObject({ ok: true, terminated: false });
+    });
+  });
+
   describe('informational precedence', () => {
     test('--help wins over an earlier unknown option', () => {
       const result = parseArgs(['--oops', '--help']);
@@ -308,6 +329,7 @@ describe('parseArgs', () => {
       const result = parseArgs(['2d6', '--json', '--help']);
       expect(result).toEqual({
         ok: true,
+        terminated: false,
         args: {
           notation: undefined,
           verbose: false,
@@ -367,5 +389,35 @@ describe('parseArgs', () => {
 
     // The `-x` short-flag case sits in `notation parsing`, next to the
     // negative-notation cases it draws the boundary against.
+  });
+});
+
+describe('isKnownOption', () => {
+  // Each row asserts the predicate against what `parseArgs` actually does with
+  // the same argument, so an option added to `applyArg` alone fails here.
+  // Blind to one added to neither — that pairs two silences, not two lists.
+  test.each([
+    ['--verbose', true],
+    ['-v', true],
+    ['--json', true],
+    ['--help', true],
+    ['-h', true],
+    ['--version', true],
+    ['--seed', true],
+    ['--seed=demo', true],
+    ['--unknown', false],
+    ['--seeds', false],
+    ['-x', false],
+  ])('agrees with parseArgs on %s', (arg, known) => {
+    const parsed = parseArgs([arg as string]);
+    const rejectedAsUnknown = !parsed.ok && parsed.error === `Unknown option: ${arg}`;
+
+    expect(isKnownOption(arg as string)).toBe(known);
+    expect(rejectedAsUnknown).toBe(!known);
+  });
+
+  // `parseArgs` accepts these as notation, which says nothing about the predicate.
+  test.each(['-1d6', '-d6', '2d6+3', '--', ''])('rejects %s, which is not an option', (arg) => {
+    expect(isKnownOption(arg)).toBe(false);
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -21,10 +21,11 @@ export type CliArgs = {
 /**
  * Result of parsing CLI arguments — either success or a usage error. The
  * failure arm carries `json` so a usage error renders in the format the
- * caller asked for.
+ * caller asked for; the success arm carries `terminated`, true only when a
+ * `--` was consumed as the terminator rather than as a `--seed` value.
  */
 export type ParseArgsResult =
-  | { ok: true; args: CliArgs }
+  | { ok: true; args: CliArgs; terminated: boolean }
   | { ok: false; error: string; json: boolean };
 
 /** Argument that stops option parsing — everything after it is notation. */
@@ -60,11 +61,22 @@ function findInformationalFlag(argv: string[]): 'help' | 'version' | undefined {
 /**
  * True for an argument that starts with `-` yet reads as notation rather than
  * an option: negative numbers (`-3`) and negative-prefixed expressions
- * (`-d6`, `-D6`, `-dF`, `-(2d6)`, `-{2d6}`, `-@str`). A fallback for users who
- * do not reach for `--`; `--` remains the unambiguous form.
+ * (`-d6`, `-D6`, `-dF`, `-(2d6)`, `-{2d6}`, `-@str`). These need no `--`, which
+ * exists for notation that would otherwise parse as an option.
  */
 function isNegativeNotation(arg: string): boolean {
   return /^[\ddD({@]/.test(arg.slice(1));
+}
+
+/** Every option this parser accepts as a whole argument. */
+const KNOWN_OPTIONS = new Set(['--verbose', '-v', '--json', '--help', '-h', '--version', '--seed']);
+
+/**
+ * True for an argument this parser accepts as a *valid* option outside a `--`
+ * terminator — `--typo` is read as an option and rejected, and is not one here.
+ */
+export function isKnownOption(arg: string): boolean {
+  return KNOWN_OPTIONS.has(arg) || arg.startsWith('--seed=');
 }
 
 /**
@@ -133,6 +145,7 @@ export function parseArgs(argv: string[]): ParseArgsResult {
   if (informational != null) {
     return {
       ok: true,
+      terminated: false,
       args: {
         ...BASE_ARGS,
         showHelp: informational === 'help',
@@ -142,12 +155,14 @@ export function parseArgs(argv: string[]): ParseArgsResult {
   }
 
   const acc: ArgAccumulator = { verbose: false, json: false, positional: [] };
+  let terminated = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i] as string;
 
     if (arg === TERMINATOR) {
       acc.positional.push(...argv.slice(i + 1));
+      terminated = true;
       break;
     }
 
@@ -166,5 +181,5 @@ export function parseArgs(argv: string[]): ParseArgsResult {
   // words and the user means one expression.
   const notation = positional.length > 0 ? positional.join(' ') : undefined;
 
-  return { ok: true, args: { ...BASE_ARGS, notation, verbose, json, seed } };
+  return { ok: true, terminated, args: { ...BASE_ARGS, notation, verbose, json, seed } };
 }

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -266,6 +266,49 @@ describe('cli main', () => {
       expect(exitCode).toBe(2);
       expect(stderr).toContain('No dice notation provided');
     });
+
+    test('an option swallowed by -- earns a hint (#344)', () => {
+      const { stderr, exitCode } = run(['--', '-1d6', '--verbose']);
+
+      expect(exitCode).toBe(1);
+      expect(stderr).toBe(
+        "Error: Unexpected identifier: 'verbose'\n" +
+          '  -1d6 --verbose\n' +
+          '         ^\n' +
+          'Hint: options must come before "--"\n',
+      );
+    });
+
+    test('a dash-prefixed non-option after -- earns no hint (#344)', () => {
+      const { stderr, exitCode } = run(['--', '-1d6', '-x']);
+
+      expect(exitCode).toBe(1);
+      expect(stderr).toBe("Error: Unexpected identifier: 'x'\n  -1d6 -x\n        ^\n");
+    });
+
+    test('a -- taken as the --seed value earns no hint (#344)', () => {
+      const { stderr, exitCode } = run(['--seed', '--', '2d6 --verbose']);
+
+      // `--seed` ate the `--` as its value, so no terminator ever ran.
+      expect(exitCode).toBe(1);
+      expect(stderr).toBe("Error: Unexpected identifier: 'verbose'\n  2d6 --verbose\n        ^\n");
+    });
+
+    test('a quoted notation carrying an option word earns no hint (#344)', () => {
+      const { stderr, exitCode } = run(['2d6 --verbose', '--seed', 'test']);
+
+      // No terminator was typed, so the ordering advice would name a `--` the
+      // user never wrote.
+      expect(exitCode).toBe(1);
+      expect(stderr).toBe("Error: Unexpected identifier: 'verbose'\n  2d6 --verbose\n        ^\n");
+    });
+
+    test('--json keeps its single line, hint or not (#344)', () => {
+      const { stderr } = run(['--json', '--seed', 'test', '--', '-1d6', '--verbose']);
+
+      expect(stderr.trimEnd()).not.toContain('\n');
+      expect(JSON.parse(stderr).error.message).toBe("Unexpected identifier: 'verbose'");
+    });
   });
 
   describe('exit codes', () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,7 +16,7 @@ import {
 } from '../errors.js';
 import { VERSION } from '../index.js';
 import { roll } from '../roll.js';
-import { parseArgs } from './args.js';
+import { isKnownOption, parseArgs } from './args.js';
 import { formatResult } from './format.js';
 
 const HELP_TEXT = `roll-parser v${VERSION}
@@ -29,7 +29,7 @@ Options:
   -v, --verbose    Show detailed roll breakdown
   --json           Print the whole result as compact JSON (wins over --verbose)
   --seed <value>   Use seed for reproducible rolls
-  --               Treat every following argument as notation
+  --               Notation that looks like an option — put options before it
 
 JSON output:
   Emits the complete result, including the structured "parts" tree, plus the
@@ -57,7 +57,7 @@ Examples:
   roll-parser 4d6kh3 --verbose
   roll-parser 4d6dl1 --seed "character-str"
   roll-parser "1d20+7 vs 25" --json
-  roll-parser -- -1d6+3
+  roll-parser -1d6+3
 `;
 
 // The build sets `types: []`, so no ambient runtime globals are declared.
@@ -91,6 +91,17 @@ export function writeErrorContext(notation: string, error: unknown, write: Write
 
   write(`  ${notation}\n`);
   write(`  ${' '.repeat(column)}^\n`);
+}
+
+/**
+ * Names the ordering rule when `--` swallowed an option. Gated on `terminated`,
+ * never on `argv` holding a `--`: `--seed --` makes that `--` a seed value, so a
+ * textual scan would name a terminator that never ran.
+ */
+function writeOptionHint(terminated: boolean, notation: string, write: WriteFn): void {
+  if (terminated && notation.split(' ').some(isKnownOption)) {
+    write('Hint: options must come before "--"\n');
+  }
 }
 
 /** The `error` member of the `--json` failure record. */
@@ -148,7 +159,7 @@ export function main(env: CliEnv): number {
     return failUsage(stderr, parsed.error, parsed.json);
   }
 
-  const { args } = parsed;
+  const { args, terminated } = parsed;
 
   if (args.showHelp) {
     stdout(HELP_TEXT);
@@ -182,6 +193,7 @@ export function main(env: CliEnv): number {
       } else {
         stderr(`Error: ${error.message}\n`);
         writeErrorContext(args.notation, error, stderr);
+        writeOptionHint(terminated, args.notation, stderr);
       }
       return 1;
     }


### PR DESCRIPTION
## Changes

Replaced the `roll-parser -- -1d6+3` example in `HELP_TEXT` and the README CLI section with `roll-parser -1d6+3`
Rewrote the `--` option line from `Treat every following argument as notation` to `Notation that looks like an option — put options before it`
Added a README paragraph naming the leading-minus forms that need no `--`, and stating that options go before the terminator
Added `Hint: options must come before "--"` to the non-JSON error path when a terminator swallowed a known option
Added `isKnownOption` to `src/cli/args.ts`, covering `--verbose`, `-v`, `--json`, `--help`, `-h`, `--version`, `--seed` and `--seed=`
Added `terminated` to `parseArgs`'s success arm, so the hint reads what the parser did rather than what `argv` contains

## Notes

The hint is gated on `terminated`, not on `argv` holding a `--`. `--seed` takes any non-empty next argument, so `--seed --` binds that `--` as a seed value and no terminator ever runs — a textual scan reports one anyway and advises reordering around a terminator that was never there. The same gate covers a quoted notation carrying an option-shaped word, where `roll-parser "2d6 --verbose"` would otherwise be told to move options around a `--` that appears nowhere in the command.

That gate is a deliberate narrowing of the issue's trigger clause, which conditions the hint on the notation alone. `--json` is narrowed the same way and never calls the hint: every diagnostic there stays one JSON line, which the README states as a contract.

The `isKnownOption` table asserts each row against what `parseArgs` does with the same argument, so an option added to `applyArg` alone reddens it. An option added to neither list still passes — closing that would mean gating every option branch on `KNOWN_OPTIONS`, which reshapes the first-error-wins structure #358 built.

`findInformationalFlag` makes the same literal-`--` mistake this change fixes, and more severely: it stops scanning at a `--` that `--seed` will consume, so `roll-parser --seed -- --help` exits 2 with `Unknown option: --help` instead of printing help. Pre-existing on `master` and untouched here; filed separately.

CLI-only, so no `size-limit` budget moves.

Closes #344
