### PR TITLE
fix: a -- taken as a --seed value stops the informational flag scan #364

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -292,6 +292,53 @@ describe('parseArgs', () => {
     test('terminated is false when no -- appears at all', () => {
       expect(parseArgs(['2d6+3'])).toMatchObject({ ok: true, terminated: false });
     });
+
+    test('a -- bound as a seed value leaves the rest to the loop (#364)', () => {
+      expect(parseArgs(['--seed', '--', '--verbose', '2d6'])).toEqual({
+        ok: true,
+        terminated: false,
+        args: {
+          notation: '2d6',
+          verbose: true,
+          json: false,
+          seed: '--',
+          showHelp: false,
+          showVersion: false,
+        },
+      });
+    });
+
+    // The first `--seed` binds the second as its value, so the `--` after it is
+    // a real terminator and everything past it is notation.
+    test('a seed value of --seed leaves the next -- terminating (#364)', () => {
+      expect(parseArgs(['--seed', '--seed', '--', '--help'])).toEqual({
+        ok: true,
+        terminated: true,
+        args: {
+          notation: '--help',
+          verbose: false,
+          json: false,
+          seed: '--seed',
+          showHelp: false,
+          showVersion: false,
+        },
+      });
+    });
+
+    test('a real terminator still stops the scan (#364)', () => {
+      expect(parseArgs(['--seed=x', '--', '--help'])).toEqual({
+        ok: true,
+        terminated: true,
+        args: {
+          notation: '--help',
+          verbose: false,
+          json: false,
+          seed: 'x',
+          showHelp: false,
+          showVersion: false,
+        },
+      });
+    });
   });
 
   describe('informational precedence', () => {
@@ -323,6 +370,50 @@ describe('parseArgs', () => {
         expect(result.args.showHelp).toBe(true);
         expect(result.args.showVersion).toBe(false);
       }
+    });
+
+    test('--help still wins when --seed took the -- as its value (#364)', () => {
+      expect(parseArgs(['--seed', '--', '--help'])).toEqual({
+        ok: true,
+        terminated: false,
+        args: {
+          notation: undefined,
+          verbose: false,
+          json: false,
+          seed: undefined,
+          showHelp: true,
+          showVersion: false,
+        },
+      });
+    });
+
+    test('--version still wins when --seed took the -- as its value (#364)', () => {
+      expect(parseArgs(['--seed', '--', '--version'])).toEqual({
+        ok: true,
+        terminated: false,
+        args: {
+          notation: undefined,
+          verbose: false,
+          json: false,
+          seed: undefined,
+          showHelp: false,
+          showVersion: true,
+        },
+      });
+    });
+
+    test('-h still wins when --seed took the -- as its value (#364)', () => {
+      const result = parseArgs(['--seed', '--', '-h']);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.args.showHelp).toBe(true);
+    });
+
+    // The scan skips a seed value, so `-h` sitting in one has to be exempted by
+    // name or it is consumed and never seen.
+    test('-h in the seed-value position outranks the seed (#364)', () => {
+      const result = parseArgs(['--seed', '-h']);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.args.showHelp).toBe(true);
     });
 
     test('informational flags drop other options', () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -41,18 +41,34 @@ const BASE_ARGS: CliArgs = {
   showVersion: false,
 };
 
+/** Which informational flag an argument is, if any. */
+function informationalKind(arg: string | undefined): 'help' | 'version' | undefined {
+  if (arg === '--help' || arg === '-h') return 'help';
+  if (arg === '--version') return 'version';
+  return undefined;
+}
+
 /**
  * Finds `--help` / `--version` anywhere before the `--` terminator. Help wins
  * over version regardless of order, and both win over usage errors — a user
  * who mistyped an option is asking for the manual, not for a diagnostic.
+ *
+ * Consumes a `--seed` value the way the main loop does, so a `--` in that
+ * position is the value and not the terminator. The one exception is an
+ * informational flag sitting there, which outranks the seed: `--seed --help`
+ * is help, not a seed of `--help`.
  */
 function findInformationalFlag(argv: string[]): 'help' | 'version' | undefined {
   let flag: 'help' | 'version' | undefined;
 
-  for (const arg of argv) {
-    if (arg === TERMINATOR) break;
-    if (arg === '--help' || arg === '-h') return 'help';
-    if (arg === '--version') flag = 'version';
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] as string;
+    const kind = informationalKind(arg);
+
+    if (kind === 'help') return 'help';
+    if (kind === 'version') flag = 'version';
+    else if (arg === TERMINATOR) break;
+    else if (arg === '--seed' && informationalKind(argv[i + 1]) == null) i += 1;
   }
 
   return flag;

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -89,6 +89,14 @@ describe('cli main', () => {
       expect(stderr).toBe('');
     });
 
+    test('--help survives a -- taken as the --seed value (#364)', () => {
+      const { stdout, stderr, exitCode } = run(['--seed', '--', '--help']);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Usage: roll-parser');
+      expect(stderr).toBe('');
+    });
+
     test('help documents json output and exit codes', () => {
       const { stdout } = run(['--help']);
 


### PR DESCRIPTION
## Changes

Made `findInformationalFlag` consume a `--seed` value the way the main loop does, instead of breaking on any argument that is literally `--`
Exempted an informational flag sitting in the seed-value position from that skip, so `--seed --help` stays help rather than a seed of `--help`
Extracted `informationalKind` so `--help`, `-h` and `--version` are listed once, shared by the skip decision and the match
Pinned the spellings the issue names, the `-h` value-position case, and both terminator boundaries

## Notes

`roll-parser --seed -- --help` exited 2 with `Unknown option: --help`. `readSeedValue` takes any non-empty next argument, so that `--` is the seed value and never reaches the main loop's terminator branch — but the scan had already stopped there, and `--help`, `-h` and `--version` are reached only through the scan.

The issue proposed skipping the seed value outright. That is wrong: it swallows `--seed --help`, which `--help wins over a dangling --seed` pins as help. The exemption is what keeps both rules, and it leaves the scan agreeing with the loop everywhere the loop actually terminates — `--seed --seed --` included, where the second `--seed` is the value and the `--` after it is real, so what follows stays notation as `README.md` promises.

The one place the two still differ is a three-deep `--seed` chain, where the loop reaches `Unknown option: --help` and the scan prints help. That is the documented precedence — informational flags beat usage errors — not a divergence this change introduces.

Three mutants, each killed by a different test: reverting the guard reddens four; skipping the value unconditionally reddens the dangling-`--seed` precedence and the `-h` case; widening the guard to a `--seed` prefix reddens `a real terminator still stops the scan` alone.

CLI-only, so no `size-limit` budget moves.

Closes #364
